### PR TITLE
CRIMRE-23 view list of applications

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -5,3 +5,7 @@
 # To adapt to your local setup, copy this file to `.env.development.local` to make changes
 #
 DATABASE_URL=postgresql://postgres@localhost/laa-review-criminal-legal-aid
+
+CRIME_REVIEW_HOST=laa-review-criminal-legal-aid.test
+
+CRIME_APPLY_API_URL=https://laa-apply-for-criminal-legal-aid.test/api/

--- a/.env.test
+++ b/.env.test
@@ -5,3 +5,4 @@
 # To adapt to your local setup, copy this file to `.env.test.local` to make changes
 #
 DATABASE_URL=postgresql://postgres@localhost/laa-review-criminal-legal-aid-test
+CRIME_APPLY_API_URL=https://crime-apply-api.test/api/

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem 'pg', '~> 1.4'
 gem 'puma'
 gem 'rails', '~> 7.0.3'
 
+gem 'faraday'
+
 gem 'govuk_design_system_formbuilder', '~> 3.1.0'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
@@ -23,6 +25,8 @@ gem 'dartsass-rails', '~> 0.4.0'
 # Exceptions notifications
 gem 'sentry-rails'
 gem 'sentry-ruby'
+
+gem 'dry-struct'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
@@ -46,4 +50,5 @@ group :test do
   gem 'selenium-webdriver'
   gem 'simplecov', require: false
   gem 'webdrivers'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
       xpath (~> 3.2)
     childprocess (4.1.0)
     concurrent-ruby (1.1.10)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     dartsass-rails (0.4.0)
       railties (>= 6.0.0)
@@ -105,6 +107,24 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    dry-container (0.11.0)
+      concurrent-ruby (~> 1.0)
+    dry-core (0.8.1)
+      concurrent-ruby (~> 1.0)
+    dry-inflector (0.3.0)
+    dry-logic (1.2.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.5, >= 0.5)
+    dry-struct (1.4.0)
+      dry-core (~> 0.5, >= 0.5)
+      dry-types (~> 1.5)
+      ice_nine (~> 0.11)
+    dry-types (1.5.1)
+      concurrent-ruby (~> 1.0)
+      dry-container (~> 0.3)
+      dry-core (~> 0.5, >= 0.5)
+      dry-inflector (~> 0.1, >= 0.1.2)
+      dry-logic (~> 1.0, >= 1.0.2)
     erb_lint (0.2.0)
       activesupport
       better_html (>= 2.0.1)
@@ -113,6 +133,10 @@ GEM
       rubocop
       smart_properties
     erubi (1.11.0)
+    faraday (2.6.0)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
     govuk_design_system_formbuilder (3.1.2)
@@ -120,10 +144,12 @@ GEM
       activemodel (>= 6.1)
       activesupport (>= 6.1)
       html-attributes-utils (~> 0.9, >= 0.9.2)
+    hashdiff (1.0.1)
     html-attributes-utils (0.9.2)
       activesupport (>= 6.1.4.4)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     importmap-rails (1.1.5)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -243,6 +269,7 @@ GEM
     rubocop-rspec (2.11.1)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.4.0)
       childprocess (>= 0.5, < 5.0)
@@ -283,6 +310,10 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -301,7 +332,9 @@ DEPENDENCIES
   dartsass-rails (~> 0.4.0)
   debug
   dotenv-rails
+  dry-struct
   erb_lint
+  faraday
   govuk_design_system_formbuilder (~> 3.1.0)
   importmap-rails
   pg (~> 1.4)
@@ -319,6 +352,7 @@ DEPENDENCIES
   sprockets-rails
   web-console
   webdrivers
+  webmock
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -1,0 +1,11 @@
+class CrimeApplicationsController < ApplicationController
+  def index
+    @applications = CrimeApplication.all
+  end
+
+  def show
+    @crime_application = CrimeApplication.find(params[:id])
+
+    raise ActionController::RoutingError, 'Not Found' unless @crime_application
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,3 +1,0 @@
-class HomeController < ApplicationController
-  def index; end
-end

--- a/app/lib/api_client.rb
+++ b/app/lib/api_client.rb
@@ -1,0 +1,23 @@
+class ApiClient
+  def initialize(connection: nil)
+    @connection = connection || default_connection
+  end
+
+  def all(_options = {})
+    response = @connection.get('applications')
+
+    return [] unless response.success?
+
+    JSON.parse(response.body)
+  end
+
+  private
+
+  def default_connection
+    Faraday.new(
+      url: ENV.fetch('CRIME_APPLY_API_URL'),
+      ssl: { verify: !Rails.env.development? },
+      headers: { 'Content-Type' => 'application/json' }
+    )
+  end
+end

--- a/app/lib/api_resource.rb
+++ b/app/lib/api_resource.rb
@@ -1,0 +1,21 @@
+class ApiResource < Dry::Struct
+  class << self
+    def all
+      @all ||= ApiClient.new.all.map do |json|
+        new(extract_from_source(json))
+      end
+    end
+
+    def find(id)
+      all.find { |r| r.id == id }
+    end
+
+    # Overide if transformation required
+    # :nocov:
+    def skip_this_method
+      never_reached
+    end
+    # :nocov:
+    #
+  end
+end

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -1,0 +1,3 @@
+module Types
+  include Dry.Types()
+end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,0 +1,28 @@
+class CrimeApplication < ApiResource
+  attribute :id, Types::String
+  attribute :laa_reference, Types::String
+  attribute :applicant_name, Types::String
+  attribute :received_at, Types::JSON::DateTime
+
+  def to_param
+    id
+  end
+
+  class << self
+    # TOOD: find a better home
+    #
+    def extract_from_source(source)
+      applicant_name = [
+        source.dig('client_details', 'client', 'first_name'),
+        source.dig('client_details', 'client', 'last_name')
+      ].join(' ')
+
+      {
+        id: source['id'],
+        applicant_name: applicant_name,
+        laa_reference: source['application_reference'],
+        received_at: source['application_start_date']
+      }
+    end
+  end
+end

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -1,0 +1,42 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full govuk-!-margin-bottom-5">
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <table class="govuk-table app-dashboard-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">
+            <%= t('.table_headings.applicant_name') %>
+          </th>
+          <th scope="col" class="govuk-table__header">
+            <%= t('.table_headings.reference') %>
+          </th>
+          <th scope="col" class="govuk-table__header">
+            <%= t('.table_headings.received_at') %>
+          </th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @applications.each do |app| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">
+              <%= link_to app.applicant_name, crime_application_path(app) %>
+            </th>
+            <td class="govuk-table__cell">
+              <%= app.laa_reference %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= l(app.received_at) %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/crime_applications/show.html.erb
+++ b/app/views/crime_applications/show.html.erb
@@ -1,0 +1,13 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= @crime_application.laa_reference %>
+    </h1>
+
+    <h2 class="govuk-heading-l">
+      <%= @crime_application.applicant_name %>
+    </h2>
+  </div>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,10 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  
+  # Allow a host to be set in development
+  if ENV.fetch("CRIME_REVIEW_HOST", false)
+    config.hosts << ENV['CRIME_REVIEW_HOST']
+  end
+  #
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,3 +18,20 @@ en:
   flash:
     success:
       title: Success
+
+  crime_applications:
+    index:
+      page_title: Your list
+      heading: Your list
+      table_headings:
+        applicant_name: Applicant
+        reference: Reference 
+        received_at: Date received 
+    show:
+      page_title: Application
+      heading: Application
+      subheading: Application Sub
+      table_headings:
+        applicant_name: Applicant
+        reference: Reference 
+        received_at: Date received 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,8 @@ Rails.application.routes.draw do
   get :health, to: 'healthcheck#show'
   get :ping,   to: 'healthcheck#ping'
 
-  root 'home#index'
+
+  resources :crime_applications, only: [:index, :show], path: 'applications'
+
+  root 'crime_applications#index'
 end

--- a/spec/fixtures/files/crime_apply_data/applications.json
+++ b/spec/fixtures/files/crime_apply_data/applications.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "207a30bd-d425-41d7-8665-75d93606cda6",
+    "application_reference": "LAA-207a30",
+    "application_start_date": "2022-10-11T09:07:25.000+00:00",
+    "client_details": {
+      "client": {
+        "first_name": "Zoe",
+        "last_name": "Wrong"
+      }
+    }
+  },
+  {
+    "id": "d8d384ec-ea6c-4fd0-a788-b3240c5fb14a",
+    "application_reference": "LAA-d8d384",
+    "application_start_date": "2022-10-12T17:05:19.000+00:00",
+    "client_details": {
+      "client": {
+        "first_name": "Ben",
+        "last_name": "Fish"
+      }
+    }
+  },
+  {
+    "id": "809e9e8f-50c5-4513-9579-3da4a1c176fb",
+    "application_reference": "LAA-809e9e",
+    "application_start_date": "2022-10-17T08:25:21.000+00:00",
+    "client_details": {
+      "client": {
+        "first_name": "Cat",
+        "last_name": "Brown"
+      }
+    }
+  },
+  {
+    "id": "696dd4fd-b619-4637-ab42-a5f4565bcf4a",
+    "application_reference": "LAA-696dd4",
+    "application_start_date": "2022-10-17T12:24:18.000+00:00",
+    "client_details": {
+      "client": {
+        "first_name": "Kit",
+        "last_name": "Pound"
+      }
+    }
+  }
+]

--- a/spec/init/webmock.rb
+++ b/spec/init/webmock.rb
@@ -1,0 +1,6 @@
+require 'webmock'
+
+# Allow connections to webdriver urls
+#
+driver_urls = Webdrivers::Common.subclasses.map(&:base_url)
+WebMock.disable_net_connect!(allow_localhost: true, allow: driver_urls)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,10 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 
+Dir[
+  Rails.root.join('spec/support/**/*.rb')
+].each { |f| require f }
+
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
 begin
@@ -26,6 +30,11 @@ RSpec.configure do |config|
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
+
+  # Use the faster rack test by default for system specs
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change

--- a/spec/requests/applications_list_spec.rb
+++ b/spec/requests/applications_list_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe 'Requesting applications' do
+  subject(:applications_response) { response }
+
+  before do
+    stub_request(:get, "#{ENV.fetch('CRIME_APPLY_API_URL')}applications")
+      .to_return(body: stubbed_body, status: stubbed_status)
+
+    get '/applications'
+  end
+
+  context 'when the crime apply api returns applications' do
+    let(:stubbed_body) { file_fixture('crime_apply_data/applications.json').read }
+    let(:stubbed_status) { 200 }
+
+    it { is_expected.to be_successful }
+  end
+
+  context 'when the crime apply api returns no applications' do
+    let(:stubbed_body) { [].to_json }
+    let(:stubbed_status) { 200 }
+
+    it { is_expected.to be_successful }
+  end
+
+  context 'with a crime apply api server error' do
+    let(:stubbed_body) { 'Server Error' }
+    let(:stubbed_status) { 500 }
+
+    it { is_expected.to be_successful }
+  end
+
+  context 'with a crime apply api not found error' do
+    let(:stubbed_body) { 'Not Found' }
+    let(:stubbed_status) { 404 }
+
+    it { is_expected.to be_successful }
+  end
+end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Home' do
+  include_context 'when applications exist'
+
   describe 'index' do
-    it 'renders the expected page' do
+    it 'renders the admin dashboard' do
       get '/'
       expect(response).to have_http_status(:ok)
     end

--- a/spec/support/shared_contexts_for_crime_apply_api.rb
+++ b/spec/support/shared_contexts_for_crime_apply_api.rb
@@ -1,0 +1,9 @@
+shared_context 'when applications exist' do
+  before do
+    stub_request(:get, "#{ENV.fetch('CRIME_APPLY_API_URL')}applications")
+      .to_return(
+        body: file_fixture('crime_apply_data/applications.json').read,
+        status: 200
+      )
+  end
+end

--- a/spec/system/applications_dashboard_spec.rb
+++ b/spec/system/applications_dashboard_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'Applications Dashboard' do
+  include_context 'when applications exist'
+
+  before do
+    visit '/applications'
+  end
+
+  it 'includes the page title' do
+    expect(page).to have_content I18n.t('crime_applications.index.page_title')
+  end
+
+  it 'includes the correct headings' do
+    column_headings = page.first('.app-dashboard-table thead tr').text
+
+    expect(column_headings).to eq('Applicant Reference Date received')
+  end
+
+  it 'shows the correct information' do
+    first_row_text = page.first('.app-dashboard-table tbody tr').text
+    expect(first_row_text).to eq('Zoe Wrong LAA-207a30 11 Oct 2022')
+  end
+
+  it 'can be used to navigate to an application' do
+    click_on('Zoe Wrong')
+
+    expect(current_url).to match('applications/207a30bd-d425-41d7-8665-75d93606cda6')
+  end
+end


### PR DESCRIPTION
## Description of change
Applications from Crime Apply can be viewed on the applications dashboard.

additionally:
- use rack_test for system specs by default

## Link to relevant ticket
https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMRE/boards/960?modal=detail&selectedIssue=CRIMRE-23

## Notes for reviewer

Test coverage in this exploratory phase comes primarily from system and not unit tests. 

The rational for this being:
- the architecture is experimental and likely to change 
- user expectations are decoupled from architecture, more evolved, less likely to change
- if the architecture changes, the system specs will be useful in catching regressions
- the data store is a stubbed http request to the dev api, so system specs are fast

## Screenshots of changes (if applicable)
<img width="1758" alt="Screenshot 2022-10-18 at 13 04 42" src="https://user-images.githubusercontent.com/34935/196424601-0a1620e2-cdd7-412c-b1d6-446a4cdfa87b.png">

## How to manually test the feature

Install puma-dev and configure https://laa-apply-for-criminal-legal-aid.test to point to apply and https://laa-review-criminal-legal-aid.test to review.