### PR TITLE
Crimre 31 co defendants

### DIFF
--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -27,10 +27,24 @@ module Types
     provider_address
   ].freeze
 
+  INTERESTS_OF_JUSTICE_TYPES = %w[
+    liberty
+    suspended_sentence
+    livelihood
+    reputation
+    question_of_law
+    unable_to_understand
+    witnesses_needed
+    expert_cross_examination
+    interests_of_another
+    ioj_other
+  ].freeze
+
   CorrespondenceAddressType = String.enum(*CORRESPONDENCE_ADDRESS_TYPES)
   OffenceClass = String.enum(*OFFENCE_CLASSES)
   CaseType = String.enum(*CASE_TYPES)
   CourtType = String.enum(*COURT_TYPES)
+  InterestsOfJusticeCriterion = String.enum(*INTERESTS_OF_JUSTICE_TYPES)
 
   CrimeApplicationReference = Types::String
   Uuid = String

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -27,24 +27,24 @@ module Types
     provider_address
   ].freeze
 
-  INTERESTS_OF_JUSTICE_TYPES = %w[
-    liberty
+  INTERESTS_OF_JUSTICE_CRITERIA = %w[
+    loss_of_liberty
     suspended_sentence
-    livelihood
+    loss_of_livelihood
     reputation
     question_of_law
-    unable_to_understand
-    witnesses_needed
-    expert_cross_examination
-    interests_of_another
-    ioj_other
+    understanding
+    witness_tracing
+    expert_examination
+    interest_of_another
+    other
   ].freeze
 
   CorrespondenceAddressType = String.enum(*CORRESPONDENCE_ADDRESS_TYPES)
   OffenceClass = String.enum(*OFFENCE_CLASSES)
   CaseType = String.enum(*CASE_TYPES)
   CourtType = String.enum(*COURT_TYPES)
-  InterestsOfJusticeCriterion = String.enum(*INTERESTS_OF_JUSTICE_TYPES)
+  InterestsOfJusticeCriterion = String.enum(*INTERESTS_OF_JUSTICE_CRITERIA)
 
   CrimeApplicationReference = Types::String
   Uuid = String

--- a/app/models/interest_of_justice.rb
+++ b/app/models/interest_of_justice.rb
@@ -1,4 +1,4 @@
 class InterestOfJustice < ApplicationStruct
-  attribute :type, Types::String
+  attribute :type, Types::InterestsOfJusticeCriterion
   attribute :reason, Types::String
 end

--- a/app/views/crime_applications/_co_defendants.html.erb
+++ b/app/views/crime_applications/_co_defendants.html.erb
@@ -1,0 +1,20 @@
+<h2 class="govuk-heading-m">
+  <%= t(:co_defendants, scope: 'crime_applications.section.headings') %>
+</h2>
+
+<dl class="govuk-summary-list">
+  <% co_defendants.each_with_index do |co_defendant, i| %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= t(:co_defendant, scope: 'crime_applications.labels', number: i + 1) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= co_defendant.first_name %>
+        <%= co_defendant.last_name %>
+      </dd>
+      <dd class="govuk-summary-list__value">
+        <%= co_defendant.conflict_of_interest %>
+      </dd>
+    </div>
+  <% end %>
+</dl>

--- a/app/views/crime_applications/_interests_of_justice.html.erb
+++ b/app/views/crime_applications/_interests_of_justice.html.erb
@@ -6,7 +6,7 @@
   <% interests_of_justice.each do |interest_of_justice| %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        <%= interest_of_justice.type %>
+        <%= t(interest_of_justice.type, scope: 'crime_applications.values') %>
       </dt>
       <dd class="govuk-summary-list__value">
         <%= interest_of_justice.reason %>

--- a/app/views/crime_applications/_interests_of_justice.html.erb
+++ b/app/views/crime_applications/_interests_of_justice.html.erb
@@ -1,0 +1,16 @@
+<h2 class="govuk-heading-m">
+  <%= t(:interests_of_justice, scope: 'crime_applications.section.headings') %>
+</h2>
+
+<dl class="govuk-summary-list">
+  <% interests_of_justice.each do |interest_of_justice| %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= interest_of_justice.type %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= interest_of_justice.reason %>
+      </dd>
+    </div>
+  <% end %>
+</dl>

--- a/app/views/crime_applications/show.html.erb
+++ b/app/views/crime_applications/show.html.erb
@@ -17,5 +17,6 @@
     <%= render partial: 'client_details', object: @crime_application.client_details %>
     <%= render partial: 'case_details', object: @crime_application.case_details %>
     <%= render partial: 'offences', object: @crime_application.case_details.offences %>
+    <%= render partial: 'co_defendants', object: @crime_application.case_details.co_defendants %>
   </div>
 </div>

--- a/app/views/crime_applications/show.html.erb
+++ b/app/views/crime_applications/show.html.erb
@@ -18,5 +18,6 @@
     <%= render partial: 'case_details', object: @crime_application.case_details %>
     <%= render partial: 'offences', object: @crime_application.case_details.offences %>
     <%= render partial: 'co_defendants', object: @crime_application.case_details.co_defendants %>
+    <%= render partial: 'interests_of_justice', object: @crime_application.interests_of_justice %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
         client_details: Client details
         overview: Overview
         offence_details: Offence details
+        co_defendants: Co-defendants 
     labels:
       first_name: First name
       last_name: Last name
@@ -52,6 +53,7 @@ en:
       hearing_date: Next court hearing 
       home_address: Home address 
       correspondence_address: Correspondence address 
+      co_defendant: Co-defendant %{number}
     values:
       "true": "Yes"
       "false": "No"
@@ -65,3 +67,6 @@ en:
       commital: Commital
       appeal_to_crown_court: Appeal to Crown Court
       appeal_to_crown_court_with_changes: Appeal to Crown Court with charges
+      conflict_of_interest:
+        "true": CONFLICT
+        "false": ''

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
         overview: Overview
         offence_details: Offence details
         co_defendants: Co-defendants 
+        interests_of_justice: Interest of Justice 
     labels:
       first_name: First name
       last_name: Last name
@@ -70,3 +71,13 @@ en:
       conflict_of_interest:
         "true": CONFLICT
         "false": ''
+      liberty: Liberty
+      suspended_sentence: suspended sentence
+      livelihood: livelihood
+      reputation: reputation
+      question_of_law: Question of Law
+      unable_to_understand: unabled to understand
+      witnesses_needed: witnesses needed
+      expert_cross_examination: expert cross examination
+      interests_of_another: Interests of Another
+      ioj_other: Other Interest of Justice

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,13 +71,13 @@ en:
       conflict_of_interest:
         "true": CONFLICT
         "false": ''
-      liberty: Liberty
-      suspended_sentence: suspended sentence
-      livelihood: livelihood
-      reputation: reputation
+      loss_of_liberty: Loss of liberty
+      suspended_sentence: Suspended sentence
+      loss_of_livelihood: Loss of livelihood
+      reputation: Reputation
       question_of_law: Question of Law
-      unable_to_understand: unabled to understand
-      witnesses_needed: witnesses needed
-      expert_cross_examination: expert cross examination
-      interests_of_another: Interests of Another
-      ioj_other: Other Interest of Justice
+      understanding: understanding
+      witness_tracing: Witness tracing
+      expert_examination: Expert examination
+      interest_of_another: Interest of another
+      other: Other

--- a/spec/fixtures/files/crime_apply_data/applications.json
+++ b/spec/fixtures/files/crime_apply_data/applications.json
@@ -2,8 +2,8 @@
   {
     "id": "696dd4fd-b619-4637-ab42-a5f4565bcf4a",
     "application_reference": "LAA-696dd4",
-    "application_start_date": "2022-10-21T16:19:00.000+00:00",
-    "submission_date": "2022-10-21T16:19:00.000+00:00",
+    "application_start_date": "2022-10-24T09:33:04.000+00:00",
+    "submission_date": "2022-10-24T09:33:04.000+00:00",
     "client_details": {
       "client": {
         "address": {
@@ -28,17 +28,37 @@
     },
     "interests_of_justice": [
       {
-        "reason": "Loss of liberty",
-        "type": "liberty"
+        "reason": "More details about why loss of liberty likely from the provider.",
+        "type": "loss_of_liberty"
+      },
+      {
+        "reason": "Witness justification as entered by the provider.",
+        "type": "expert_examination"
       }
     ],
     "case_details": {
       "case_type": "either_way",
-      "co_defendants": [],
+      "co_defendants": [
+        {
+          "conflict_of_interest": true,
+          "first_name": "Zoe",
+          "last_name": "Blogs"
+        },
+        {
+          "conflict_of_interest": false,
+          "first_name": "Ben",
+          "last_name": "Blogs"
+        }
+      ],
       "offences": [
         {
           "class": "Class C",
           "date": "2020-05-11",
+          "name": "Attempt robbery"
+        },
+        {
+          "class": "Class C",
+          "date": "2012-12-12",
           "name": "Attempt robbery"
         }
       ],

--- a/spec/fixtures/files/crime_apply_data/applications/696dd4fd-b619-4637-ab42-a5f4565bcf4a.json
+++ b/spec/fixtures/files/crime_apply_data/applications/696dd4fd-b619-4637-ab42-a5f4565bcf4a.json
@@ -1,8 +1,8 @@
 {
   "id": "696dd4fd-b619-4637-ab42-a5f4565bcf4a",
   "application_reference": "LAA-696dd4",
-  "application_start_date": "2022-10-21T16:19:00.000+00:00",
-  "submission_date": "2022-10-21T16:19:00.000+00:00",
+  "application_start_date": "2022-10-24T09:33:04.000+00:00",
+  "submission_date": "2022-10-24T09:33:04.000+00:00",
   "client_details": {
     "client": {
       "address": {
@@ -27,17 +27,37 @@
   },
   "interests_of_justice": [
     {
-      "reason": "Loss of liberty",
-      "type": "liberty"
+      "reason": "More details about why loss of liberty likely from the provider.",
+      "type": "loss_of_liberty"
+    },
+    {
+      "reason": "Witness justification as entered by the provider.",
+      "type": "expert_examination"
     }
   ],
   "case_details": {
     "case_type": "either_way",
-    "co_defendants": [],
+    "co_defendants": [
+      {
+        "conflict_of_interest": true,
+        "first_name": "Zoe",
+        "last_name": "Blogs"
+      },
+      {
+        "conflict_of_interest": false,
+        "first_name": "Ben",
+        "last_name": "Blogs"
+      }
+    ],
     "offences": [
       {
         "class": "Class C",
         "date": "2020-05-11",
+        "name": "Attempt robbery"
+      },
+      {
+        "class": "Class C",
+        "date": "2012-12-12",
         "name": "Attempt robbery"
       }
     ],

--- a/spec/system/applications_dashboard_spec.rb
+++ b/spec/system/applications_dashboard_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Applications Dashboard' do
 
   it 'shows the correct information' do
     first_row_text = page.first('.app-dashboard-table tbody tr').text
-    expect(first_row_text).to eq('Kit Pound LAA-696dd4 21 Oct 2022')
+    expect(first_row_text).to eq('Kit Pound LAA-696dd4 24 Oct 2022')
   end
 
   it 'can be used to navigate to an application' do


### PR DESCRIPTION
## Description of change
Adds Interests of Justice and Co-defendants to review page.

## Link to relevant ticket
[CRIMRE-31](https://dsdmoj.atlassian.net/browse/CRIMRE-31)
[CRIMRE-32](https://dsdmoj.atlassian.net/browse/CRIMRE-32)

## Notes for reviewer

NB: this does not include tag styling (see: https://dsdmoj.atlassian.net/browse/CRIMRE-62 )

This omits the table headings for offences and IoJ shown on the design. 

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="767" alt="Screenshot 2022-10-24 at 14 08 25" src="https://user-images.githubusercontent.com/34935/197532924-483f5041-3fe8-49ff-9b8f-1cc5784e4303.png">



## How to manually test the feature
