### PR TITLE
Crimre 62 add moj badge tag styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,4 @@
 @import "local/govuk";
 @import "local/custom";
+
+@import "local/moj";

--- a/app/assets/stylesheets/local/moj.scss
+++ b/app/assets/stylesheets/local/moj.scss
@@ -1,0 +1,9 @@
+// MOJ Design System
+// https://design-patterns.service.justice.gov.uk
+//
+// NOTE: using hand-picked components instead of importing
+// the whole library, as we only need a few ones.
+
+// Badge
+// https://design-patterns.service.justice.gov.uk/components/badge/
+@import "@ministryofjustice/frontend/moj/components/badge/badge";

--- a/app/views/crime_applications/_co_defendants.html.erb
+++ b/app/views/crime_applications/_co_defendants.html.erb
@@ -14,7 +14,7 @@
       </dd>
       <% if co_defendant.conflict_of_interest %>
         <dd class="govuk-summary-list__value">
-          <span class="govuk-tag govuk-tag--red">
+          <span class="moj-badge moj-badge--red">
             <%= t("crime_applications.values.conflict_of_interest.#{co_defendant.conflict_of_interest}") %>
           </span>
         </dd>

--- a/app/views/crime_applications/_overview.html.erb
+++ b/app/views/crime_applications/_overview.html.erb
@@ -18,7 +18,7 @@
     </dt>
     <dd class="govuk-summary-list__value">
       <% if overview.means_type == :passported %>
-        <span class="govuk-tag"><%= overview.means_type %></span>
+        <span class="moj-badge moj-badge--blue"><%= overview.means_type %></span>
       <% end %>
     </dd>
   </div>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "laa-review-criminal-legal-aid",
   "private": "true",
   "dependencies": {
-    "govuk-frontend": "4.3.1"
+    "govuk-frontend": "4.3.1",
+    "@ministryofjustice/frontend": "1.6.0"
   },
   "scripts": {
     "postinstall": "bin/importmap pin govuk-frontend@4.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,20 @@
 # yarn lockfile v1
 
 
-govuk-frontend@4.3.1:
+"@ministryofjustice/frontend@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-1.6.0.tgz#a17951012207f1b17d42cefe02ec90667d4ced7f"
+  integrity sha512-LFmDiO3y8l4qey2WDmRnHb98vAVSCD/QSYYEUBwS10ouyBNbYKGHWNLxF1VfulqOa5uPJp/fA2JUT9Pj1T4NUg==
+  dependencies:
+    govuk-frontend "^3.0.0 || ^4.0.0"
+    moment "^2.27.0"
+
+govuk-frontend@4.3.1, "govuk-frontend@^3.0.0 || ^4.0.0":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.3.1.tgz#d9c581aca3d23bbfe9bd27c25fee65322b276393"
   integrity sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A==
+
+moment@^2.27.0:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==


### PR DESCRIPTION
## Description of change
Imports badge component for MoJ design system

## Link to relevant ticket
[CRIMRE-62](https://dsdmoj.atlassian.net/browse/CRIMRE-62)


## Notes for reviewer
- I have only added the badge component to the build, we can require others as needed. This stops us needing to import everything and reduces the scss namespace to avoid clashes etc. similar approach used on apply.
 
## Screenshots of changes (if applicable)

### Before changes:
Overview section:
<img width="693" alt="Screenshot 2022-10-26 at 11 16 27" src="https://user-images.githubusercontent.com/13377553/198001230-642d10f6-7fe7-4f8e-aada-581816c2b872.png">

Co-defendants section:
<img width="677" alt="Screenshot 2022-10-26 at 11 17 10" src="https://user-images.githubusercontent.com/13377553/198001323-23412ef0-4d1d-4c13-8321-b81200f65bfe.png">

### After changes:
Overview section:
<img width="710" alt="Screenshot 2022-10-26 at 11 15 22" src="https://user-images.githubusercontent.com/13377553/198000913-23e1c155-bcad-4432-819f-9b3ac201ea35.png">

Co-defendants section:
<img width="676" alt="Screenshot 2022-10-26 at 11 15 52" src="https://user-images.githubusercontent.com/13377553/198001106-2b2bdb53-45bc-4f1a-90f1-7e557ec0b01e.png">

## How to manually test the feature
- run `yarn install`
- got to app url > click through to an application's show page > see the new badges.