### PR TITLE
Display offences as a table

### DIFF
--- a/app/views/crime_applications/_offences.html.erb
+++ b/app/views/crime_applications/_offences.html.erb
@@ -2,18 +2,30 @@
   <%= t(:offence_details, scope: 'crime_applications.section.headings') %>
 </h2>
 
-<dl class="govuk-summary-list">
-  <% offences.each do |offence| %>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= offence.name %>
-        <span class='govuk-caption-m'>
-          <%= offence.offence_class %>
-        </span>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= l offence.date %>
-      </dd>
-    </div>
-  <% end %>
-</dl>
+<table class="govuk-table app-dashboard-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">
+        <%= t('crime_applications.labels.offence') %>
+      </th>
+      <th scope="col" class="govuk-table__header">
+        <%= t('crime_applications.labels.offence_date') %>
+      </th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% offences.each do |offence| %>
+      <tr class="govuk-table__row">
+        <td scope="row" class="govuk-table__cell">
+          <%= offence.name %>
+          <span class='govuk-caption-m'>
+            <%= offence.offence_class %>
+          </span>
+        </td>
+        <td class="govuk-table__cell">
+          <%= l offence.date %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,8 @@ en:
       home_address: Home address 
       correspondence_address: Correspondence address 
       co_defendant: Co-defendant %{number}
+      offence: Offence 
+      offence_date: Offence date 
     values:
       "true": "Yes"
       "false": "No"


### PR DESCRIPTION
## Description of change
Display offences as a table 

## Link to relevant ticket
[CRIMRE-30](https://dsdmoj.atlassian.net/browse/CRIMRE-30)

## Notes for reviewer

Design requirement.

## Screenshots of changes (if applicable)

### Before changes:
<img width="861" alt="Screenshot 2022-11-02 at 09 06 31" src="https://user-images.githubusercontent.com/34935/199449083-1e2b9afa-82bd-489b-911e-8493f2ee9ef0.png">

### After changes:
<img width="1021" alt="Screenshot 2022-11-02 at 09 06 23" src="https://user-images.githubusercontent.com/34935/199449128-16fad348-7cfc-4805-bedd-22ade62b0195.png">

## How to manually test the feature
