### PR TITLE
Crimre 72 primary nav

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'dotenv-rails'
+  gem 'pry'
   gem 'rspec-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
@@ -239,6 +240,9 @@ GEM
     parser (3.1.2.1)
       ast (~> 2.4.1)
     pg (1.4.3)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (5.0.0)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -436,6 +440,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   openid_connect
   pg (~> 1.4)
+  pry
   puma
   rails (~> 7.0.3)
   rails_event_store

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,3 @@
 @import "local/govuk";
 @import "local/custom";
-
 @import "local/moj";

--- a/app/assets/stylesheets/local/moj.scss
+++ b/app/assets/stylesheets/local/moj.scss
@@ -7,3 +7,6 @@
 // Badge
 // https://design-patterns.service.justice.gov.uk/components/badge/
 @import "@ministryofjustice/frontend/moj/components/badge/badge";
+@import "@ministryofjustice/frontend/moj/settings/measurements";
+@import "@ministryofjustice/frontend/moj/objects/width-container";
+@import "@ministryofjustice/frontend/moj/components/primary-navigation/primary-navigation";

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,13 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   helper_method :current_user
-
+  helper_method :assignments_count
+  
   private
+
+  def assignments_count
+    current_user.assigned_applications.count
+  end
 
   def current_user
     warden.user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   helper_method :current_user
   helper_method :assignments_count
-  
+
   private
 
   def assignments_count

--- a/app/views/assigned_applications/index.html.erb
+++ b/app/views/assigned_applications/index.html.erb
@@ -9,7 +9,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= link_to t('calls_to_action.view_all_open_applications'), crime_applications_path %>
     <table class="govuk-table app-dashboard-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -1,8 +1,5 @@
 <% title t('.page_title') %>
 
-<%# TODO: tab navigation %>
-<%= link_to t('assigned_applications.index.heading'), assigned_applications_path %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full govuk-!-margin-bottom-5">
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>

--- a/app/views/layouts/_primary_navigation.html.erb
+++ b/app/views/layouts/_primary_navigation.html.erb
@@ -3,26 +3,30 @@
   <div class="moj-primary-navigation__container">
 
     <div class="moj-primary-navigation__nav">
-
       <nav class="moj-primary-navigation" aria-label="Primary navigation">
 
         <ul class="moj-primary-navigation__list">
           <li class="moj-primary-navigation__item">
-            <a class="moj-primary-navigation__link" aria-current="page" href="#1">Nav item 1</a>
+            <%= link_to t('primary_navigation.your_list', count: assignments_count), 
+              assigned_applications_path, 
+              class: 'moj-primary-navigation__link', 
+              aria_current: 'page' %>
           </li>
 
           <li class="moj-primary-navigation__item">
-            <a class="moj-primary-navigation__link" href="#2">Nav item 2</a>
+            <%= link_to t('primary_navigation.open_apps'), 
+              crime_applications_path, 
+              class: 'moj-primary-navigation__link' %>
           </li>
 
           <li class="moj-primary-navigation__item">
-            <a class="moj-primary-navigation__link" href="#3">Nav item 3</a>
+            <%= link_to t('primary_navigation.closed_apps'), 
+              '#TODO', 
+              class: 'moj-primary-navigation__link' %>
           </li>
         </ul>
 
       </nav>
-
     </div>
   </div>
-
-</div
+</div>

--- a/app/views/layouts/_primary_navigation.html.erb
+++ b/app/views/layouts/_primary_navigation.html.erb
@@ -10,22 +10,16 @@
             <%= link_to t('primary_navigation.your_list', count: assignments_count), 
               assigned_applications_path, 
               class: 'moj-primary-navigation__link', 
-              aria_current: 'page' %>
+              aria: { current: current_page?('/assigned_applications') ? 'page' : nil } %>
           </li>
 
           <li class="moj-primary-navigation__item">
             <%= link_to t('primary_navigation.open_apps'), 
               crime_applications_path, 
-              class: 'moj-primary-navigation__link' %>
-          </li>
-
-          <li class="moj-primary-navigation__item">
-            <%= link_to t('primary_navigation.closed_apps'), 
-              '#TODO', 
-              class: 'moj-primary-navigation__link' %>
+              class: 'moj-primary-navigation__link', 
+              aria: { current: current_page?('/applications') ? 'page' : nil } %>
           </li>
         </ul>
-
       </nav>
     </div>
   </div>

--- a/app/views/layouts/_primary_navigation.html.erb
+++ b/app/views/layouts/_primary_navigation.html.erb
@@ -7,17 +7,18 @@
 
         <ul class="moj-primary-navigation__list">
           <li class="moj-primary-navigation__item">
-            <%= link_to t('primary_navigation.your_list', count: assignments_count), 
-              assigned_applications_path, 
-              class: 'moj-primary-navigation__link', 
-              aria: { current: current_page?(assigned_applications_path) ? 'page' : nil } %>
+            <%= link_to t('primary_navigation.your_list',
+                          count: assignments_count),
+                        assigned_applications_path,
+                        class: 'moj-primary-navigation__link',
+                        aria: { current: current_page?(assigned_applications_path) ? 'page' : nil } %>
           </li>
 
           <li class="moj-primary-navigation__item">
-            <%= link_to t('primary_navigation.open_apps'), 
-              crime_applications_path, 
-              class: 'moj-primary-navigation__link', 
-              aria: { current: current_page?(crime_applications_path) ? 'page' : nil } %>
+            <%= link_to t('primary_navigation.open_apps'),
+                        crime_applications_path,
+                        class: 'moj-primary-navigation__link',
+                        aria: { current: current_page?(crime_applications_path) ? 'page' : nil } %>
           </li>
         </ul>
       </nav>

--- a/app/views/layouts/_primary_navigation.html.erb
+++ b/app/views/layouts/_primary_navigation.html.erb
@@ -1,0 +1,28 @@
+<div class="moj-primary-navigation">
+
+  <div class="moj-primary-navigation__container">
+
+    <div class="moj-primary-navigation__nav">
+
+      <nav class="moj-primary-navigation" aria-label="Primary navigation">
+
+        <ul class="moj-primary-navigation__list">
+          <li class="moj-primary-navigation__item">
+            <a class="moj-primary-navigation__link" aria-current="page" href="#1">Nav item 1</a>
+          </li>
+
+          <li class="moj-primary-navigation__item">
+            <a class="moj-primary-navigation__link" href="#2">Nav item 2</a>
+          </li>
+
+          <li class="moj-primary-navigation__item">
+            <a class="moj-primary-navigation__link" href="#3">Nav item 3</a>
+          </li>
+        </ul>
+
+      </nav>
+
+    </div>
+  </div>
+
+</div

--- a/app/views/layouts/_primary_navigation.html.erb
+++ b/app/views/layouts/_primary_navigation.html.erb
@@ -10,14 +10,14 @@
             <%= link_to t('primary_navigation.your_list', count: assignments_count), 
               assigned_applications_path, 
               class: 'moj-primary-navigation__link', 
-              aria: { current: current_page?('/assigned_applications') ? 'page' : nil } %>
+              aria: { current: current_page?(assigned_applications_path) ? 'page' : nil } %>
           </li>
 
           <li class="moj-primary-navigation__item">
             <%= link_to t('primary_navigation.open_apps'), 
               crime_applications_path, 
               class: 'moj-primary-navigation__link', 
-              aria: { current: current_page?('/applications') ? 'page' : nil } %>
+              aria: { current: current_page?(crime_applications_path) ? 'page' : nil } %>
           </li>
         </ul>
       </nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,10 @@
   <%= render partial: 'layouts/phase_banner' %>
 <% end %>
 
+<% content_for(:primary_navgation) do %>
+  <%= render partial: 'layouts/primary_navigation' %>
+<% end %>
+
 <% content_for(:content) do %>
   <%= yield %>
 <% end %>

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -58,6 +58,7 @@
 
 <div class="govuk-width-container">
   <%= yield(:phase_banner) %>
+  <%= yield(:primary_navgation) %>
   <%= yield(:back_link) %>
 
   <main class="govuk-main-wrapper" id="main-content" role="main">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,7 +27,6 @@ en:
   primary_navigation:
     your_list: "Your list (%{count})"
     open_apps: All open applications
-    closed_apps: Closed applications
 
   assigned_applications:
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,11 @@ en:
     new:
       page_title: Login
 
+  primary_navigation:
+    your_list: "Your list (%{count})"
+    open_apps: All open applications
+    closed_apps: Closed applications
+
   assigned_applications:
     index:
       page_title: Your list

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ApplicationHelper, type: :helper do
+RSpec.describe ApplicationHelper do
   describe '#title' do
     let(:title) { helper.content_for(:page_title) }
 

--- a/spec/helpers/form_builder_helper_spec.rb
+++ b/spec/helpers/form_builder_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe FormBuilderHelper, type: :helper do
+RSpec.describe FormBuilderHelper do
   let(:form_object) { class_double(Class) }
 
   let(:builder) do

--- a/spec/system/primary_nav_spec.rb
+++ b/spec/system/primary_nav_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Applications Dashboard' do
+RSpec.describe 'Primary navigation' do
   before do
     visit '/applications'
   end

--- a/spec/system/primary_nav_spec.rb
+++ b/spec/system/primary_nav_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe 'Applications Dashboard' do
     visit '/applications'
   end
 
-  context 'Your list link' do
-    context 'before assignment' do
+  context 'with the "Your list" link' do
+    describe 'before assignment' do
       it 'has the correct number of applications in the link' do
         expect(page).to have_content('Your list (0)')
       end
     end
-    context 'after assignment' do
 
+    describe 'after assignment' do
       before do
         click_on('Kit Pound')
         click_on('Assign to myself')
@@ -35,7 +35,7 @@ RSpec.describe 'Applications Dashboard' do
     end
   end
 
-  context 'other primary nav links' do
+  context 'with the other primary nav links' do
     it 'takes you to All applications when you click "All open applications"' do
       click_on('All open applications')
 
@@ -44,11 +44,6 @@ RSpec.describe 'Applications Dashboard' do
 
       expect(heading_text).to eq('All open applications')
       expect(first_row_text).to eq('Kit Pound LAA-696dd4 27 Oct 2022')
-    end
-
-    it 'takes you to closed applications when "Closed applications" is clicked' do
-      pending('add spec when we have Closed applications functionality / page')
-      raise 'pending closed applications'
     end
   end
 end

--- a/spec/system/primary_nav_spec.rb
+++ b/spec/system/primary_nav_spec.rb
@@ -27,10 +27,8 @@ RSpec.describe 'Applications Dashboard' do
         click_on('Your list (1)')
 
         heading_text = page.first('.govuk-heading-xl').text
-        first_row_text = page.first('.app-dashboard-table tbody tr').text
 
         expect(heading_text).to eq('Your list')
-        expect(first_row_text).to eq('Kit Pound LAA-696dd4 21 days 27 Oct 2022 Yes')
       end
     end
   end

--- a/spec/system/primary_nav_spec.rb
+++ b/spec/system/primary_nav_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe 'Applications Dashboard' do
+  before do
+    visit '/applications'
+  end
+
+  context 'Your list link' do
+    context 'before assignment' do
+      it 'has the correct number of applications in the link' do
+        expect(page).to have_content('Your list (0)')
+      end
+    end
+    context 'after assignment' do
+
+      before do
+        click_on('Kit Pound')
+        click_on('Assign to myself')
+        visit '/applications'
+      end
+
+      it 'has the correct number of applications in the link' do
+        expect(page).to have_content('Your list (1)')
+      end
+
+      it 'takes the user to their list when clicked' do
+        click_on('Your list (1)')
+
+        heading_text = page.first('.govuk-heading-xl').text
+        first_row_text = page.first('.app-dashboard-table tbody tr').text
+
+        expect(heading_text).to eq('Your list')
+        expect(first_row_text).to eq('Kit Pound LAA-696dd4 21 days 27 Oct 2022 Yes')
+      end
+    end
+  end
+
+  context 'other primary nav links' do
+    it 'takes you to All applications when you click "All open applications"' do
+      click_on('All open applications')
+
+      heading_text = page.first('.govuk-heading-xl').text
+      first_row_text = page.first('.app-dashboard-table tbody tr').text
+
+      expect(heading_text).to eq('All open applications')
+      expect(first_row_text).to eq('Kit Pound LAA-696dd4 27 Oct 2022')
+    end
+
+    it 'takes you to closed applications when "Closed applications" is clicked' do
+      pending('add spec when we have Closed applications functionality / page')
+      raise 'pending closed applications'
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Adds primary nav to the application

## Link to relevant ticket
[CRIMRE-72](https://dsdmoj.atlassian.net/browse/CRIMRE-72)

## Notes for reviewer
- I have left out 'closed applications' as they don't exist yet

## Screenshots of changes (if applicable)

### After changes:
<img width="1030" alt="Screenshot 2022-11-18 at 14 58 45" src="https://user-images.githubusercontent.com/13377553/202734204-6a9b4131-8954-4a5d-bfa9-20ada84d69d8.png">

## How to manually test the feature
- click on primary nav a link - it should have the blue highlight under it after being clicked
- the 'Your list' page should reflect the number of applications in your list
- if you go to an application show page then none of the nav links should have the blue highlight