### PR TITLE
Implement sub nav

### DIFF
--- a/app/assets/stylesheets/local/moj.scss
+++ b/app/assets/stylesheets/local/moj.scss
@@ -7,6 +7,11 @@
 // Badge
 // https://design-patterns.service.justice.gov.uk/components/badge/
 @import "@ministryofjustice/frontend/moj/components/badge/badge";
+
+// Primary navigation
 @import "@ministryofjustice/frontend/moj/settings/measurements";
 @import "@ministryofjustice/frontend/moj/objects/width-container";
 @import "@ministryofjustice/frontend/moj/components/primary-navigation/primary-navigation";
+
+// Sub navigation
+@import "@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";

--- a/app/views/crime_applications/show.html.erb
+++ b/app/views/crime_applications/show.html.erb
@@ -17,6 +17,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render partial: 'shared/subnavigation', locals: { crime_application: @crime_application } %>
     <%= render partial: 'overview', object: @crime_application %>
     <%= render partial: 'client_details', object: @crime_application.client_details %>
     <%= render partial: 'case_details', object: @crime_application.case_details %>

--- a/app/views/shared/_subnavigation.html.erb
+++ b/app/views/shared/_subnavigation.html.erb
@@ -1,0 +1,11 @@
+<nav class="moj-sub-navigation" aria-label="Sub navigation">
+  <ul class="moj-sub-navigation__list">
+    <li class="moj-sub-navigation__item">
+      <%= link_to t('.application_details'), crime_application_path(crime_application), class: 'moj-sub-navigation__link', aria: { current: current_page?(crime_application_path, action: 'show') ? 'page' : nil } %>
+    </li>
+    <%# To do when we have application history path %>
+    <li class="moj-sub-navigation__item">
+      <%= link_to t('.application_history'), health_path, class: 'moj-sub-navigation__link', aria: { current: current_page?(health_path, action: 'show') ? 'page' : nil } %>
+    </li>
+  </ul>
+</nav>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,3 +115,10 @@ en:
   calls_to_action:
     assign_to_myself: Assign to myself
     view_all_open_applications: View all open applications 
+
+  shared:
+    subnavigation:
+      application_details: Application details
+      application_history: Application history
+      
+        

--- a/spec/system/sub_nav_spec.rb
+++ b/spec/system/sub_nav_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe 'Sub navigation' do
+  before do
+    visit '/applications'
+    click_on('Kit Pound')
+  end
+
+  context 'with the "Application details" link' do
+    it 'takes the user to their list when clicked' do
+      click_on('Application details')
+
+      heading_text = page.first('.govuk-heading-l').text
+
+      expect(heading_text).to eq('Kit Pound')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Implements sub navigation on view application page. 2 links, one for Application details and one for Application history (which is not yet hooked up)

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-35

## Notes for reviewer
As Application history not yet working, this links out to heathcheck - it is possible to inspect the link for Application details to view the correct aria-current tag, but not for history until this is available to implement. 

## Screenshots of changes (if applicable)

### Before changes:
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/45827968/202795544-01e9c485-96d3-4f03-b82e-c78075b7b541.png">

### After changes:
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/45827968/202795882-517f7a2d-ad05-4b66-a52d-aabb94a700ba.png">



## How to manually test the feature
Go to all applications, click on an applicant name to view application - see the sub navigation
