### PR TITLE
CRIMRE-69 use indirect object name and not self

### DIFF
--- a/app/models/application_history_event.rb
+++ b/app/models/application_history_event.rb
@@ -5,7 +5,12 @@ class ApplicationHistoryEvent < ApplicationStruct
   attribute :event_type, Types::String
 
   def description
-    I18n.t(event_type.underscore.tr('/', '.'), scope: 'event.description', name: user_name)
+    I18n.t(
+      event_type.underscore.tr('/', '.'),
+      scope: 'event.description',
+      who_user_name: user_name,
+      whom_user_name: user_name
+    )
   end
 
   class << self

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,7 +87,7 @@ en:
       other: "%{count} days"
   
   calls_to_action:
-    assign_to_self: Assign to myself
+    assign_to_self: Assign to myself 
     unassign_from_self: Remove from your list 
     view_all_open_applications: View all open applications 
 
@@ -99,10 +99,10 @@ en:
   event:
     description:
       application:
-        submitted: Application submitted by provider
+        submitted: Application submitted
       assigning:
-        assigned_to_user: Application assigned to self
-        unassigned_from_self: Application unassigned from self
+        assigned_to_user: Application assigned to %{whom_user_name}
+        unassigned_from_self: Application removed from %{whom_user_name}
 
 
   assigned_applications:

--- a/spec/system/viewing_application_history_spec.rb
+++ b/spec/system/viewing_application_history_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Viewing application history' do
 
     it 'includes the submission event' do
       first_row = page.first('.app-dashboard-table tbody tr').text
-      expect(first_row).to match('Monday 24 Oct 09:33 Provider Name Application submitted by provider')
+      expect(first_row).to match('Monday 24 Oct 09:33 Provider Name Application submitted')
     end
   end
 
@@ -26,7 +26,7 @@ RSpec.describe 'Viewing application history' do
 
     it 'includes the submission event' do
       first_row = page.first('.app-dashboard-table tbody tr').text
-      expect(first_row).to match('Joe EXAMPLE Application assigned to self')
+      expect(first_row).to match('Joe EXAMPLE Application assigned to Joe EXAMPLE')
     end
   end
 
@@ -41,7 +41,7 @@ RSpec.describe 'Viewing application history' do
 
     it 'includes the submission event' do
       first_row = page.first('.app-dashboard-table tbody tr').text
-      expect(first_row).to match('Joe EXAMPLE Application unassigned from self')
+      expect(first_row).to match('Joe EXAMPLE Application removed from Joe EXAMPLE')
     end
   end
 end


### PR DESCRIPTION
## Description of change
Update application history event description to use the name of the person whom the application was assigned to or from rather than self.

## Link to relevant ticket
[CRIMRE-69](https://dsdmoj.atlassian.net/browse/CRIMRE-69)

## Notes for reviewer

This reverts a change I'd made the wording of assigning event descriptions when the indirect object of the sentence was the subject. 

## Screenshots of changes (if applicable)

### Before changes:

<img width="689" alt="Screenshot 2022-11-23 at 10 46 33" src="https://user-images.githubusercontent.com/34935/203527844-7b750041-e0c9-4b07-9197-1f44e7d9d3e9.png">

### After changes:
<img width="720" alt="Screenshot 2022-11-23 at 10 46 16" src="https://user-images.githubusercontent.com/34935/203527920-ba9e4786-f0e9-4935-934c-1aefed2f37c2.png">

## How to manually test the feature
