### PR TITLE
Align text right to match design

### DIFF
--- a/app/views/crime_applications/_codefendants.html.erb
+++ b/app/views/crime_applications/_codefendants.html.erb
@@ -13,7 +13,7 @@
         <%= codefendant.last_name %>
       </dd>
       <% if codefendant.conflict_of_interest %>
-        <dd class="govuk-summary-list__value">
+        <dd class="govuk-summary-list__value govuk-!-text-align-right">
           <span class="moj-badge moj-badge--red">
             <%= t("crime_applications.values.conflict_of_interest.#{codefendant.conflict_of_interest}") %>
           </span>


### PR DESCRIPTION
## Description of change
Conflict tag already present - this PR just right aligns it to match the designs in the ticket.

## Link to relevant ticket
[CRIMRE-77](https://dsdmoj.atlassian.net/browse/CRIMRE-77)

## Screenshots of changes (if applicable)

### Before change
<img width="887" alt="Screenshot 2022-12-06 at 13 54 03" src="https://user-images.githubusercontent.com/13377553/205930707-d2fc4e1f-803d-434d-8ada-8ce22f930893.png">

### After changes:
<img width="884" alt="Screenshot 2022-12-06 at 13 50 05" src="https://user-images.githubusercontent.com/13377553/205930731-9debe58b-ceac-4491-ae2b-4647464e742f.png">


## How to manually test the feature
