### PR TITLE
Change default date to match MAAT's format

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,8 +1,7 @@
 en:
   dictionary:
     DATE_FORMATS: &DATE_FORMATS
-      default: '%-d %b %Y'  # 3 Jan 2019
-      compact: '%d/%m/%Y'   # 03/01/2019
+      default: '%d/%m/%Y'  ## 03/01/2019
 
   service:
     name: Review criminal legal aid applications

--- a/spec/system/applications_dashboard_spec.rb
+++ b/spec/system/applications_dashboard_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Applications Dashboard' do
   it 'shows the correct information' do
     first_row_text = page.first('.app-dashboard-table tbody tr').text
     days_ago = Rational((Time.zone.now - DateTime.parse('2022-10-27T14:09:11.000+00:00')), 1.day).floor
-    expect(first_row_text).to eq("Kit Pound 120398120 27 Oct 2022 #{days_ago} days Yes")
+    expect(first_row_text).to eq("Kit Pound 120398120 27/10/2022 #{days_ago} days Yes")
   end
 
   it 'can be used to navigate to an application' do


### PR DESCRIPTION
## Description of change
Changes default date to be in DD/MM/YYYY format in the app to reflect the format on MAAT.

## Link to relevant ticket
[CRIMRE-37](https://dsdmoj.atlassian.net/browse/CRIMRE-37)

## Screenshots of changes (if applicable)

### Before changes:
<img width="1306" alt="Screenshot 2022-12-06 at 14 09 40" src="https://user-images.githubusercontent.com/13377553/205934194-54dd7806-15cc-490b-90e2-effc5dd4f98e.png">

### After changes:
<img width="1350" alt="Screenshot 2022-12-06 at 14 09 14" src="https://user-images.githubusercontent.com/13377553/205934123-8ef6e6bf-e426-4d22-a8fd-673456d6f861.png">