### PR TITLE
Account for situation where there is no next application to get

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,9 @@ Layout/HashAlignment:
 Metrics/MethodLength:
   Max: 12
 
+RSpec/ExampleLength:
+  Max: 6
+
 # https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashSyntax
 Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
     important:
       title: Important
       state_has_changed: This application has already been assigned to someone else.
+      no_next_to_assign: There are no unassigned applications to that need processing at this time. Please try again later.
 
   sessions:
     new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,7 @@ en:
     important:
       title: Important
       state_has_changed: This application has already been assigned to someone else.
-      no_next_to_assign: There are no unassigned applications to that need processing at this time. Please try again later.
+      no_next_to_assign: There are no new applications to be reviewed at this time. Please try again later.
 
   sessions:
     new:

--- a/spec/system/get_next_application_spec.rb
+++ b/spec/system/get_next_application_spec.rb
@@ -8,16 +8,13 @@ RSpec.describe 'Assigning an application to myself' do
     expect(page).to have_content('This application has been assigned to you')
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it 'shows an error when there is no next application' do
-    visit '/'
-    click_on 'Get next application'
-    visit '/'
-    click_on 'Get next application'
-    visit '/'
-    click_on 'Get next application'
+    3.times do
+      visit '/'
+      click_on 'Get next application'
+    end
+
     expect(page).to have_content('Your list')
-    expect(page).to have_content('There are no unassigned applications to that need processing at this time')
+    expect(page).to have_content('There are no new applications to be reviewed')
   end
-  # rubocop:enable RSpec/ExampleLength
 end

--- a/spec/system/get_next_application_spec.rb
+++ b/spec/system/get_next_application_spec.rb
@@ -7,4 +7,17 @@ RSpec.describe 'Assigning an application to myself' do
     expect(page).to have_content('Kit Pound')
     expect(page).to have_content('This application has been assigned to you')
   end
+
+  # rubocop:disable RSpec/ExampleLength
+  it 'shows an error when there is no next application' do
+    visit '/'
+    click_on 'Get next application'
+    visit '/'
+    click_on 'Get next application'
+    visit '/'
+    click_on 'Get next application'
+    expect(page).to have_content('Your list')
+    expect(page).to have_content('There are no unassigned applications to that need processing at this time')
+  end
+  # rubocop:enable RSpec/ExampleLength
 end


### PR DESCRIPTION
## Description of change

Add conditional around get next feature dependent on there being an available unassigned application for a casework to assign to themselves

## Notes for reviewer
I have made decisions unilaterally whilst awaiting response from product and design - redirecting user to their list, and showing flash message: `There are no unassigned applications to that need processing at this time, please try again later`

## Screenshots of changes (if applicable)

### Before changes:
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/45827968/207377563-959b8919-5636-4863-a478-bbe093153bdb.png">

### After changes:
<img width="1087" alt="image" src="https://user-images.githubusercontent.com/45827968/207381726-66ac8685-8877-47c8-86a2-5070bf3a997b.png">



## How to manually test the feature
Ensure there are no unassigned applications, navigate to your list page, click get next. 
