### PR TITLE
Change copy on search to match designs

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -17,4 +17,8 @@ form.search {
     width: 8em;
   }
 }
+
+p.help-text {
+  color: govuk-colour("dark-grey");
+}
 //

--- a/app/views/application/_application_search_filter.html.erb
+++ b/app/views/application/_application_search_filter.html.erb
@@ -1,20 +1,21 @@
 <%= form_with url: application_searches_path, scope: :filter, method: :post, class: 'search' do |f| %>
 
-  <%= f.govuk_fieldset legend: { text: t('legends.search_applications') } do %>
-    <label class="govuk-label govuk-label--s"><%= t('labels.application_information')%></label>
-      <div class="input-group">
-        <%= f.govuk_text_field(
-              :search_text,
-              label: { text: t('labels.search_text') },
-              autocomplete: 'off'
-            ) %>
-        <%= f.search_date_field(
-              :applicant_date_of_birth,
-              as: :date,
-              value: f.object&.strftime('%m/%m/%d/%y'),
-              label: { text: t('labels.applicant_date_of_birth') }
-            ) %>
-      </div>
+  <p class="help-text"><%= t('application_searches.hint_text') %></p>
+
+  <%= f.govuk_fieldset legend: { text: nil } do %>
+    <div class="input-group">
+      <%= f.govuk_text_field(
+            :search_text,
+            label: { text: t('labels.search_text') },
+            autocomplete: 'off'
+          ) %>
+      <%= f.search_date_field(
+            :applicant_date_of_birth,
+            as: :date,
+            value: f.object&.strftime('%m/%m/%d/%y'),
+            label: { text: t('labels.applicant_date_of_birth') }
+          ) %>
+    </div>
 
     <label class="govuk-label govuk-label--s"><%= t('labels.search_criteria')%></label>
     <div class="input-group">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,7 +76,6 @@ en:
     status: Status
 
   legends:
-    search_applications: Search for open applications
 
   values: &VALUES
     "true": "Yes"
@@ -153,6 +152,7 @@ en:
         page_title: Confirm reassign
 
   application_searches:
+    hint_text: All fields are optional
     new:
       page_title: Search for an application
       heading: Search for an application

--- a/spec/system/search_applications/no_search_results_spec.rb
+++ b/spec/system/search_applications/no_search_results_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe 'No search results' do
     click_on 'Search'
   end
 
+  describe 'form help text' do
+    it 'states that all fields are optional' do
+      expect(page).to have_content('All fields are optional')
+    end
+  end
+
   describe 'no results found header' do
     before do
       fill_in 'filter-applicant-date-of-birth-field', with: dob


### PR DESCRIPTION
## Description of change

Small PR to change search copy to match designs - removes heading from the search and addes some grey help text in place

## Link to relevant ticket

[CRIMRE-108](https://dsdmoj.atlassian.net/browse/CRIMRE-108)

## Screenshots of changes (if applicable)

### Before changes:
<img width="1680" alt="Screenshot 2022-12-13 at 15 40 19" src="https://user-images.githubusercontent.com/13377553/207377685-c2364244-3fd8-46c2-b05b-bf41657e6f15.png">


### After changes:
<img width="1676" alt="Screenshot 2022-12-13 at 15 39 48" src="https://user-images.githubusercontent.com/13377553/207377553-7746f766-573a-4821-a46f-1694090cf67c.png">



## How to manually test the feature
- go to search page - check it against the designs
