### PR TITLE
Add event browser for development

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,6 @@ Rails.application.routes.draw do
     post :get_next, on: :collection
   end
 
+  mount RailsEventStore::Browser => "/event_browser" if Rails.env.development?
   root 'assigned_applications#index'
 end


### PR DESCRIPTION
## Description of change

Adds rails event store browser to app when running in development mode.

Browser is mounted at `/event_browser`

## Link to relevant ticket
n/a

## Notes for reviewer
is this useful, id like your thoughts? I think it will be helpful for debugging

## Screenshots of changes (if applicable)

### After changes:
<img width="1752" alt="Screenshot 2022-12-14 at 14 41 47" src="https://user-images.githubusercontent.com/13377553/207625955-59dd1325-c8e9-475c-888a-d4dd5b815850.png">


## How to manually test the feature
Load app in dev mode

Go to `/event_browser` -> click on an event to see details of it
