### PR TITLE
Add csv download link

### DIFF
--- a/app/controllers/application_searches_controller.rb
+++ b/app/controllers/application_searches_controller.rb
@@ -10,6 +10,13 @@ class ApplicationSearchesController < ApplicationController
     render :show
   end
 
+  def download
+    filter = ApplicationSearchFilter.new(search_params)
+    csv = ApplicationSearchCsv.new(filter:)
+
+    send_data csv.csv, filename: csv.file_name
+  end
+
   private
 
   def search_params

--- a/app/models/application_search_csv.rb
+++ b/app/models/application_search_csv.rb
@@ -1,0 +1,38 @@
+require 'csv'
+
+class ApplicationSearchCsv
+  def initialize(filter:)
+    @filter = filter
+  end
+
+  def csv
+    @csv ||= CSV.generate do |csv|
+      csv << headers
+
+      search.each do |result|
+        csv << ApplicationSearchResult.new(result).as_csv
+      end
+    end
+  end
+
+  def file_name
+    [
+      'application_search',
+      @filter.state_key
+    ].join('_')
+  end
+
+  private
+
+  def headers
+    %i[reference received_at reviewed_at caseworker status].map do |key|
+      I18n.t(key, scope: :table_headings)
+    end
+  end
+
+  def search
+    @search ||= DatastoreApi::Requests::SearchApplications.new(
+      **@filter.as_json, per_page: 10_000
+    ).call
+  end
+end

--- a/app/models/application_search_filter.rb
+++ b/app/models/application_search_filter.rb
@@ -37,6 +37,10 @@ class ApplicationSearchFilter < ApplicationStruct
     }
   end
 
+  def state_key
+    Digest::SHA256.hexdigest(as_json.values.join)
+  end
+
   private
 
   def assigned_to_user_options

--- a/app/models/application_search_result.rb
+++ b/app/models/application_search_result.rb
@@ -23,4 +23,11 @@ class ApplicationSearchResult < ApplicationStruct
   def time_passed
     Time.zone.now - submitted_at
   end
+
+  def as_csv
+    [
+      reference, submitted_at, '', current_assignment&.user_id,
+      I18n.t(status, scope: 'values.status')
+    ]
+  end
 end

--- a/app/views/application/_application_search_filter.html.erb
+++ b/app/views/application/_application_search_filter.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: application_searches_path, scope: :filter, method: :post, class: 'search' do |f| %>
+<%= form_with url: application_searches_path, scope: :filter, method: :post, class: 'search', id: 'search_filter' do |f| %>
 
   <p class="help-text"><%= t('application_searches.hint_text') %></p>
 

--- a/app/views/application_searches/show.html.erb
+++ b/app/views/application_searches/show.html.erb
@@ -11,10 +11,15 @@
   <%= render 'no_search_results'%>
 <% else %>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-s">
         <%= t('.total', count: @search.total) %>
       </h2>
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <div class="govuk-!-text-align-right">
+        <%=  button_to 'Download', download_application_searches_path, class: 'govuk-button govuk-button--secondary', params: { filter: @filter.to_h } %>
+      </div>
     </div>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,7 @@ en:
     reference: Ref. no.
     time_passed: Time passed
     received_at: Date received
+    reviewed_at: Date reviewed
     caseworker: Caseworker
     status: Status
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,9 @@ Rails.application.routes.draw do
     resource :reassign, only: [:new, :create]
   end
 
-  resource :application_searches, only: [:create, :new]
+  resource :application_searches, only: [:create, :new] do
+    post :download, on: :collection
+  end
 
   resources :assigned_applications, only: [:index, :destroy, :create] do
     post :next_application, on: :collection

--- a/spec/fixtures/files/application_search.csv
+++ b/spec/fixtures/files/application_search.csv
@@ -1,0 +1,3 @@
+Ref. no.,Date received,Date reviewed,Caseworker,Status
+120398120,2022-10-27T14:09:11+00:00,"",,Open
+1230234359,2022-11-14T16:58:15+00:00,"",,Open

--- a/spec/system/search_applications/download_search_results_spec.rb
+++ b/spec/system/search_applications/download_search_results_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'Download Search Page' do
+  include_context 'when search results are returned'
+
+  before do
+    click_button 'Search'
+    click_button 'Download'
+  end
+
+  it 'downloads a csv of the search results' do
+    csv = page.driver.response.body
+    expect(csv).to match(file_fixture('application_search.csv').read)
+  end
+end


### PR DESCRIPTION
Download search results as csv

Co-authored-by: "willmcb"<william.mcbrien@digital.justice.gov.uk>

## Description of change

Adds basic CSV download for application searches.

## Link to relevant ticket
[CRIMRE-50](https://dsdmoj.atlassian.net/browse/CRIMRE-50)

## Notes for reviewer
Very basic for demonstration purposes.

Unlike the design, we have used a button for the download action.  We felt that downloading should probably not be a link/GET request because were likely to want to:

- restrict downloading to specific roles,
- log downloading events, and
- generally discourage what could be quite a costly requests

## Screenshots of changes (if applicable)

### Before changes:
<img width="1178" alt="Screenshot 2023-01-04 at 15 35 44" src="https://user-images.githubusercontent.com/34935/210591428-e4c4f938-7959-4668-921e-07a1c2c79f90.png">

### After changes:
<img width="1089" alt="Screenshot 2023-01-04 at 15 34 55" src="https://user-images.githubusercontent.com/34935/210591295-3cf6813d-defd-4b49-b9ae-555972af74f0.png">

## How to manually test the feature


[CRIMRE-50]: https://dsdmoj.atlassian.net/browse/CRIMRE-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMRE-50]: https://dsdmoj.atlassian.net/browse/CRIMRE-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ