### PR TITLE
Add extension to download file name

### DIFF
--- a/app/models/application_search_csv.rb
+++ b/app/models/application_search_csv.rb
@@ -16,10 +16,7 @@ class ApplicationSearchCsv
   end
 
   def file_name
-    [
-      'application_search',
-      @filter.state_key
-    ].join('_')
+    "application_search-#{@filter.state_key}.csv"
   end
 
   private

--- a/spec/system/search_applications/download_search_results_spec.rb
+++ b/spec/system/search_applications/download_search_results_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Download Search Page' do
+RSpec.describe 'Downloading the Search Results' do
   include_context 'when search results are returned'
 
   before do
@@ -8,8 +8,9 @@ RSpec.describe 'Download Search Page' do
     click_button 'Download'
   end
 
-  it 'downloads a csv of the search results' do
+  it 'downloads the expected search results as a csv file' do
     csv = page.driver.response.body
     expect(csv).to match(file_fixture('application_search.csv').read)
+    expect(page.driver.response.content_type).to eq 'text/csv'
   end
 end


### PR DESCRIPTION
## Description of change

Adds ".csv" to the download filename.

## Link to relevant ticket
[CRIMRE-50](https://dsdmoj.atlassian.net/browse/CRIMRE-50)

## Notes for reviewer
Add the file extension to the filename, which also sets the response content-type etc.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-50]: https://dsdmoj.atlassian.net/browse/CRIMRE-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ