### PR TITLE
CRIMRE-106 filter by review status

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -6,10 +6,9 @@
 #
 DATABASE_URL=postgresql://postgres@localhost/laa-review-criminal-legal-aid
 
-CRIME_REVIEW_HOST=laa-review-criminal-legal-aid.test
-
+DEVELOPMENT_HOST=laa-review-criminal-legal-aid.test
 CRIME_APPLY_API_URL=https://laa-apply-for-criminal-legal-aid.test/api/
-#
+
 # speak to the team to get these 
 # OMNIAUTH_AZURE_CLIENT_ID:
 # OMNIAUTH_AZURE_TENANT_ID: 

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -12,13 +12,13 @@ module Types
   # Map of review application statuses to LaaCrimeSchemas::Types:APPLICATION_STATUSES
   #
   REVIEW_APPLICATION_STATUSES = {
-    'open' => APPLICATION_STATUSES & ['submitted'],
-    'completed' => APPLICATION_STATUSES & ['completed'],
-    'sent_back' => APPLICATION_STATUSES & ['returned'],
+    'open' => [ApplicationStatus['submitted']],
+    'completed' => [], # NOTE: completed status does no yet exist in datastore/schema
+    'sent_back' => [ApplicationStatus['returned']],
     'all' => APPLICATION_STATUSES
   }.freeze
 
-  ReviewApplicationStatus = String.default('open').enum(
+  ReviewApplicationStatus = String.default('open'.freeze).enum(
     *REVIEW_APPLICATION_STATUSES.keys
   )
 

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -1,64 +1,37 @@
-# TODO: share types via gem
+require 'laa_crime_schemas/types/types'
 
 module Types
-  include Dry.Types()
+  include LaaCrimeSchemas::Types
 
-  COURT_TYPES = %w[
-    crown
-    magistrates
-  ].freeze
-
-  OFFENCE_CLASSES = %w[
-    a b c d e f g h i j k
-  ].freeze
-
-  CASE_TYPES = %w[
-    summary_only
-    either_way
-    indictable
-    already_in_crown_court
-    commital
-    appeal_to_crown_court
-    appeal_to_crown_court_with_changes
-  ].freeze
-
-  CORRESPONDENCE_ADDRESS_TYPES = %w[
-    other_address
-    home_address
-    provider_address
-  ].freeze
-
-  INTERESTS_OF_JUSTICE_CRITERIA = %w[
-    loss_of_liberty
-    suspended_sentence
-    loss_of_livelihood
-    reputation
-    question_of_law
-    understanding
-    witness_tracing
-    expert_examination
-    interest_of_another
-    other
-  ].freeze
-
-  CorrespondenceAddressType = String.enum(*CORRESPONDENCE_ADDRESS_TYPES)
-  OffenceClass = String.enum(*OFFENCE_CLASSES)
-  CaseType = String.enum(*CASE_TYPES)
-  CourtType = String.enum(*COURT_TYPES)
-  InterestsOfJusticeCriterion = String.enum(*INTERESTS_OF_JUSTICE_CRITERIA)
-
-  CrimeApplicationReference = Types::String
   Uuid = String
   PhoneNumber = String
   Date = Date | JSON::Date
   DateTime = DateTime | JSON::DateTime
 
-  # Review only types
+  #
+  # Map of review application statuses to LaaCrimeSchemas::Types:APPLICATION_STATUSES
+  #
+  REVIEW_APPLICATION_STATUSES = {
+    'open' => APPLICATION_STATUSES & ['submitted'],
+    'completed' => APPLICATION_STATUSES & ['completed'],
+    'sent_back' => APPLICATION_STATUSES & ['returned'],
+    'all' => APPLICATION_STATUSES
+  }.freeze
+
+  ReviewApplicationStatus = String.default('open').enum(
+    *REVIEW_APPLICATION_STATUSES.keys
+  )
+
   USER_ROLES = %w[
     caseworker
     supervisor
   ].freeze
-
   UserRole = String.enum(*USER_ROLES)
   UserRoles = Array.of(UserRole)
+
+  ASSIGNED_STATUSES = %w[
+    unassigned
+    assigned
+  ].freeze
+  AssignedStatus = String.enum(*ASSIGNED_STATUSES)
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -36,6 +36,7 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
     Time.zone.now - submitted_at
   end
 
+  # TODO: Convert to working days
   def applicant
     client_details.applicant
   end

--- a/app/views/application/_application_search_filter.html.erb
+++ b/app/views/application/_application_search_filter.html.erb
@@ -19,6 +19,11 @@
 
     <label class="govuk-label govuk-label--s"><%= t('labels.search_criteria')%></label>
     <div class="input-group">
+      <%= f.govuk_select(
+            :application_status,
+            application_search_filter.application_status_options,
+            label: { text: t('labels.application_status') }
+          ) %>
       <%= f.search_date_field(
             :submitted_after,
             as: :date,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -7,6 +7,7 @@ Rails.application.configure do
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
+  config.hosts << 'laa-review-criminal-legal-aid.test'
 
   # Do not eager load code on boot.
   config.eager_load = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -7,7 +7,6 @@ Rails.application.configure do
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
-  config.hosts << 'laa-review-criminal-legal-aid.test'
 
   # Do not eager load code on boot.
   config.eager_load = false
@@ -69,9 +68,6 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
   
-  # Allow a host to be set in development
-  if ENV.fetch("CRIME_REVIEW_HOST", false)
-    config.hosts << ENV['CRIME_REVIEW_HOST']
-  end
-  #
+  # Add the development host if set
+  config.hosts += [ENV["DEVELOPMENT_HOST"]]
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,7 @@ en:
     assigned_to: 'Assigned to:'
     date_received: 'Date received:'
     application_information: Application information
+    all_applications: All applications 
     search_criteria: Search criteria
     applicant_date_of_birth: Applicant's date of birth
     caseworker: Caseworker
@@ -68,9 +69,7 @@ en:
     when: When
     who: Who
     what: What
-    assigned_status:
-      assigned: All assigned
-      unassigned: Unassigned
+    application_status: Status
 
   table_headings: &TABLE_HEADINGS
     applicant_name: Applicant
@@ -113,6 +112,14 @@ en:
     days_passed:
       one: 1 day
       other: "%{count} days"
+    application_status: 
+      open: Open
+      sent_back: Sent back to provider
+      completed: Completed 
+      all: All applications 
+    assigned_status:
+      assigned: All assigned
+      unassigned: Unassigned
 
   calls_to_action:
     abandon_reassign_to_self: No, do not reassign

--- a/spec/models/application_search_filter_spec.rb
+++ b/spec/models/application_search_filter_spec.rb
@@ -54,12 +54,11 @@ RSpec.describe ApplicationSearchFilter do
 
     context 'when the filter is empty' do
       it 'returns the correct datastore api search params as json' do
-        expect(to_json).to eq(
-          {
-            applicant_date_of_birth: nil, application_id_in: [], application_id_not_in: [],
+        expect(to_json).to eq({
+          applicant_date_of_birth: nil, application_id_in: [],
+            application_id_not_in: [], status: ['submitted'],
             submitted_after: nil, submitted_before: nil, search_text: nil
-          }.to_json
-        )
+        }.to_json)
       end
     end
 
@@ -67,16 +66,17 @@ RSpec.describe ApplicationSearchFilter do
       let(:params) do
         {
           applicant_date_of_birth: '1970-10-10', assigned_status: david.id,
-          search_text: 'David 100003', submitted_after: '2022-12-22', submitted_before: '2022-12-21'
+          search_text: 'David 100003', application_status: 'sent_back',
+          submitted_after: '2022-12-22', submitted_before: '2022-12-21'
         }
       end
 
       it 'returns the correct datastore api search params as json' do
-        expect(to_json).to eq(
-          { applicant_date_of_birth: '1970-10-10', application_id_in: david.current_assignments.pluck(:assignment_id),
-           application_id_not_in: [], submitted_after: '2022-12-22', submitted_before: '2022-12-21',
-           search_text: 'David 100003' }.to_json
-        )
+        expect(to_json).to eq({ applicant_date_of_birth: '1970-10-10',
+            application_id_in: david.current_assignments.pluck(:assignment_id),
+            application_id_not_in: [], status: ['returned'],
+            submitted_after: '2022-12-22', submitted_before: '2022-12-21',
+            search_text: 'David 100003' }.to_json)
       end
     end
   end

--- a/spec/system/search_applications/filter_by_status_spec.rb
+++ b/spec/system/search_applications/filter_by_status_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe 'Search applications status filter' do
+  include_context 'when search results are returned'
+  let(:choice) { nil }
+  let(:filter_field) { 'filter-application-status-field' }
+
+  before do
+    visit '/'
+    click_on 'Search'
+  end
+
+  it 'filters by "Open" by default' do
+    expect(page).to have_select(filter_field, selected: 'Open')
+  end
+
+  it "can choose from 'Open', 'Completed', 'Sent back to provider' or 'All applications'" do
+    choices = ['Open', 'Completed', 'Sent back to provider', 'All applications']
+    expect(page).to have_select(filter_field, options: choices)
+  end
+
+  describe 'search by:' do
+    describe 'default' do
+      it 'filters by status "open"' do
+        click_button 'Search'
+        assert_api_searched_with_filter(:application_status, 'open')
+        expect(page).to have_select(filter_field, selected: 'Open')
+      end
+    end
+
+    describe 'Completed' do
+      before do
+        select 'Completed', from: filter_field
+        click_button 'Search'
+      end
+
+      it 'filters by status "completed"' do
+        assert_api_searched_with_filter(:application_status, 'completed')
+        expect(page).to have_select(filter_field, selected: 'Completed')
+      end
+    end
+
+    describe 'Sent back to provider' do
+      before do
+        select 'Sent back to provider', from: filter_field
+        click_button 'Search'
+      end
+
+      it 'filters by status "completed"' do
+        assert_api_searched_with_filter(:application_status, 'sent_back')
+        expect(page).to have_select(filter_field, selected: 'Sent back to provider')
+      end
+    end
+
+    describe 'All applications' do
+      before do
+        select 'All applications', from: filter_field
+        click_button 'Search'
+      end
+
+      it 'filters by all statuses"' do
+        assert_api_searched_with_filter(:application_status, 'all')
+        expect(page).to have_select(filter_field, selected: 'All applications')
+      end
+    end
+  end
+end

--- a/spec/system/search_applications/filter_by_status_spec.rb
+++ b/spec/system/search_applications/filter_by_status_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'Search applications status filter' do
   include_context 'when search results are returned'
-  let(:choice) { nil }
   let(:filter_field) { 'filter-application-status-field' }
 
   before do


### PR DESCRIPTION
Co-authored-by: Arthur Ashman <arthur.ashman@digital.justice.gov.uk>

## Description of change
Adds filter by review status to search.

## Link to relevant ticket
[CRIMRE-106](https://dsdmoj.atlassian.net/browse/CRIMRE-106)

## Notes for reviewer

Review statuses are different to apply and datastore. The mapping of review status to datastore status take place in the Types.
Also uses types from LaaCrimeSchemas (these were previously duplicated).

[Datastore PR](https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/16)

## Screenshots of changes (if applicable)

### Before changes:
<img width="1132" alt="Screenshot 2023-01-06 at 12 08 59" src="https://user-images.githubusercontent.com/34935/211010124-73ce85df-79ae-4f1e-922a-4c060ffd2cc4.png">

### After changes:
<img width="1095" alt="Screenshot 2023-01-06 at 12 08 44" src="https://user-images.githubusercontent.com/34935/211010152-b620bf86-c843-4373-a21d-2e564e2073d0.png">
<img width="294" alt="Screenshot 2023-01-06 at 12 08 38" src="https://user-images.githubusercontent.com/34935/211010167-28cc2c4e-ce4d-465b-873e-199594ae3f1b.png">

## How to manually test the feature


[CRIMRE-106]: https://dsdmoj.atlassian.net/browse/CRIMRE-106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ