### PR TITLE
Add reviewing aggregate, commands and events

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,3 +69,7 @@ Rails/SkipsModelValidations:
   Exclude:
     - '**/app/read_models/**/*'
     - '**/lib/warden/**/*'
+
+# Prefer block over method call.
+RSpec/ExpectChange:
+  EnforcedStyle: block

--- a/app/aggregates/reviewing.rb
+++ b/app/aggregates/reviewing.rb
@@ -1,0 +1,10 @@
+module Reviewing
+  %w[event command].each do |sub_dir|
+    require File.expand_path("reviewing/#{sub_dir}.rb", __dir__)
+
+    Dir[File.expand_path("reviewing/#{sub_dir}s/*.rb", __dir__)].each { |f| require f }
+  end
+
+  require_relative 'reviewing/errors'
+  require_relative 'reviewing/review'
+end

--- a/app/aggregates/reviewing/command.rb
+++ b/app/aggregates/reviewing/command.rb
@@ -1,0 +1,23 @@
+module Reviewing
+  class Command < Dry::Struct
+    attribute :application_id, Types::Uuid
+
+    def with_review(&block)
+      repository.with_aggregate(
+        Review.new(application_id), stream_name, &block
+      )
+    end
+
+    private
+
+    def repository
+      @repository ||= AggregateRoot::Repository.new(
+        Rails.configuration.event_store
+      )
+    end
+
+    def stream_name
+      "Reviewing$#{application_id}"
+    end
+  end
+end

--- a/app/aggregates/reviewing/commands/complete.rb
+++ b/app/aggregates/reviewing/commands/complete.rb
@@ -1,0 +1,12 @@
+module Reviewing
+  class Complete < Command
+    attribute :application_id, Types::Uuid
+    attribute :user_id, Types::Uuid
+
+    def call
+      with_review do |review|
+        review.complete(application_id:, user_id:)
+      end
+    end
+  end
+end

--- a/app/aggregates/reviewing/commands/receive_application.rb
+++ b/app/aggregates/reviewing/commands/receive_application.rb
@@ -1,0 +1,11 @@
+module Reviewing
+  class ReceiveApplication < Command
+    attribute :application_id, Types::Uuid
+
+    def call
+      with_review do |review|
+        review.receive_application(application_id:)
+      end
+    end
+  end
+end

--- a/app/aggregates/reviewing/commands/send_back.rb
+++ b/app/aggregates/reviewing/commands/send_back.rb
@@ -1,0 +1,13 @@
+module Reviewing
+  class SendBack < Command
+    attribute :application_id, Types::Uuid
+    attribute :user_id, Types::Uuid
+    attribute :reason, Types::ReturnReason
+
+    def call
+      with_review do |review|
+        review.send_back(application_id:, reason:, user_id:)
+      end
+    end
+  end
+end

--- a/app/aggregates/reviewing/errors.rb
+++ b/app/aggregates/reviewing/errors.rb
@@ -1,0 +1,16 @@
+module Reviewing
+  class AlreadyReceived < StandardError
+  end
+
+  class AlreadySentBack < StandardError
+  end
+
+  class AlreadyCompleted < StandardError
+  end
+
+  class CannotCompleteWhenSentBack < StandardError
+  end
+
+  class CannotSendBackWhenCompleted < StandardError
+  end
+end

--- a/app/aggregates/reviewing/event.rb
+++ b/app/aggregates/reviewing/event.rb
@@ -1,0 +1,4 @@
+module Reviewing
+  class Event < RailsEventStore::Event
+  end
+end

--- a/app/aggregates/reviewing/events/application_recieved.rb
+++ b/app/aggregates/reviewing/events/application_recieved.rb
@@ -1,0 +1,4 @@
+module Reviewing
+  class ApplicationReceived < Event
+  end
+end

--- a/app/aggregates/reviewing/events/completed.rb
+++ b/app/aggregates/reviewing/events/completed.rb
@@ -1,0 +1,4 @@
+module Reviewing
+  class Completed < Event
+  end
+end

--- a/app/aggregates/reviewing/events/sent_back.rb
+++ b/app/aggregates/reviewing/events/sent_back.rb
@@ -1,0 +1,4 @@
+module Reviewing
+  class SentBack < Event
+  end
+end

--- a/app/aggregates/reviewing/review.rb
+++ b/app/aggregates/reviewing/review.rb
@@ -1,0 +1,55 @@
+module Reviewing
+  class Review
+    include AggregateRoot
+
+    def initialize(id)
+      @id = id
+      @state = nil
+      @return_reason = nil
+    end
+
+    attr_reader :id, :state, :return_reason
+
+    alias application_id id
+
+    def receive_application(application_id:)
+      raise AlreadyReceived unless @state.nil?
+
+      apply ApplicationReceived.new(
+        data: { application_id: }
+      )
+    end
+
+    def send_back(application_id:, user_id:, reason:)
+      raise AlreadySentBack if @state.equal?(:sent_back)
+      raise CannotSendBackWhenCompleted if @state.equal?(:completed)
+
+      apply SentBack.new(
+        data: { application_id:, user_id:, reason: }
+      )
+    end
+
+    def complete(application_id:, user_id:)
+      raise AlreadyCompleted if @state.equal?(:completed)
+      raise CannotCompleteWhenSentBack if @state.equal?(:sent_back)
+
+      apply Completed.new(
+        data: { application_id:, user_id: }
+      )
+    end
+
+    on ApplicationReceived do |_event|
+      @state = :received
+    end
+
+    on SentBack do |event|
+      @state = :sent_back
+      @return_reason = Types::ReturnReason[event.data.fetch(:reason)]
+    end
+
+    on Completed do |_event|
+      @assignee_id = nil
+      @state = :completed
+    end
+  end
+end

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -12,9 +12,9 @@ module Types
   # Map of review application statuses to LaaCrimeSchemas::Types:APPLICATION_STATUSES
   #
   REVIEW_APPLICATION_STATUSES = {
-    'open' => [ApplicationStatus['submitted']],
+    'open' => [Types::ApplicationStatus['submitted']],
     'completed' => [], # NOTE: completed status does no yet exist in datastore/schema
-    'sent_back' => [ApplicationStatus['returned']],
+    'sent_back' => [Types::ApplicationStatus['returned']],
     'all' => APPLICATION_STATUSES
   }.freeze
 
@@ -34,4 +34,20 @@ module Types
     assigned
   ].freeze
   AssignedStatus = String.enum(*ASSIGNED_STATUSES)
+
+  RETURN_REASONS = %w[
+    clarification_required
+    evidence_issue
+    duplicate_application
+    case_concluded
+    provider_request
+  ].freeze
+
+  #
+  # Is this rendered on apply? Should we add it to types?
+  #
+  ReturnReason = Hash.schema(
+    details?: Nil | String,
+    selected_reason: String.enum(*RETURN_REASONS)
+  )
 end

--- a/config/initializers/aggregates.rb
+++ b/config/initializers/aggregates.rb
@@ -1,2 +1,3 @@
 require_relative '../../app/lib/types'
 require_relative '../../app/aggregates/assigning.rb'
+require_relative '../../app/aggregates/reviewing.rb'

--- a/spec/aggregates/reviewing/complete_spec.rb
+++ b/spec/aggregates/reviewing/complete_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Reviewing::Complete do
+  subject(:command) do
+    described_class.new(application_id:, user_id:)
+  end
+
+  include_context 'with review'
+
+  before do
+    Reviewing::ReceiveApplication.new(application_id:).call
+  end
+
+  let(:user_id) { SecureRandom.uuid }
+
+  it 'changes the state from :received to :completed' do
+    expect { command.call }.to change { review.state }
+      .from(:received).to(:completed)
+  end
+end

--- a/spec/aggregates/reviewing/receive_application_spec.rb
+++ b/spec/aggregates/reviewing/receive_application_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Reviewing::ReceiveApplication do
+  subject(:command) do
+    described_class.new(application_id:)
+  end
+
+  include_context 'with review'
+
+  it 'changes the state from :nil to :received' do
+    expect { command.call }.to change { review.state }
+      .from(nil).to(:received)
+  end
+end

--- a/spec/aggregates/reviewing/review_spec.rb
+++ b/spec/aggregates/reviewing/review_spec.rb
@@ -1,0 +1,96 @@
+require 'aggregates_helper'
+require_relative '../../../app/aggregates/reviewing'
+
+describe Reviewing::Review do
+  subject(:review) { described_class.new(SecureRandom.uuid) }
+
+  let(:reason) { { selected_reason: 'case_concluded' } }
+
+  let(:application_id) { SecureRandom.uuid }
+
+  describe '#recieve_application' do
+    before do
+      review.receive_application(application_id:)
+    end
+
+    it 'is becomes "received"' do
+      expect(review.state).to eq :received
+    end
+
+    it 'creates an event' do
+      expect(review.unpublished_events.map(&:event_type)).to match [
+        'Reviewing::ApplicationReceived'
+      ]
+    end
+
+    context 'when has already been received' do
+      it 'raises AlreadyReceived' do
+        expect { review.receive_application(application_id:) }.to raise_error(
+          Reviewing::AlreadyReceived
+        )
+      end
+    end
+  end
+
+  describe 'sending back a received application' do
+    let(:user_id) { SecureRandom.uuid }
+
+    before do
+      review.receive_application(application_id:)
+      review.send_back(application_id:, user_id:, reason:)
+    end
+
+    it 'is becomes "sent_back"' do
+      expect(review.state).to eq :sent_back
+    end
+
+    it 'creates an event' do
+      expect(review.unpublished_events.map(&:event_type)).to match [
+        'Reviewing::ApplicationReceived', 'Reviewing::SentBack'
+      ]
+    end
+
+    it 'can only happen once' do
+      expect do
+        review.send_back(application_id:, user_id:, reason:)
+      end.to raise_error Reviewing::AlreadySentBack
+    end
+
+    it 'cannot then be completed' do
+      expect do
+        review.complete(application_id:, user_id:)
+      end.to raise_error Reviewing::CannotCompleteWhenSentBack
+    end
+  end
+
+  describe 'completing a received application' do
+    let(:user_id) { SecureRandom.uuid }
+
+    before do
+      review.receive_application(application_id:)
+      review.complete(application_id:, user_id:)
+    end
+
+    it 'is becomes "completed"' do
+      expect(review.state).to eq :completed
+    end
+
+    it 'creates an event' do
+      expect(review.unpublished_events.map(&:event_type)).to match [
+        'Reviewing::ApplicationReceived', 'Reviewing::Completed'
+      ]
+    end
+
+    it 'can only happen once' do
+      expect { review.complete(application_id:, user_id:) }.to raise_error(
+        Reviewing::AlreadyCompleted
+      )
+    end
+
+    it 'cannot then be sent back' do
+      expect do
+        review.send_back(application_id:, user_id:, reason:)
+      end.to raise_error Reviewing::CannotSendBackWhenCompleted
+    end
+  end
+end

--- a/spec/aggregates/reviewing/send_back_spec.rb
+++ b/spec/aggregates/reviewing/send_back_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Reviewing::SendBack do
+  subject(:command) do
+    described_class.new(application_id:, user_id:, reason:)
+  end
+
+  include_context 'with review'
+
+  let(:user_id) { SecureRandom.uuid }
+  let(:reason) { { selected_reason: 'evidence_issue' } }
+
+  before do
+    Reviewing::ReceiveApplication.new(application_id:).call
+  end
+
+  context 'with a valid reason' do
+    it 'changes the state from :received to :sent_back' do
+      expect { command.call }.to change { review.state }
+        .from(:received).to(:sent_back)
+    end
+
+    it 'records the return reason' do
+      expect { command.call }.to change { review.return_reason }
+        .from(nil).to(reason)
+    end
+  end
+
+  context 'with an invalid reason' do
+    let(:reason) { { selected_reason: 'not_a_reason' } }
+
+    it 'raises an invalid reason error' do
+      expect { command.call }.to raise_error(/has invalid type for :reason/)
+      expect(review.state).to eq(:received)
+    end
+  end
+end

--- a/spec/shared_contexts/with_review.rb
+++ b/spec/shared_contexts/with_review.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.shared_context 'with review', shared_context: :metadata do
+  let(:application_id) { SecureRandom.uuid }
+
+  def review
+    repository.load(
+      Reviewing::Review.new(application_id),
+      "Reviewing$#{application_id}"
+    )
+  end
+
+  def repository
+    @repository ||= AggregateRoot::Repository.new(
+      Rails.configuration.event_store
+    )
+  end
+end

--- a/spec/system/reassign_an_application_confirmation_spec.rb
+++ b/spec/system/reassign_an_application_confirmation_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Reassigning an application confirmation errors' do
     it 'redirects to the application details page' do
       reassign_to_another
 
-      expect { click_on('Yes, reassign') }.to change(page, :current_path)
+      expect { click_on('Yes, reassign') }.to change { page.current_path }
         .from(confirm_path).to(
           crime_application_path(crime_application_id)
         )

--- a/spec/system/reassign_an_application_to_myself_spec.rb
+++ b/spec/system/reassign_an_application_to_myself_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Reassigning an application to myself' do
 
     describe 'clicking on "Yes, reassign"' do
       it 'redirects to the application details' do
-        expect { click_on('Yes, reassign') }.to change(page, :current_path)
+        expect { click_on('Yes, reassign') }.to change { page.current_path }
           .from(confirm_path)
           .to(crime_application_path(crime_application_id))
       end
@@ -74,7 +74,7 @@ RSpec.describe 'Reassigning an application to myself' do
 
     describe 'clicking on "No, do not reassign"' do
       it 'redirects to application details' do
-        expect { click_on('No, do not reassign') }.to change(page, :current_path)
+        expect { click_on('No, do not reassign') }.to change { page.current_path }
           .from(confirm_path).to(
             crime_application_path(crime_application_id)
           )

--- a/spec/system/sub_nav_spec.rb
+++ b/spec/system/sub_nav_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Sub navigation' do
 
   context 'when the "Application history" link' do
     it 'links to the application history page' do
-      expect { click_on('Application history') }.to change(page, :current_path).from(
+      expect { click_on('Application history') }.to change { page.current_path }.from(
         '/applications/696dd4fd-b619-4637-ab42-a5f4565bcf4a'
       ).to(
         '/applications/696dd4fd-b619-4637-ab42-a5f4565bcf4a/history'


### PR DESCRIPTION
## Description of change

Adds Review aggregates and reviewing commands and events.

adds the Reviewing::Review aggregate root (event sourced).

adds the following commands:
Reviewing::ReceiveApplication
Reviewing::SendBack
Reviewing::Complete

adds the following events:
Reviewing::ApplicationReceived
Reviewing::SentBack
Reviewing::Completed

adds a new type, Types::ReturnReason


## Link to relevant ticket

[CRIMRE-84](https://dsdmoj.atlassian.net/browse/CRIMRE-84)

## Notes for reviewer

In order to build the time passed reports (and many other things), Review needs a temporal understanding of changes in an applications review status.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-84]: https://dsdmoj.atlassian.net/browse/CRIMRE-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ