### PR TITLE
Mail 2.8.0 has issues. Revert update.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,11 +195,8 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)

--- a/app/aggregates/reviewing.rb
+++ b/app/aggregates/reviewing.rb
@@ -1,4 +1,5 @@
 module Reviewing
+  # TODO: review depature from rails/zeitwork for aggregates.
   %w[event command].each do |sub_dir|
     require File.expand_path("reviewing/#{sub_dir}.rb", __dir__)
 


### PR DESCRIPTION
## Description of change

Revert update to mail gem to a version that work on CP.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
