### PR TITLE
CRIMRE-124 Handle anonymous caseworkers

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,20 +6,19 @@ class User < ApplicationRecord
   end
 
   class << self
-
-    # 
+    #
     # For GDPR caseworker personal data is not stored in the event stream.
     # Rendering an application's history can require many user names to be
     # found. This method caches those lookups.
     #
-    # It returns "Anonymous" for a forgotten/not found user
+    # It returns "[deleted]" for a forgotten/not found user
     #
     def name_for(id)
-       Rails.cache.fetch("user_names#{id}", expires_in: 10.minutes) do
+      Rails.cache.fetch("user_names#{id}", expires_in: 10.minutes) do
         User.find(id).name
       rescue ActiveRecord::RecordNotFound
-        "Anonymous"
+        I18n.t('values.deleted_user_name')
       end
-     end
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,3 @@
-# TODO: move
-
 class User < ApplicationRecord
   has_many :current_assignments, dependent: :destroy
 
@@ -8,13 +6,20 @@ class User < ApplicationRecord
   end
 
   class << self
+
+    # 
     # For GDPR caseworker personal data is not stored in the event stream.
-    # Rendering an applications history can require many user names to be
+    # Rendering an application's history can require many user names to be
     # found. This method caches those lookups.
+    #
+    # It returns "Anonymous" for a forgotten/not found user
+    #
     def name_for(id)
-      Rails.cache.fetch("user_names#{id}", expires_in: 10.minutes) do
+       Rails.cache.fetch("user_names#{id}", expires_in: 10.minutes) do
         User.find(id).name
+      rescue ActiveRecord::RecordNotFound
+        "Anonymous"
       end
-    end
+     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,7 @@ en:
     home_address: Same as home address
     provider_address: Same as provider address
     summary_only: Summary only
+    deleted_user_name: '[deleted]'
     either_way: Either way
     indictable: Indictable
     already_in_crown_court: Already in Crown Court

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe User do
+  describe '.name_for(:id)' do
+    subject(:name_for) { described_class.name_for(user_id) }
+    let(:user_id) { SecureRandom.uuid }
+
+    context 'when user not found' do
+      it { is_expected.to eq 'Anonymous' } 
+    end
+    
+    context 'when user is found' do
+      before  do
+        User.create!(
+          id: user_id,
+          auth_oid: SecureRandom.uuid,
+          first_name: 'John',
+          last_name: 'Deere'
+        )
+      end
+
+      it { is_expected.to eq 'John Deere' } 
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,15 +3,16 @@ require 'rails_helper'
 RSpec.describe User do
   describe '.name_for(:id)' do
     subject(:name_for) { described_class.name_for(user_id) }
+
     let(:user_id) { SecureRandom.uuid }
 
     context 'when user not found' do
-      it { is_expected.to eq 'Anonymous' } 
+      it { is_expected.to eq '[deleted]' }
     end
-    
+
     context 'when user is found' do
-      before  do
-        User.create!(
+      before do
+        described_class.create!(
           id: user_id,
           auth_oid: SecureRandom.uuid,
           first_name: 'John',
@@ -19,7 +20,7 @@ RSpec.describe User do
         )
       end
 
-      it { is_expected.to eq 'John Deere' } 
+      it { is_expected.to eq 'John Deere' }
     end
   end
 end


### PR DESCRIPTION
## Description of change

Return "Anonymous" for names when showing application history for users that have been forgotten.

## Link to relevant ticket

[CRIMRE-124](https://dsdmoj.atlassian.net/browse/CRIMRE-124)

## Notes for reviewer

Arguably part of later GDPR forgetting features. However this was causing an issue on staging where we had applications assigned to deleted users.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="774" alt="Screenshot 2023-01-11 at 11 40 35" src="https://user-images.githubusercontent.com/34935/211798438-ce0de4ee-4ec4-428d-9e6b-2277878a71c7.png">

## How to manually test the feature


[CRIMRE-124]: https://dsdmoj.atlassian.net/browse/CRIMRE-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ