### PR TITLE
Crimre 127 handle applications deleted from datastore

### DIFF
--- a/app/controllers/assigned_applications_controller.rb
+++ b/app/controllers/assigned_applications_controller.rb
@@ -1,10 +1,9 @@
 class AssignedApplicationsController < ApplicationController
   def index
-    current_assignments = CurrentAssignment.where(
-      user_id: current_user_id
-    )
+    filter = ApplicationSearchFilter.new(assigned_status: current_user_id)
+    search = ApplicationSearch.new(filter:)
 
-    @applications = current_assignments.pluck(:assignment_id).map { |id| CrimeApplication.find(id) }
+    @applications = search.results
   end
 
   def create

--- a/app/models/application_search_result.rb
+++ b/app/models/application_search_result.rb
@@ -30,4 +30,8 @@ class ApplicationSearchResult < ApplicationStruct
       I18n.t(status, scope: 'values.status')
     ]
   end
+
+  def to_param
+    id
+  end
 end

--- a/spec/init/api_data.rb
+++ b/spec/init/api_data.rb
@@ -33,5 +33,15 @@ RSpec.configure do |config|
         status: 200
       )
     end
+
+    #
+    # All DatastoreApi search requests are stubbed to return empty result sets by default.
+    # To return anything other than that include the shared_context "with stubbed search".
+    #
+    stub_request(:post, "#{ENV.fetch('DATASTORE_API_ROOT')}/api/v2/searches")
+      .to_return(
+        body: { pagination: {}, records: [] }.to_json,
+        status: 201
+      )
   end
 end

--- a/spec/shared_contexts/when_search_results_are_returned.rb
+++ b/spec/shared_contexts/when_search_results_are_returned.rb
@@ -1,44 +1,5 @@
 RSpec.shared_context 'when search results are returned', shared_context: :metadata do
-  let(:datastore_search) do
-    DatastoreApi::Requests::SearchApplications
-  end
-
-  let(:search_response) do
-    pagination = { total_pages: 1, current_page: 1, total_count: 2 }.stringify_keys
-
-    results = [
-      ApplicationSearchResult.new(
-        applicant_name: 'Kit Pound',
-        resource_id: '696dd4fd-b619-4637-ab42-a5f4565bcf4a',
-        reference: 120_398_120,
-        status: 'submitted',
-        submitted_at: '2022-10-27T14:09:11.000+00:00'
-      ),
-      ApplicationSearchResult.new(
-        applicant_name: 'Don Jones',
-        resource_id: '1aa4c689-6fb5-47ff-9567-5eee7f8ac2cc',
-        reference: 1_230_234_359,
-        status: 'submitted',
-        submitted_at: '2022-11-14T16:58:15.000+00:00'
-      )
-    ]
-
-    DatastoreApi::Decorators::PaginatedCollection.new(
-      results, pagination
-    )
-  end
-
-  before do
-    allow(datastore_search).to receive(:new) {
-      instance_double(
-        datastore_search,
-        call: search_response
-      )
-    }
-
-    visit '/'
-    click_on 'Search'
-  end
+  include_context 'with stubbed search'
 
   def assert_api_searched_with_filter(*params)
     expect(datastore_search).to have_received(:new).with(

--- a/spec/shared_contexts/when_search_results_empty.rb
+++ b/spec/shared_contexts/when_search_results_empty.rb
@@ -1,15 +1,5 @@
 RSpec.shared_context 'when search results empty', shared_context: :metadata do
-  let(:datastore_search) do
-    DatastoreApi::Requests::SearchApplications
-  end
+  include_context 'with stubbed search'
 
-  before do
-    allow(datastore_search).to receive(:new) {
-      instance_double(datastore_search, call: [])
-    }
-
-    visit '/'
-    click_on 'Search'
-    click_button 'Search'
-  end
+  let(:stubbed_search_results) { [] }
 end

--- a/spec/shared_contexts/with_stubbed_search.rb
+++ b/spec/shared_contexts/with_stubbed_search.rb
@@ -1,0 +1,53 @@
+RSpec.shared_context 'with stubbed search', shared_context: :metadata do
+  let(:datastore_search) do
+    DatastoreApi::Requests::SearchApplications
+  end
+
+  let(:stubbed_search_results) do
+    [
+      ApplicationSearchResult.new(
+        applicant_name: 'Kit Pound',
+        resource_id: '696dd4fd-b619-4637-ab42-a5f4565bcf4a',
+        reference: 120_398_120,
+        status: 'submitted',
+        submitted_at: '2022-10-27T14:09:11.000+00:00'
+      ),
+      ApplicationSearchResult.new(
+        applicant_name: 'Don Jones',
+        resource_id: '1aa4c689-6fb5-47ff-9567-5eee7f8ac2cc',
+        reference: 1_230_234_359,
+        status: 'submitted',
+        submitted_at: '2022-11-14T16:58:15.000+00:00'
+      )
+    ]
+  end
+
+  let(:search_response) do
+    pagination = {
+      total_pages: 1, current_page: 1, total_count: stubbed_search_results.size
+    }.stringify_keys
+
+    DatastoreApi::Decorators::PaginatedCollection.new(
+      stubbed_search_results, pagination
+    )
+  end
+
+  before do
+    allow(datastore_search).to receive(:new) {
+      instance_double(
+        datastore_search,
+        call: search_response
+      )
+    }
+  end
+
+  def assert_api_searched_with_filter(*params)
+    expect(datastore_search).to have_received(:new).with(
+      ApplicationSearchFilter.new(**Hash[*params]).as_json
+    ) {
+      instance_double(
+        DatastoreApi::Requests::SearchApplications, call: []
+      )
+    }
+  end
+end

--- a/spec/system/search_applications/download_search_results_spec.rb
+++ b/spec/system/search_applications/download_search_results_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe 'Downloading the Search Results' do
   include_context 'when search results are returned'
 
   before do
+    visit '/'
+    click_link 'Search'
     click_button 'Search'
     click_button 'Download'
   end

--- a/spec/system/search_applications/filter_by_caseworker_spec.rb
+++ b/spec/system/search_applications/filter_by_caseworker_spec.rb
@@ -3,6 +3,17 @@ require 'rails_helper'
 RSpec.describe 'Search applications casewoker filter' do
   include_context 'when search results are returned'
 
+  before do
+    visit '/'
+
+    user_id = User.last.id
+    Assigning::AssignToUser.new(
+      assignment_id: SecureRandom.uuid, user_id: user_id, to_whom_id: user_id
+    ).call
+
+    click_link 'Search'
+  end
+
   context 'when unassigned status is selected' do
     before do
       select 'Unassigned', from: 'filter-assigned-status-field'
@@ -42,11 +53,6 @@ RSpec.describe 'Search applications casewoker filter' do
   end
 
   describe 'options for selecting assigned status' do
-    before do
-      visit '/'
-      click_on 'Search'
-    end
-
     it 'can choose from "", "Unassigned", "All assigned", and caseworkers' do
       choices = ['', 'Unassigned', 'All assigned', 'Joe EXAMPLE']
       expect(page).to have_select('filter-assigned-status-field', options: choices)

--- a/spec/system/search_applications/filter_by_date_range_spec.rb
+++ b/spec/system/search_applications/filter_by_date_range_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe 'Search by submitted date' do
   let(:before_date) { Date.parse('2011-06-09') }
 
   before do
+    visit '/'
+    click_link 'Search'
+
     fill_in 'filter-submitted-after-field', with: after_date
     fill_in 'filter-submitted-before-field', with: before_date
 

--- a/spec/system/search_applications/filter_by_status_spec.rb
+++ b/spec/system/search_applications/filter_by_status_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Search applications status filter' do
 
   before do
     visit '/'
-    click_on 'Search'
+    click_link 'Search'
   end
 
   it 'filters by "Open" by default' do
@@ -21,7 +21,6 @@ RSpec.describe 'Search applications status filter' do
   describe 'search by:' do
     describe 'default' do
       it 'filters by status "open"' do
-        click_button 'Search'
         assert_api_searched_with_filter(:application_status, 'open')
         expect(page).to have_select(filter_field, selected: 'Open')
       end

--- a/spec/system/search_applications/no_search_results_spec.rb
+++ b/spec/system/search_applications/no_search_results_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe 'No search results' do
   include_context 'when search results empty'
 
+  before do
+    visit '/'
+    click_link 'Search'
+    click_button 'Search'
+  end
+
   describe 'form help text' do
     it 'states that all fields are optional' do
       expect(page).to have_content('All fields are optional')

--- a/spec/system/search_applications/search_filters_and_results_spec.rb
+++ b/spec/system/search_applications/search_filters_and_results_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Search Page' do
   include_context 'when search results are returned'
   before do
+    visit '/'
+    click_link 'Search'
     click_button 'Search'
   end
 

--- a/spec/system/unassign_an_application_from_myself_spec.rb
+++ b/spec/system/unassign_an_application_from_myself_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Unassign an application from myself' do
+  include_context 'with stubbed search'
+
+  let(:stubbed_search_results) { [] }
+
   before do
     visit '/'
     click_on 'All open applications'
@@ -10,9 +14,8 @@ RSpec.describe 'Unassign an application from myself' do
   end
 
   it 'the assigned application is unassigned' do
-    expect(page).to have_content(
-      '0 saved applications'
-    )
+    expect(page).to have_content('Your list (0)')
+    expect(page).to have_content('0 saved applications')
   end
 
   it 'a success notice is shown' do

--- a/spec/system/viewing_your_assigned_applications_spec.rb
+++ b/spec/system/viewing_your_assigned_applications_spec.rb
@@ -1,21 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe 'Viewing your assigned application' do
+  include_context 'with stubbed search'
+
   before do
     visit '/'
   end
 
-  context 'when using the all applications link' do
-    before do
-      click_on('View all open applications')
-    end
-
-    it 'proceeds to the correct page' do
-      expect(page).to have_content 'All open applications'
-    end
-  end
-
   context 'when there are no assigned applications' do
+    let(:stubbed_search_results) { [] }
+
     it 'includes the page title' do
       expect(page).to have_content I18n.t('assigned_applications.index.page_title')
     end
@@ -26,6 +20,18 @@ RSpec.describe 'Viewing your assigned application' do
   end
 
   context 'when one application is assigned' do
+    let(:stubbed_search_results) do
+      [
+        ApplicationSearchResult.new(
+          applicant_name: 'Kit Pound',
+          resource_id: '696dd4fd-b619-4637-ab42-a5f4565bcf4a',
+          reference: 120_398_120,
+          status: 'submitted',
+          submitted_at: '2022-10-27T14:09:11.000+00:00'
+        )
+      ]
+    end
+
     before do
       click_on 'All open applications'
       click_on('Kit Pound')
@@ -52,6 +58,44 @@ RSpec.describe 'Viewing your assigned application' do
 
     it 'shows shows how many assignments' do
       expect(page).to have_content '2 saved application'
+    end
+  end
+
+  context 'when using the all applications link' do
+    before do
+      click_on('View all open applications')
+    end
+
+    it 'proceeds to the correct page' do
+      expect(page).to have_content 'All open applications'
+    end
+  end
+
+  context 'when an assigned application is not found on the datastore' do
+    let(:stubbed_search_results) { [] }
+
+    # The wider process for handing this scenario has not been determined.
+    # The solution tested here will result in a mismatch between the assignment counts
+    # and the number of records shown in the table. However, we do not want to delete
+    # the Assignment from review (which would correct the mismatch) when it is not found.
+    # We cannot be sure that the record not being found in the datastore is intentional
+    # or a temporary issue as the a result of a bug.
+
+    before do
+      user = User.where(auth_oid: current_user_auth_oid).first
+
+      Assigning::AssignToUser.new(
+        assignment_id: SecureRandom.uuid,
+        user_id: user.id,
+        to_whom_id: user.id
+      ).call
+
+      click_on 'Your list'
+    end
+
+    it 'shows the assignment in the counts' do
+      expect(page).to have_content 'Your list (1)'
+      expect(page).to have_content '0 saved application'
     end
   end
 end


### PR DESCRIPTION
## Description of change

Your list only shows assignments if they exist in the data store.

Prior to this change, if an application was removed from the datastore whilst still assigned to a user, that user would not be able to load the "Your list" page.
 
## Link to relevant ticket
[CRIMRE-127](https://dsdmoj.atlassian.net/browse/CRIMRE-127)

## Notes for reviewer

This is a minimal solution to unblock staging should this happen again. The wider process for handing this scenario has not been determined.

This solution can result in a mismatch between the assignment counts and the number of records shown in the table. However, we do not want to delete the Assignment from review (which would correct the mismatch) because we cannot be sure that the record not being found in the datastore is intentional or just a temporary issue as a result of a bug.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-127]: https://dsdmoj.atlassian.net/browse/CRIMRE-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ