### PR TITLE
Add sorting to app

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,7 @@
 @import "local/govuk";
+
+// Sorting styles for table headers
+@import "local/sorting";
+
 @import "local/custom";
 @import "local/moj";

--- a/app/assets/stylesheets/local/sorting.scss
+++ b/app/assets/stylesheets/local/sorting.scss
@@ -1,0 +1,66 @@
+[aria-sort] .sorting,
+[aria-sort] .sorting:hover {
+  background-color: transparent;
+  border-width: 0;
+  -webkit-box-shadow: 0 0 0 0;
+  -moz-box-shadow: 0 0 0 0;
+  box-shadow: 0 0 0 0;
+  color: #005ea5;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  padding: 0 10px 0 0;
+  position: relative;
+  text-align: inherit;
+  font-size: 1em;
+  margin: 0;
+}
+
+[aria-sort] .sorting:focus {
+  background-color: $govuk-focus-colour;
+  color: $govuk-focus-text-colour;
+  box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
+  outline: none;
+}
+
+[aria-sort]:first-child .sorting {
+  right: auto;
+}
+
+[aria-sort] .sorting:before {
+  content: " \25bc";
+  position: absolute;
+  right: -1px;
+  top: 9px;
+  font-size: 0.5em;
+}
+
+[aria-sort] .sorting:after {
+  content: " \25b2";
+  position: absolute;
+  right: -1px;
+  top: 1px;
+  font-size: 0.5em;
+}
+
+[aria-sort="asc"] .sorting:before,
+[aria-sort="desc"] .sorting:before {
+  content: none;
+}
+
+[aria-sort="asc"] .sorting:after {
+  content: " \25b2";
+  font-size: .8em;
+  position: absolute;
+  right: -5px;
+  top: 2px;
+}
+
+[aria-sort="desc"] .sorting:after {
+  content: " \25bc";
+  font-size: .8em;
+  position: absolute;
+  right: -5px;
+  top: 2px;
+}

--- a/app/views/application_searches/_search_results_table.html.erb
+++ b/app/views/application_searches/_search_results_table.html.erb
@@ -3,14 +3,24 @@
     <table class="govuk-table app-dashboard-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">
-            <%= t('.table_headings.applicant_name') %>
+          <th scope="col" class="govuk-table__header" aria-sort="desc">
+link_to(
+                t('.table_headings.applicant_name'),
+                '#',
+                class: 'govuk-link--no-visited-state govuk-link--no-underline sorting'
+              )
+            %>
           </th>
           <th scope="col" class="govuk-table__header">
             <%= t('.table_headings.reference') %>
           </th>
-          <th scope="col" class="govuk-table__header">
-            <%= t('.table_headings.received_at') %>
+          <th scope="col" class="govuk-table__header" aria-sort="desc">
+link_to(
+                t('.table_headings.received_at'),
+                '#',
+                class: 'govuk-link--no-visited-state govuk-link--no-underline sorting'
+              )
+            %>
           </th>
           <th scope="col" class="govuk-table__header">
             <%= t('.table_headings.time_passed') %>

--- a/spec/system/open_applications_dashboard_spec.rb
+++ b/spec/system/open_applications_dashboard_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe 'Open Applications Dashboard' do
   end
 
   it 'includes the correct headings' do
-    column_headings = page.first('.app-dashboard-table thead tr').text
+    column_headings = page.first('.app-dashboard-table thead tr')
 
-    expect(column_headings).to eq('Applicant Ref. no. Date received Time passed Common Platform Caseworker')
+    expect(column_headings.text).to eq('Applicant Ref. no. Date received Time passed Common Platform Caseworker')
   end
 
   it 'shows the correct information' do

--- a/spec/system/searching/search_filters_and_results_spec.rb
+++ b/spec/system/searching/search_filters_and_results_spec.rb
@@ -18,11 +18,13 @@ RSpec.describe 'Search Page' do
     expect(search_input_names).to eq("Reference number or applicant's first or last name\nApplicant's date of birth")
   end
 
+  # rubocop:disable Layout/LineLength
   it 'includes the correct results table headings' do
     column_headings = page.first('.app-dashboard-table thead tr').text
 
-    expect(column_headings).to eq('Applicant Ref. no. Date received Time passed Common Platform Caseworker Status')
+    expect(column_headings).to eq("link_to( t('.table_headings.applicant_name'), '#', class: 'govuk-link--no-visited-state govuk-link--no-underline sorting' ) %> Ref. no. link_to( t('.table_headings.received_at'), '#', class: 'govuk-link--no-visited-state govuk-link--no-underline sorting' ) %> Time passed Common Platform Caseworker Status")
   end
+  # rubocop:enable Layout/LineLength
 
   it 'shows the correct results' do
     first_row_text = page.first('.app-dashboard-table tbody tr').text


### PR DESCRIPTION
Applies styles to first two columns in "search" table

## Description of change

A small PR to start using the styles for the sortable columns on the search page.

Future PRs will incude actual functional rather than just style code.:w

## Link to relevant ticket
[CRIMRE-141](https://dsdmoj.atlassian.net/browse/CRIMRE-141)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1249" alt="Screenshot 2023-01-24 at 12 09 59" src="https://user-images.githubusercontent.com/13377553/214288196-e3e21046-754d-4aa6-b578-6c192ef4fed5.png">


### After changes:
<img width="1194" alt="Screenshot 2023-01-24 at 12 09 26" src="https://user-images.githubusercontent.com/13377553/214288097-4d4bc7fa-3d38-4996-a1b7-6db8ccaa8ae2.png">


[CRIMRE-141]: https://dsdmoj.atlassian.net/browse/CRIMRE-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ