### PR TITLE
CRIMRE-52 show return in application history

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
-  revision: 89bb758a13361e5eac17d255f42888cb946397f9
+  revision: f0d5d0bb3a56e9708569d95513f99294586d634a
   specs:
     laa-criminal-applications-datastore-api-client (0.0.1)
       faraday (~> 2.6)
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: ee9096e0bafa444f9ac999ed8e9580a62461fbe4
+  revision: c7febd8d13df6522d19971d0a37db0095abb45b2
   specs:
     laa-criminal-legal-aid-schemas (0.1.1)
       dry-struct

--- a/app/aggregates/reviewing/commands/send_back.rb
+++ b/app/aggregates/reviewing/commands/send_back.rb
@@ -10,7 +10,11 @@ module Reviewing
           review.send_back(application_id:, user_id:, reason:)
         end
 
-        # TODO: Call http client
+        DatastoreApi::Requests::UpdateApplication.new(
+          application_id: application_id,
+          payload: { return_details: },
+          member: :return
+        ).call
       end
     end
 

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -36,16 +36,6 @@ module Types
   ].freeze
   AssignedStatus = String.enum(*ASSIGNED_STATUSES)
 
-  RETURN_REASONS = %w[
-    clarification_required
-    evidence_issue
-    duplicate_application
-    case_concluded
-    provider_request
-  ].freeze
-
-  ReturnReason = String.enum(*RETURN_REASONS)
-
   ReturnDetails = Hash.schema(
     reason: ReturnReason,
     details: String

--- a/app/models/application_history.rb
+++ b/app/models/application_history.rb
@@ -2,7 +2,8 @@ class ApplicationHistory < ApplicationStruct
   EVENT_TYPES = [
     Assigning::AssignedToUser,
     Assigning::UnassignedFromUser,
-    Assigning::ReassignedToUser
+    Assigning::ReassignedToUser,
+    Reviewing::SentBack
   ].freeze
 
   attribute :application, Types.Instance(CrimeApplication)
@@ -15,7 +16,7 @@ class ApplicationHistory < ApplicationStruct
 
   def load_from_events
     RailsEventStore::Projection
-      .from_stream("Assigning$#{application.id}")
+      .from_stream(streams)
       .init(-> { [application_submitted_item] })
       .when(ApplicationHistory::EVENT_TYPES,
             lambda { |state, event|
@@ -23,15 +24,23 @@ class ApplicationHistory < ApplicationStruct
             }).run(Rails.application.config.event_store).reverse
   end
 
+  def streams
+    ["Assigning$#{application.id}", "Reviewing$#{application.id}"]
+  end
+
   # NOTE: provider name is not yet availble in the data.
   # Tihs is a fake submission event. It will be replace by a
   # real one on import from the datastore.
   def application_submitted_item
+    provider_name = [
+      application.provider_details.legal_rep_first_name,
+      application.provider_details.legal_rep_last_name
+    ].join ' '
     ApplicationHistoryItem.new(
       user_id: nil,
-      user_name: 'Provider Name',
+      user_name: provider_name,
       timestamp: application.submitted_at,
-      event_type: 'Application::Submitted'
+      event_type: 'Reviewing::ApplicationReceived'
     )
   end
 end

--- a/app/models/application_history_item.rb
+++ b/app/models/application_history_item.rb
@@ -2,47 +2,24 @@
 # View Object for an application history item
 #
 class ApplicationHistoryItem < ApplicationStruct
-  VIEWABLE_DATA = %i[from_whom_name to_whom_name].freeze
-
-  attribute :user_id, Types::Uuid.optional
   attribute :user_name, Types::String
   attribute :timestamp, Types::Nominal::DateTime
   attribute :event_type, Types::String
-  attribute :viewable_data, Types::Hash.default({}.freeze)
+  attribute? :event_data, Types::Hash
 
-  def description
-    I18n.t(
-      event_type.underscore.tr('/', '.'),
-      scope: 'event.description',
-      **viewable_data
-    )
+  def to_partial_path
+    ["#{super}s", event_type.underscore.tr('/', '_')].join '/'
   end
 
   class << self
     def from_event(event)
       user_id = event.data.fetch(:user_id)
-
       new(
-        user_id: user_id,
         user_name: User.name_for(user_id),
         timestamp: event.timestamp,
         event_type: event.event_type,
-        viewable_data: viewable_data_for_event(event)
+        event_data: event.data
       )
-    end
-
-    def viewable_data_for_event(event)
-      case event.event_type
-      when 'Assigning::AssignedToUser'
-        { to_whom_name: User.name_for(event.data.fetch(:to_whom_id)) }
-      when 'Assigning::UnassignedFromUser'
-        { from_whom_name: User.name_for(event.data.fetch(:from_whom_id)) }
-      when 'Assigning::ReassignedToUser'
-        {
-          to_whom_name: User.name_for(event.data.fetch(:to_whom_id)),
-          from_whom_name: User.name_for(event.data.fetch(:from_whom_id))
-        }
-      end
     end
   end
 end

--- a/app/models/application_search_result.rb
+++ b/app/models/application_search_result.rb
@@ -1,6 +1,7 @@
 class ApplicationSearchResult < ApplicationStruct
   attribute :applicant_name, Types::String
   attribute :submitted_at, Types::DateTime
+  attribute? :reviewed_at, Types::DateTime.optional
   attribute :reference, Types::Integer
   attribute :resource_id, Types::Uuid
   attribute :status, Types::String

--- a/app/views/application_history_items/_assigning_assigned_to_user.html.erb
+++ b/app/views/application_history_items/_assigning_assigned_to_user.html.erb
@@ -1,0 +1,3 @@
+<strong>
+  <%= t(:assigned_to_user, scope: 'event.description.assigning', to_whom_name: User.name_for(item.event_data.fetch(:to_whom_id))) %>
+</strong>

--- a/app/views/application_history_items/_assigning_reassigned_to_user.html.erb
+++ b/app/views/application_history_items/_assigning_reassigned_to_user.html.erb
@@ -1,0 +1,3 @@
+<strong>
+  <%= t(:reassigned_to_user, scope: 'event.description.assigning', to_whom_name: User.name_for(item.event_data.fetch(:to_whom_id)), from_whom_name: User.name_for(item.event_data.fetch(:from_whom_id))) %>
+</strong>

--- a/app/views/application_history_items/_assigning_unassigned_from_user.html.erb
+++ b/app/views/application_history_items/_assigning_unassigned_from_user.html.erb
@@ -1,0 +1,3 @@
+<strong>
+  <%= t(:unassigned_from_user, scope: 'event.description.assigning', from_whom_name: User.name_for(item.event_data.fetch(:from_whom_id))) %>
+</strong>

--- a/app/views/application_history_items/_reviewing_application_received.html.erb
+++ b/app/views/application_history_items/_reviewing_application_received.html.erb
@@ -1,0 +1,3 @@
+<strong>
+  <%= t('reviewing.application_received', scope: 'event.description') %>
+</strong>

--- a/app/views/application_history_items/_reviewing_sent_back.html.erb
+++ b/app/views/application_history_items/_reviewing_sent_back.html.erb
@@ -1,0 +1,5 @@
+<strong>
+  <%= t('reviewing.sent_back', scope: 'event.description') %>
+</strong>
+<p><%= t(item.event_data.fetch(:reason), scope: 'values.return_reason') %></p>
+<%= simple_format application.return_details&.details %>

--- a/app/views/crime_applications/_closed_crime_applications_table_body.html.erb
+++ b/app/views/crime_applications/_closed_crime_applications_table_body.html.erb
@@ -9,8 +9,7 @@
     <%= l(app.submitted_at) %>
   </td>
   <td class="govuk-table__cell">
-  <%# TODO: Reviewed at is not implemented yet - (app.reviewed_at) %>
-    <%= l(app.submitted_at) %>
+    <%= l(app.reviewed_at) if app.reviewed_at %>
   </td>
   <td class="govuk-table__cell">
     <%= app.current_assignment&.user&.name %>

--- a/app/views/crime_applications/_history_item.html.erb
+++ b/app/views/crime_applications/_history_item.html.erb
@@ -1,11 +1,11 @@
 <tr class="govuk-table__row">
   <td scope="row" class="govuk-table__cell">
-    <%= l event.timestamp, format: :timestamp %>
+    <%= l item.timestamp, format: :timestamp %>
   </td>
   <td class="govuk-table__cell">
-    <%= event.user_name %>
+    <%= item.user_name %>
   </td>
   <td class="govuk-table__cell">
-    <%= event.description %>
+    <%= yield %>
   </td>
 </tr>

--- a/app/views/crime_applications/history.html.erb
+++ b/app/views/crime_applications/history.html.erb
@@ -37,9 +37,9 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <%= render partial: 'history_item',
-                 collection: @crime_application.history.items,
-                 as: :event %>
+      <% @crime_application.history.items.each do |item| %>
+        <%= render partial: item, layout: 'history_item', as: :item, locals: { application: @crime_application } %>
+      <% end %>
     </tbody>
   </table>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,13 +160,15 @@ en:
       application_history: Application history
 
   event:
+    title:
     description:
-      application:
-        submitted: Application submitted
       assigning:
         assigned_to_user: Application assigned to %{to_whom_name}
         unassigned_from_user: Application removed from %{from_whom_name}
         reassigned_to_user: Application reassigned from %{from_whom_name} to %{to_whom_name}
+      reviewing:
+        sent_back: Application sent back to provider
+        application_received: Application submitted
 
   assigned_applications:
     index:

--- a/spec/init/api_data.rb
+++ b/spec/init/api_data.rb
@@ -10,9 +10,16 @@ RSpec.configure do |config|
     #
     stub_request(
       :get,
+      "#{ENV.fetch('DATASTORE_API_ROOT')}/api/v2/applications/47a93336-7da6-48ac-b139-808ddd555a41"
+    ).to_return(body: LaaCrimeSchemas.fixture(1.0, name: 'application_returned').read, status: 200)
+
+    #
+    # Stub for valid returned application for Kit Pound, fixture provided by the LaaCrimeSchemas Gem
+    #
+    stub_request(
+      :get,
       "#{ENV.fetch('DATASTORE_API_ROOT')}/api/v2/applications/696dd4fd-b619-4637-ab42-a5f4565bcf4a"
     ).to_return(body: LaaCrimeSchemas.fixture(1.0).read, status: 200)
-
     #
     # Stub datastore find for ids listed in application_ids.
     #

--- a/spec/system/closed_applications_dashboard_spec.rb
+++ b/spec/system/closed_applications_dashboard_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Closed Applications Dashboard' do
         reference: 5_230_234_344,
         status: 'returned',
         submitted_at: '2022-12-14T16:58:15.000+00:00',
-        returned_at: '2022-12-14T16:58:15.000+00:00'
+        reviewed_at: '2022-12-15T16:58:15.000+00:00'
       )
     ]
   end
@@ -37,7 +37,7 @@ RSpec.describe 'Closed Applications Dashboard' do
 
   it 'shows the correct information' do
     first_row_text = page.first('.app-dashboard-table tbody tr').text
-    expect(first_row_text).to eq('Ella Fitzgerald 5230234344 14/12/2022 14/12/2022 Returned')
+    expect(first_row_text).to eq('Ella Fitzgerald 5230234344 14/12/2022 15/12/2022 Returned')
   end
 
   it 'has the correct count' do

--- a/spec/system/reviewing/send_back_to_provider_spec.rb
+++ b/spec/system/reviewing/send_back_to_provider_spec.rb
@@ -37,7 +37,11 @@ RSpec.describe 'Send an application back to the provider' do
     end
 
     describe 'adding the return reason' do
-      before { click_button(send_back_cta) }
+      before do
+        allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
+          .and_return(instance_double(DatastoreApi::Requests::UpdateApplication, call: {}))
+        click_button(send_back_cta)
+      end
 
       it 'shows the applicant name in the heading' do
         expect(page).to have_content "Send Kit Pound's application back to the provider"

--- a/spec/system/viewing_application_history_spec.rb
+++ b/spec/system/viewing_application_history_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Viewing application history' do
 
     it 'includes the submission event' do
       first_row = page.first('.app-dashboard-table tbody tr').text
-      expect(first_row).to match('Monday 24 Oct 09:50 Provider Name Application submitted')
+      expect(first_row).to match('Monday 24 Oct 09:50 John Doe Application submitted')
     end
   end
 
@@ -74,6 +74,53 @@ RSpec.describe 'Viewing application history' do
     it 'includes the reassignment event' do
       first_row = page.first('.app-dashboard-table tbody tr').text
       expect(first_row).to match('Joe EXAMPLE Application reassigned from Fred Smitheg to Joe EXAMPLE')
+    end
+  end
+
+  context 'with a returned application' do
+    let(:return_details) do
+      ReturnDetails.new(
+        reason: 'evidence_issue',
+        details: 'September bank statement required'
+      )
+    end
+
+    before do
+      stub_request(
+        :put,
+        "#{ENV.fetch('DATASTORE_API_ROOT')}/api/v2/applications/#{crime_application_id}/return"
+      ).to_return(body: LaaCrimeSchemas.fixture(1.0, name: 'application_returned').read, status: 200)
+
+      user = User.create(
+        first_name: 'Fred',
+        last_name: 'Smitheg',
+        auth_oid: '976658f9-f3d5-49ec-b0a9-485ff8b308fa',
+        email: 'Fred.Smitheg@justice.gov.uk'
+      )
+
+      Assigning::AssignToUser.new(
+        user_id: user.id,
+        to_whom_id: user.id,
+        assignment_id: crime_application_id
+      ).call
+
+      Reviewing::SendBack.new(
+        user_id: user.id,
+        application_id: crime_application_id,
+        return_details: return_details.attributes
+      ).call
+
+      click_on 'All open applications'
+      click_on('Kit Pound')
+      click_on('Reassign to myself')
+      click_on('Yes, reassign')
+      click_on('Application history')
+    end
+
+    it 'includes the return event' do
+      first_row = page.first('.app-dashboard-table tbody tr').text
+      expect(first_row).to match('Fred Smitheg Application sent back to provider')
+      expect(first_row).to match('Evidence issue')
     end
   end
 end


### PR DESCRIPTION
## Description of change

Adds return events to application history.
User reviewed at date from datastore.

## Link to relevant ticket

Completes CRIMRE-52

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

<img width="750" alt="Screenshot 2023-01-25 at 11 28 24" src="https://user-images.githubusercontent.com/34935/214552497-c75ec4cb-39ac-4d9e-839b-0939536ad8ce.png">

<img width="782" alt="Screenshot 2023-01-25 at 11 29 51" src="https://user-images.githubusercontent.com/34935/214552542-db8c8082-9fab-4e61-8dfb-265146914e1a.png">

<img width="1122" alt="Screenshot 2023-01-25 at 11 30 57" src="https://user-images.githubusercontent.com/34935/214552656-f56d82f4-101b-4169-89b4-ae8a97cdcfc8.png">


## How to manually test the feature
