### PR TITLE
CRIMRE-123-time-past-days-past

### DIFF
--- a/app/views/application_searches/_search_results_table_body.html.erb
+++ b/app/views/application_searches/_search_results_table_body.html.erb
@@ -19,7 +19,7 @@
       <%= result.current_assignment&.user&.name %>
     </td>
     <td class="govuk-table__cell">
-      <%= t("crime_applications.values.status.#{result.status}") %>
+      <%= t(result.status, scope: 'values.status') %>
     </td>
   </tr>
 </tbody>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,7 +84,7 @@ en:
   table_headings: &TABLE_HEADINGS
     applicant_name: Applicant
     reference: Ref. no.
-    time_passed: Time passed
+    time_passed: Days passed
     received_at: Date received
     reviewed_at: Date reviewed
     caseworker: Caseworker
@@ -119,7 +119,9 @@ en:
     interest_of_another: Interest of another
     other: Other
     status:
-      "submitted": Open
+      submitted: Open
+      returned: Sent back to provider
+      completed: Completed
     days_passed:
       one: 1 day
       other: "%{count} days"

--- a/spec/system/open_applications_dashboard_spec.rb
+++ b/spec/system/open_applications_dashboard_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Open Applications Dashboard' do
   it 'includes the correct headings' do
     column_headings = page.first('.app-dashboard-table thead tr')
 
-    expect(column_headings.text).to eq('Applicant Ref. no. Date received Time passed Common Platform Caseworker')
+    expect(column_headings.text).to eq('Applicant Ref. no. Date received Days passed Common Platform Caseworker')
   end
 
   it 'shows the correct information' do

--- a/spec/system/searching/search_filters_and_results_spec.rb
+++ b/spec/system/searching/search_filters_and_results_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Search Page' do
   it 'includes the correct results table headings' do
     column_headings = page.first('.app-dashboard-table thead tr').text
 
-    expect(column_headings).to eq('Applicant Ref. no. Date received Time passed Common Platform Caseworker Status')
+    expect(column_headings).to eq('Applicant Ref. no. Date received Days passed Common Platform Caseworker Status')
   end
 
   it 'shows the correct results' do


### PR DESCRIPTION
also fixes search results page with returned applications.

## Description of change

## Link to relevant ticket
[CRIMRE-123](https://dsdmoj.atlassian.net/browse/CRIMRE-123)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1219" alt="Screenshot 2023-01-26 at 09 14 24" src="https://user-images.githubusercontent.com/34935/214800574-9a04fff4-4ce7-4b5a-b3f6-6168a059076e.png">

### After changes:
<img width="1183" alt="Screenshot 2023-01-26 at 09 15 05" src="https://user-images.githubusercontent.com/34935/214800603-d42d4ed0-6604-4ddb-b85b-9ac54ef8e9b9.png">

## How to manually test the feature


[CRIMRE-123]: https://dsdmoj.atlassian.net/browse/CRIMRE-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ