### PR TITLE
Crimre 87 set per page in views

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,10 @@ class ApplicationController < ActionController::Base
       permitted_params[:sorting] || { sort_by: default_sort_by }
     )
 
-    pagination = Pagination.new(current_page: permitted_params[:page] || 1)
+    pagination = Pagination.new(
+      current_page: permitted_params[:page],
+      limit_value: permitted_params[:per_page]
+    )
 
     @search = ApplicationSearch.new(
       filter:,

--- a/app/controllers/application_searches_controller.rb
+++ b/app/controllers/application_searches_controller.rb
@@ -15,6 +15,7 @@ class ApplicationSearchesController < ApplicationController
   def permitted_params
     params.permit(
       :page,
+      :per_page,
       filter: ApplicationSearchFilter.attribute_names,
       sorting: Sorting.attribute_names
     )

--- a/app/controllers/assigned_applications_controller.rb
+++ b/app/controllers/assigned_applications_controller.rb
@@ -1,6 +1,8 @@
 class AssignedApplicationsController < ApplicationController
   def index
-    set_search(filter: ApplicationSearchFilter.new(assigned_status: current_user_id))
+    set_search(
+      filter: ApplicationSearchFilter.new(assigned_status: current_user_id)
+    )
   end
 
   def create
@@ -53,6 +55,7 @@ class AssignedApplicationsController < ApplicationController
   def permitted_params
     params.permit(
       :page,
+      :per_page,
       sorting: Sorting.attribute_names
     )
   end

--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -15,7 +15,7 @@ class CrimeApplicationsController < ApplicationController
   def closed
     set_search(
       filter: ApplicationSearchFilter.new(
-        application_status: 'open'
+        application_status: 'sent_back'
       ),
       default_sort_by: 'reviewed_at'
     )
@@ -24,9 +24,7 @@ class CrimeApplicationsController < ApplicationController
     render :index
   end
 
-  def show
-    @current_assignment = @crime_application.current_assignment
-  end
+  def show; end
 
   def history; end
 
@@ -39,6 +37,7 @@ class CrimeApplicationsController < ApplicationController
   def permitted_params
     params.permit(
       :page,
+      :per_page,
       sorting: Sorting.attribute_names
     )
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,9 +24,11 @@ module ApplicationHelper
   #
   # The sortable column form includes params from any base_params provided.
   #
-  def table_headers(column_names, sorting:, base_params: {}, sort_form_method: :get)
+  def table_headers(column_names, search:, base_params: {}, sort_form_method: :get)
+    base_params[:per_page] = search.pagination.limit_value
+
     headers = column_names.map do |column_name|
-      TableHeader.new(column_name:, sorting:)
+      TableHeader.new(column_name:, search:)
     end
 
     render headers, base_params:, sort_form_method:

--- a/app/lib/application_struct.rb
+++ b/app/lib/application_struct.rb
@@ -1,6 +1,16 @@
 class ApplicationStruct < Dry::Struct
   transform_keys(&:to_sym)
 
+  transform_types do |type|
+    if type.default?
+      type.constructor do |value|
+        value.nil? ? Dry::Types::Undefined : value
+      end
+    else
+      type
+    end
+  end
+
   include ActiveModel::Validations
 
   def to_partial_path

--- a/app/models/pagination.rb
+++ b/app/models/pagination.rb
@@ -1,6 +1,9 @@
 class Pagination < ApplicationStruct
-  attribute :current_page, Types::Params::Integer.optional.default(1)
-  attribute? :limit_value, Types::Params::Integer.default(50)
+  DEFAULT_LIMIT_VALUE = 50
+  DEFAULT_CURRENT_PAGE = 1
+
+  attribute? :current_page, Types::Coercible::Integer.default(DEFAULT_CURRENT_PAGE)
+  attribute? :limit_value, Types::Params::Integer.default(DEFAULT_LIMIT_VALUE)
   attribute? :total_pages, Types::Params::Integer
   attribute? :total_count, Types::Params::Integer
 

--- a/app/models/table_header.rb
+++ b/app/models/table_header.rb
@@ -1,6 +1,6 @@
 class TableHeader < ApplicationStruct
   attribute :column_name, Types::String
-  attribute :sorting, Types.Instance(Sorting)
+  attribute :search, Types.Instance(ApplicationSearch)
 
   def name
     I18n.t(column_name, scope: 'table_headings')
@@ -21,6 +21,8 @@ class TableHeader < ApplicationStruct
       }
     }
   end
+
+  delegate :sorting, to: :search
 
   #
   # returns 'ascending', 'descending' or 'none' depending on

--- a/app/views/application_searches/show.html.erb
+++ b/app/views/application_searches/show.html.erb
@@ -34,7 +34,7 @@
                     status
                   ],
                   base_params: { filter: @search.filter.to_h },
-                  sorting: @search.sorting
+                  search: @search
                 ) %>
           </tr>
         </thead>

--- a/app/views/assigned_applications/index.html.erb
+++ b/app/views/assigned_applications/index.html.erb
@@ -37,7 +37,7 @@
                       time_passed
                       common_platform
                     ],
-                    sorting: @search.sorting
+                    search: @search
                   ) %>
             </tr>
           </thead>

--- a/app/views/crime_applications/_closed_crime_applications_table_headers.html.erb
+++ b/app/views/crime_applications/_closed_crime_applications_table_headers.html.erb
@@ -7,6 +7,5 @@
         reviewer
         status
       ],
-      base_params: { status: 'closed' },
-      sorting: sorting
+      search:
     ) %>

--- a/app/views/crime_applications/_open_crime_applications_table_headers.html.erb
+++ b/app/views/crime_applications/_open_crime_applications_table_headers.html.erb
@@ -7,6 +7,5 @@
         common_platform
         caseworker
       ],
-      base_params: { status: 'open' },
-      sorting: sorting
+      search:
     ) %>

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -21,7 +21,7 @@
   <table class="govuk-table app-dashboard-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <%= render "#{@review_status}_crime_applications_table_headers", sorting: @search.sorting %>
+        <%= render "#{@review_status}_crime_applications_table_headers", search: @search %>
       </tr>
     </thead>
 

--- a/spec/models/application_search_filter_spec.rb
+++ b/spec/models/application_search_filter_spec.rb
@@ -52,13 +52,21 @@ RSpec.describe ApplicationSearchFilter do
   describe '#datastore_params' do
     subject(:datastore_params) { new.datastore_params }
 
+    let(:expected_datastore_params) do
+      {
+        applicant_date_of_birth: nil,
+        application_id_in: [],
+        application_id_not_in: [],
+        status: ['submitted'],
+        submitted_after: nil,
+        submitted_before: nil,
+        search_text: nil
+      }
+    end
+
     context 'when the filter is empty' do
       it 'returns the correct datastore api search params' do
-        expect(datastore_params).to eq({
-                                         applicant_date_of_birth: nil, application_id_in: [],
-            application_id_not_in: [], status: ['submitted'],
-            submitted_after: nil, submitted_before: nil, search_text: nil
-                                       })
+        expect(datastore_params).to eq(expected_datastore_params)
       end
     end
 
@@ -71,7 +79,7 @@ RSpec.describe ApplicationSearchFilter do
         }
       end
 
-      let(:expected_datstore_params) do
+      let(:expected_datastore_params) do
         {
           applicant_date_of_birth: Date.parse('1970-10-10'),
           application_id_in: david.current_assignments.pluck(:assignment_id),
@@ -84,7 +92,7 @@ RSpec.describe ApplicationSearchFilter do
       end
 
       it 'returns the correct datastore api search params' do
-        expect(datastore_params).to eq expected_datstore_params
+        expect(datastore_params).to eq expected_datastore_params
       end
     end
   end

--- a/spec/models/pagination_spec.rb
+++ b/spec/models/pagination_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Pagination do
+  subject(:new) { described_class.new(**params) }
+
+  let(:params) { {} }
+
+  describe '#limit_value' do
+    subject(:limit_value) { new.limit_value }
+
+    context 'when an string number is provided' do
+      let(:params) { { limit_value: '35' } }
+
+      it { is_expected.to be 35 }
+    end
+
+    context 'when an integer' do
+      let(:params) { { limit_value: 30 } }
+
+      it { is_expected.to be 30 }
+    end
+
+    context 'when an empty string' do
+      let(:params) { { limit_value: nil } }
+
+      it { is_expected.to be 50 }
+    end
+
+    context 'when no attribute povided' do
+      it { is_expected.to be 50 }
+    end
+  end
+end

--- a/spec/shared_contexts/with_stubbed_search.rb
+++ b/spec/shared_contexts/with_stubbed_search.rb
@@ -21,9 +21,12 @@ RSpec.shared_context 'with stubbed search', shared_context: :metadata do
   let(:http_client) { instance_double(DatastoreApi::HttpClient, post: search_response) }
 
   let(:search_response) do
-    pagination = {
-      total_pages: 1, current_page: 1, total_count: stubbed_search_results.size
-    }
+    pagination = Pagination.new(
+      total_count: stubbed_search_results.size,
+      total_pages: 1,
+      limit_value: 50
+    ).to_h
+
     records = stubbed_search_results.map(&:to_h)
 
     { pagination:, records: }.deep_stringify_keys


### PR DESCRIPTION
## Description of change

Allows per_page to be set in the query string of any paginated page for testing and development purposes.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

for example, visit:

```
/applications/open?per_page=1
```
