### PR TITLE
CRIMRE-45 fix default sort order

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,9 +25,9 @@ class ApplicationController < ActionController::Base
     request.env['warden']
   end
 
-  def set_search(filter: ApplicationSearchFilter.new, default_sort_by: 'submitted_at')
+  def set_search(filter: ApplicationSearchFilter.new, sorting: {})
     sorting = Sorting.new(
-      permitted_params[:sorting] || { sort_by: default_sort_by }
+      permitted_params[:sorting] || sorting.to_h
     )
 
     pagination = Pagination.new(

--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -3,23 +3,16 @@ class CrimeApplicationsController < ApplicationController
 
   def open
     set_search(
-      filter: ApplicationSearchFilter.new(
-        application_status: 'open'
-      )
+      filter: ApplicationSearchFilter.new(application_status: 'open')
     )
-    @review_status = 'open'
-
     render :index
   end
 
   def closed
     set_search(
-      filter: ApplicationSearchFilter.new(
-        application_status: 'sent_back'
-      ),
-      default_sort_by: 'reviewed_at'
+      filter: ApplicationSearchFilter.new(application_status: 'sent_back'),
+      sorting: Sorting.new(sort_by: 'reviewed_at', sort_direction: 'descending')
     )
-    @review_status = 'closed'
 
     render :index
   end

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -41,7 +41,7 @@ module Types
     details: String
   )
 
-  SortDirection = String.default('descending'.freeze).enum('descending', 'ascending')
+  SortDirection = String.default('ascending'.freeze).enum('descending', 'ascending')
 
   SORTABLE_COLUMNS = %w[
     submitted_at

--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -1,9 +1,9 @@
-<% title t(".#{@review_status}_title") %>
+<% title t(".#{action_name}_title") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full govuk-!-margin-bottom-5">
       <h1 class="govuk-heading-xl">
-        <%= t ".#{@review_status}_heading" %>
+        <%= t ".#{action_name}_heading" %>
       </h1>
   </div>
 </div>
@@ -21,12 +21,12 @@
   <table class="govuk-table app-dashboard-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <%= render "#{@review_status}_crime_applications_table_headers", search: @search %>
+        <%= render "#{action_name}_crime_applications_table_headers", search: @search %>
       </tr>
     </thead>
 
     <tbody class="govuk-table__body">
-      <%= render partial: "#{@review_status}_crime_applications_table_body",
+      <%= render partial: "#{action_name}_crime_applications_table_body",
                  collection: @search.results,
                  as: :app %>
     </tbody>

--- a/spec/system/assigning/viewing_your_assigned_applications_spec.rb
+++ b/spec/system/assigning/viewing_your_assigned_applications_spec.rb
@@ -65,14 +65,14 @@ RSpec.describe 'Viewing your assigned application' do
         page.find('thead tr th#submitted_at')['aria-sort']
       end
 
-      it 'is active and descending by default' do
-        expect(column_sort).to eq 'descending'
+      it 'is active and ascending by default' do
+        expect(column_sort).to eq 'ascending'
       end
 
       context 'when clicked' do
-        it 'changes to ascending when it is selected' do
+        it 'changes to descending when it is selected' do
           expect { click_button 'Date received' }.not_to(change { current_path })
-          expect(column_sort).to eq 'ascending'
+          expect(column_sort).to eq 'descending'
         end
       end
     end

--- a/spec/system/open_applications_dashboard_spec.rb
+++ b/spec/system/open_applications_dashboard_spec.rb
@@ -41,14 +41,14 @@ RSpec.describe 'Open Applications Dashboard' do
       page.find('thead tr th#submitted_at')['aria-sort']
     end
 
-    it 'is active and descending by default' do
-      expect(column_sort).to eq 'descending'
+    it 'is active and ascending by default' do
+      expect(column_sort).to eq 'ascending'
     end
 
     context 'when clicked' do
-      it 'changes to ascending when it is selected' do
+      it 'changes to adescending when it is selected' do
         expect { click_button 'Date received' }.not_to(change { current_path })
-        expect(column_sort).to eq 'ascending'
+        expect(column_sort).to eq 'descending'
       end
     end
   end

--- a/spec/system/searching/sorting_search_results_spec.rb
+++ b/spec/system/searching/sorting_search_results_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe 'Sorting search results' do
         page.find('thead tr th#submitted_at')['aria-sort']
       end
 
-      it 'is active and descending by default' do
-        expect(column_sort).to eq 'descending'
+      it 'is active and ascending by default' do
+        expect(column_sort).to eq 'ascending'
       end
 
       context 'when clicked' do
-        it 'changes to ascending when it is selected' do
+        it 'changes to descending when it is selected' do
           click_button 'Date received'
-          expect(column_sort).to eq 'ascending'
+          expect(column_sort).to eq 'descending'
         end
       end
     end


### PR DESCRIPTION
## Description of change
Open applications, your list, and search show oldest at the top initially. 
Closed applications show most recently reviewed at the top initially.

## Link to relevant ticket

[CRIMRE-45](https://dsdmoj.atlassian.net/browse/CRIMRE-45)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
