### PR TITLE
CRIMRE-158-superseded-as-sent-back

### DIFF
--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -14,8 +14,8 @@ module Types
   #
   REVIEW_APPLICATION_STATUSES = {
     'open' => [Types::ApplicationStatus['submitted']],
-    'completed' => [], # NOTE: completed status does no yet exist in datastore/schema
-    'sent_back' => [Types::ApplicationStatus['returned']],
+    'completed' => ['completed'], # NOTE: completed status does no yet exist in datastore/schema
+    'sent_back' => [Types::ApplicationStatus['returned'], Types::ApplicationStatus['superseded']],
     'all' => APPLICATION_STATUSES
   }.freeze
 

--- a/app/models/application_search.rb
+++ b/app/models/application_search.rb
@@ -27,9 +27,7 @@ class ApplicationSearch
   include DatastoreApi::Traits::PaginatedResponse
 
   def datastore_search_response
-    @datastore_search_response ||= paginated_response(
-      http_client.post('/searches', datastore_params)
-    )
+    @datastore_search_response ||= paginated_response(datastore_response)
   end
 
   def datastore_params
@@ -38,5 +36,11 @@ class ApplicationSearch
       pagination: @pagination.datastore_params,
       sorting: @sorting.to_h
     }
+  end
+
+  def datastore_response
+    http_client.post('/searches', datastore_params)
+  rescue DatastoreApi::Errors::BadRequest
+    { records: [], pagination: {} }
   end
 end

--- a/app/views/crime_applications/show.html.erb
+++ b/app/views/crime_applications/show.html.erb
@@ -10,13 +10,9 @@
       <%= @crime_application.applicant_name %>
     </h2>
 
-    <% if @crime_application.status == 'returned' %>
-      <span class="govuk-tag govuk-tag--red govuk-!-margin-bottom-6"><%= t(".status.#{@crime_application.status}") %></span>
-    <% elsif @crime_application.status == 'completed' %>
-      <span class="govuk-tag govuk-tag--green govuk-!-margin-bottom-6"><%= t(".status.#{@crime_application.status}") %></span>
-    <% else %>
-      <span class="govuk-tag govuk-!-margin-bottom-6"><%= t(".status.#{@crime_application.status}") %></span>
-    <% end %>
+    <span class="govuk-tag govuk-tag--<%= t(@crime_application.status, scope: 'values.color') %> govuk-!-margin-bottom-6">
+      <%= t(@crime_application.status, scope: 'values.status') %>
+    </span>
 
     <%= render partial: 'current_assignment', locals: { crime_application: @crime_application } %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,6 +126,7 @@ en:
     status:
       submitted: Open
       returned: Sent back to provider
+      superseded: Sent back to provider
       completed: Completed
     days_passed:
       one: 1 day
@@ -144,6 +145,12 @@ en:
       duplicate_application: Duplicate application
       case_concluded: Case has already concluded
       provider_request: Provider request
+    color:
+      submitted: default
+      returned: red 
+      superseded: red
+      completed: green 
+
 
   calls_to_action:
     abandon_reassign_to_self: No, do not reassign
@@ -236,10 +243,6 @@ en:
     show:
       page_title: Application
       heading: Application
-      status:
-        submitted: Open
-        returned: Sent back to provider
-        completed: Completed
       view_history: View application history
       view_your_list: View your list
     history:

--- a/spec/models/application_search_filter_spec.rb
+++ b/spec/models/application_search_filter_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe ApplicationSearchFilter do
           submitted_before: Date.parse('2022-12-21'),
           search_text: 'David 100003',
           application_id_not_in: [],
-          status: ['returned']
+          status: %w[returned superseded]
         }
       end
 

--- a/spec/shared_contexts/with_stubbed_search.rb
+++ b/spec/shared_contexts/with_stubbed_search.rb
@@ -18,9 +18,9 @@ RSpec.shared_context 'with stubbed search', shared_context: :metadata do
     ]
   end
 
-  let(:http_client) { instance_double(DatastoreApi::HttpClient, post: search_response) }
+  let(:http_client) { instance_double(DatastoreApi::HttpClient) }
 
-  let(:search_response) do
+  let(:datastore_response) do
     pagination = Pagination.new(
       total_count: stubbed_search_results.size,
       total_pages: 1,
@@ -33,11 +33,9 @@ RSpec.shared_context 'with stubbed search', shared_context: :metadata do
   end
 
   before do
-    allow(http_client).to receive(:post) { search_response }
-
+    allow(http_client).to receive(:post) { datastore_response }
     #
     # Temporarily allow any instance of.
-    #
     # TODO remove when datastore api client has been updated.
     #
     # rubocop:disable RSpec::AnyInstance

--- a/spec/system/searching/filter_by_status_spec.rb
+++ b/spec/system/searching/filter_by_status_spec.rb
@@ -27,14 +27,24 @@ RSpec.describe 'Search applications status filter' do
     end
 
     describe 'Completed' do
+      #
+      # Completed is expected to raise an error because the completed
+      # state is not yet supported.
+      #
+      # Here we catch the error and return an empty collection.
+      #
+      let(:datastore_response) do
+        raise DatastoreApi::Errors::BadRequest
+      end
+
       before do
         select 'Completed', from: filter_field
         click_button 'Search'
       end
 
       it 'filters by status "completed"' do
-        assert_api_searched_with_filter(:application_status, 'completed')
         expect(page).to have_select(filter_field, selected: 'Completed')
+        expect(page).to have_content('There are no results that match the search criteria')
       end
     end
 


### PR DESCRIPTION
## Description of change

Treat "superseded" applications like "send_back".
Show no results when completed filter is selected.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-158

## Notes for reviewer

When a sent back application is resubmitted by a provider the original application is marked as superseded in the datastore. 

Currently (and incorrectly) review shows these applications as “superseded” and does not return them in search results when filtering with status “Sent back to provider”.

Requirements for Review: 

Superseded applications show their status as “Sent back to provider”.

Superseded applications are included in results when searching with status filter “Sent back to the provider”.

## Screenshots of changes (if applicable)

### Before changes:

<img width="556" alt="Screenshot 2023-02-02 at 12 59 48" src="https://user-images.githubusercontent.com/34935/216332725-5ad93683-7c56-403b-9465-2b049946e034.png">
<img width="1039" alt="Screenshot 2023-02-02 at 12 59 40" src="https://user-images.githubusercontent.com/34935/216332728-3b8cfcf2-5fe4-42f8-b01d-1ce2bf354992.png">

### After changes:


## How to manually test the feature
