### PR TITLE
Move count above mini reports and reduce padding

### DIFF
--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -2,21 +2,21 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-xl">
-        <%= t ".#{action_name}_heading" %>
-      </h1>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">
+      <%= t ".#{action_name}_heading" %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-body">
+      <%= t('.total', count: @search.total) %>
+    </div>
   </div>
 </div>
 
 <%= render Reporting::DailyCount.new(filter: @search.filter)  %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <h2 class="govuk-heading-s">
-      <%= t('.total', count: @search.total) %>
-    </h2>
-  </div>
-</div>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">


### PR DESCRIPTION
## Description of change

Carol mentioned that the count is at the top of the mini report and not bold in the the design

## Link to relevant ticket
n/a

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1195" alt="Screenshot 2023-02-08 at 15 04 12" src="https://user-images.githubusercontent.com/13377553/217567937-58f897f3-938d-4373-af2e-5c6e1a6ad8fe.png">

### After changes:
<img width="1271" alt="Screenshot 2023-02-08 at 15 01 55" src="https://user-images.githubusercontent.com/13377553/217567918-4186a58d-c91a-47fd-a140-0eaf2c06f61c.png">

## How to manually test the feature
