### PR TITLE
Prepare Review to use datastore JWT auth

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,7 +7,11 @@
 DATABASE_URL=postgresql://postgres@localhost/laa-review-criminal-legal-aid
 
 DEVELOPMENT_HOST=laa-review-criminal-legal-aid.test
-CRIME_APPLY_API_URL=https://laa-apply-for-criminal-legal-aid.test/api/
+
+# Local datastore endpoint
+DATASTORE_API_ROOT=http://localhost:3003
+# Local datastore API shared secret for JWT auth
+DATASTORE_API_AUTH_SECRET=
 
 # speak to the team to get these 
 # OMNIAUTH_AZURE_CLIENT_ID:

--- a/.env.test
+++ b/.env.test
@@ -5,7 +5,7 @@
 # To adapt to your local setup, copy this file to `.env.test.local` to make changes
 #
 DATABASE_URL=postgresql://postgres@localhost/laa-review-criminal-legal-aid-test
-CRIME_APPLY_API_URL=https://crime-apply-api.test/api/
+
 OMNIAUTH_AZURE_CLIENT_ID='TestAzureClientID'
 OMNIAUTH_AZURE_CLIENT_SECRET='TestAzureClientSecret'
 OMNIAUTH_AZURE_TENANT_ID='TestAzureTenantID'

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,11 @@ gem 'laa-criminal-applications-datastore-api-client',
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas'
 
+# Gem is not published to rubygems. If published, then we will not need this,
+# as it can be loaded via the `datastore-api-client` gem instead
+gem 'simple-jwt-auth',
+    github: 'ministryofjustice/simple-jwt-auth'
+
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
-  revision: f0d5d0bb3a56e9708569d95513f99294586d634a
+  revision: d6926f1b19a8642022a68fb84659e23f8371eae1
   specs:
     laa-criminal-applications-datastore-api-client (0.0.1)
       faraday (~> 2.6)
@@ -12,6 +12,14 @@ GIT
     laa-criminal-legal-aid-schemas (0.1.1)
       dry-struct
       json-schema (~> 3.0.0)
+
+GIT
+  remote: https://github.com/ministryofjustice/simple-jwt-auth.git
+  revision: 174ad91cd1d9ba13e990ab98be2e9db21dc8b625
+  specs:
+    simple-jwt-auth (0.0.1)
+      json
+      jwt
 
 GEM
   remote: https://rubygems.org/
@@ -495,6 +503,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-rails
   sentry-ruby
+  simple-jwt-auth!
   simplecov
   sprockets-rails
   turbo-rails

--- a/config/initializers/datastore_client.rb
+++ b/config/initializers/datastore_client.rb
@@ -4,6 +4,8 @@ DatastoreApi.configure do |config|
   config.api_root = ENV.fetch('DATASTORE_API_ROOT', nil)
   config.api_path = '/api/v2'
 
+  # To be replaced with `jwt` auth soon
+  config.auth_type = :basic
   config.basic_auth_username = ENV.fetch('DATASTORE_AUTH_USERNAME', nil)
   config.basic_auth_password = ENV.fetch('DATASTORE_AUTH_PASSWORD', nil)
 

--- a/config/initializers/simple_jwt_auth.rb
+++ b/config/initializers/simple_jwt_auth.rb
@@ -1,0 +1,12 @@
+require 'simple_jwt_auth'
+
+# If DatastoreApi `auth_type` is set to `jwt` then this
+# configuration will be used to generate the auth tokens
+#
+SimpleJwtAuth.configure do |config|
+  config.issuer = 'crime-review'
+
+  config.secrets_config = {
+    config.issuer => ENV.fetch('DATASTORE_API_AUTH_SECRET', nil)
+  }
+end

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -67,3 +67,8 @@ spec:
               secretKeyRef:
                 name: rds-instance
                 key: url
+          - name: DATASTORE_API_AUTH_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: datastore-api-auth-secret
+                key: secret


### PR DESCRIPTION
## Description of change
Merging this will not enable JWT or change any functionality on Review, as it is not enabled yet (to enable, change `config.auth_type = :jwt`).

Once enabled, the datastore API client will make use of a little middleware introduced in the `simple-jwt-auth` gem to generate and send a JWT bearer token.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-273

## Notes for reviewer
If wanted to test locally, a corresponding PR has been raised in the datastore repo, in order to have an end to end, locally-testable demo.