### PR TITLE
Crimre 166 use event stream for processed report

### DIFF
--- a/app/models/application_history.rb
+++ b/app/models/application_history.rb
@@ -36,6 +36,7 @@ class ApplicationHistory < ApplicationStruct
       application.provider_details.legal_rep_first_name,
       application.provider_details.legal_rep_last_name
     ].join ' '
+
     ApplicationHistoryItem.new(
       user_id: nil,
       user_name: provider_name,

--- a/spec/models/reporting/processed_report_spec.rb
+++ b/spec/models/reporting/processed_report_spec.rb
@@ -7,19 +7,19 @@ describe Reporting::ProcessedReport do
   subject(:report) { described_class.new }
 
   describe '#table' do
-    it 'returns a table report data' do
+    it 'returns a table of report data' do
       expect(report.table).to be_a Reporting::Table
     end
 
-    it 'includes column headers' do
+    it 'has column headers' do
       expect(report.table.headers).to eq(['Closed on', 'Closed applications'])
     end
 
-    it 'includes 3 rows' do
+    it '3 rows of data' do
       expect(report.table.rows.size).to eq(3)
     end
 
-    it 'includes row headers' do
+    it 'row headers with "Today", "Yesterday", and "Day before yesterday"' do
       expect(report.table.rows.map(&:first).map(&:content)).to eq(['Today', 'Yesterday', 'Day before yesterday'])
     end
 
@@ -31,27 +31,24 @@ describe Reporting::ProcessedReport do
 
         # Yesterday
         travel_to Time.zone.now.yesterday
-
         event_store.publish(Reviewing::Completed.new)
 
         # The day before yesterday
         travel_to Time.zone.now.yesterday
-
-        event_store.publish(Reviewing::Completed.new)
+        event_store.publish(Reviewing::SentBack.new)
 
         # The day before, the day before yesterday
         travel_to Time.zone.now.yesterday
-
         event_store.publish(Reviewing::Completed.new)
 
         # Today
         travel_back
-
+        event_store.publish(Reviewing::ApplicationReceived.new)
         event_store.publish(Reviewing::Completed.new)
         event_store.publish(Reviewing::SentBack.new)
       end
 
-      it 'includes a count of completing events for each day' do
+      it 'includes a count of closing events for each day' do
         expect(data).to eq([2, 1, 1])
       end
     end

--- a/spec/models/reporting/processed_report_spec.rb
+++ b/spec/models/reporting/processed_report_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end
+
+describe Reporting::ProcessedReport do
+  subject(:report) { described_class.new }
+
+  describe '#table' do
+    it 'returns a table report data' do
+      expect(report.table).to be_a Reporting::Table
+    end
+
+    it 'includes column headers' do
+      expect(report.table.headers).to eq(['Closed on', 'Closed applications'])
+    end
+
+    it 'includes 3 rows' do
+      expect(report.table.rows.size).to eq(3)
+    end
+
+    it 'includes row headers' do
+      expect(report.table.rows.map(&:first).map(&:content)).to eq(['Today', 'Yesterday', 'Day before yesterday'])
+    end
+
+    describe 'data' do
+      subject(:data) { report.table.rows.map(&:last).map(&:content) }
+
+      before do
+        event_store = Rails.configuration.event_store
+
+        # Yesterday
+        travel_to Time.zone.now.yesterday
+
+        event_store.publish(Reviewing::Completed.new)
+
+        # The day before yesterday
+        travel_to Time.zone.now.yesterday
+
+        event_store.publish(Reviewing::Completed.new)
+
+        # The day before, the day before yesterday
+        travel_to Time.zone.now.yesterday
+
+        event_store.publish(Reviewing::Completed.new)
+
+        # Today
+        travel_back
+
+        event_store.publish(Reviewing::Completed.new)
+        event_store.publish(Reviewing::SentBack.new)
+      end
+
+      it 'includes a count of completing events for each day' do
+        expect(data).to eq([2, 1, 1])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Refactor processed reports to use event data.

## Link to relevant ticket

[CRIMRE-166](https://dsdmoj.atlassian.net/browse/CRIMRE-166)

## Notes for reviewer

Refactor to use review event data instead of datastore data for these counts. A similar refactor can be done on the workload report when we start recording ApplicationReceived events.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-166]: https://dsdmoj.atlassian.net/browse/CRIMRE-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ