### PR TITLE
Bump datastore api client gem and enable JWT auth

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -11,4 +11,4 @@ OMNIAUTH_AZURE_CLIENT_SECRET='TestAzureClientSecret'
 OMNIAUTH_AZURE_TENANT_ID='TestAzureTenantID'
 
 DATASTORE_API_ROOT=https://datastore-api-stub.test
-
+DATASTORE_API_AUTH_SECRET=foobar

--- a/Gemfile
+++ b/Gemfile
@@ -20,11 +20,6 @@ gem 'laa-criminal-applications-datastore-api-client',
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas'
 
-# Gem is not published to rubygems. If published, then we will not need this,
-# as it can be loaded via the `datastore-api-client` gem instead
-gem 'simple-jwt-auth',
-    github: 'ministryofjustice/simple-jwt-auth'
-
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
-  revision: d6926f1b19a8642022a68fb84659e23f8371eae1
+  revision: 5827572079190de784d36761d39cbcbc6f8a95ea
   specs:
     laa-criminal-applications-datastore-api-client (0.0.1)
       faraday (~> 2.6)
+      moj-simple-jwt-auth (= 0.0.1)
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
@@ -12,14 +13,6 @@ GIT
     laa-criminal-legal-aid-schemas (0.1.1)
       dry-struct
       json-schema (~> 3.0.0)
-
-GIT
-  remote: https://github.com/ministryofjustice/simple-jwt-auth.git
-  revision: 174ad91cd1d9ba13e990ab98be2e9db21dc8b625
-  specs:
-    simple-jwt-auth (0.0.1)
-      json
-      jwt
 
 GEM
   remote: https://rubygems.org/
@@ -228,6 +221,9 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
     minitest (5.17.0)
+    moj-simple-jwt-auth (0.0.1)
+      json
+      jwt
     msgpack (1.6.0)
     multi_xml (0.6.0)
     net-imap (0.3.4)
@@ -503,7 +499,6 @@ DEPENDENCIES
   selenium-webdriver
   sentry-rails
   sentry-ruby
-  simple-jwt-auth!
   simplecov
   sprockets-rails
   turbo-rails

--- a/config/initializers/datastore_client.rb
+++ b/config/initializers/datastore_client.rb
@@ -4,10 +4,12 @@ DatastoreApi.configure do |config|
   config.api_root = ENV.fetch('DATASTORE_API_ROOT', nil)
   config.api_path = '/api/v2'
 
-  # To be replaced with `jwt` auth soon
-  config.auth_type = :basic
-  config.basic_auth_username = ENV.fetch('DATASTORE_AUTH_USERNAME', nil)
-  config.basic_auth_password = ENV.fetch('DATASTORE_AUTH_PASSWORD', nil)
+  config.auth_type = :jwt
+
+  # Keeping this for some time in case we need to revert to
+  # http basic auth (`config.auth_type = :basic`)
+  # config.basic_auth_username = ENV.fetch('DATASTORE_AUTH_USERNAME', nil)
+  # config.basic_auth_password = ENV.fetch('DATASTORE_AUTH_PASSWORD', nil)
 
   config.logger = Logger.new(STDOUT)
   config.logger.level = Logger::WARN


### PR DESCRIPTION
## Description of change
The `moj-simple-jwt-auth` gem is now included in the `datastore-api-client` gem, so we don't have to add it explicitly to the Gemfile.

**NOTE: this PR once merged will enable JWT authentication against the Datastore. Corresponding PRs will be raised in Review and in the Datastore.
Keeping all in place for a quick revert to http basic auth if needed.**

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-277
