### PR TITLE
Set a more sensible default for ENV variable

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -11,7 +11,9 @@ DEVELOPMENT_HOST=laa-review-criminal-legal-aid.test
 # Local datastore endpoint
 DATASTORE_API_ROOT=http://localhost:3003
 # Local datastore API shared secret for JWT auth
-DATASTORE_API_AUTH_SECRET=
+# Value does not matter, as long as it is not blank or nil,
+# and the datastore has the same env value
+DATASTORE_API_AUTH_SECRET=foobar
 
 # speak to the team to get these 
 # OMNIAUTH_AZURE_CLIENT_ID:


### PR DESCRIPTION
## Description of change
With openssl >= 3.0.0 you need to have something in those secrets. Nil or empty string will produce an error.

With openssl < 3.0.0 a nil value will blow up but funnily enough not an empty string.

To avoid confusion and edge cases with the openssl version installed in each system, we set a default dummy value, so developers don't need to set their own in their `.local` files.
