### PR TITLE
CRIMRE-149 Mark application as complete

### DIFF
--- a/app/aggregates/reviewing/commands/complete.rb
+++ b/app/aggregates/reviewing/commands/complete.rb
@@ -4,8 +4,16 @@ module Reviewing
     attribute :user_id, Types::Uuid
 
     def call
-      with_review do |review|
-        review.complete(application_id:, user_id:)
+      ActiveRecord::Base.transaction do
+        with_review do |review|
+          review.complete(application_id:, user_id:)
+        end
+
+        DatastoreApi::Requests::UpdateApplication.new(
+          application_id: application_id,
+          payload: true,
+          member: :complete
+        ).call
       end
     end
   end

--- a/app/views/crime_applications/show.html.erb
+++ b/app/views/crime_applications/show.html.erb
@@ -20,8 +20,8 @@
     <% if @crime_application.reviewable_by?(current_user_id) %>
       <div class="govuk-button-group govuk-!-margin-bottom-6">
         <%= button_to t('calls_to_action.mark_complete'),
-                      new_crime_application_return_path(@crime_application),
-                      method: :post,
+                      complete_crime_application_path(@crime_application),
+                      method: :put,
                       class: 'govuk-button govuk-button' %>
         <%= button_to t('calls_to_action.send_back'),
                       new_crime_application_return_path(@crime_application),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,12 +21,14 @@ en:
       assigned_to_self: This application has been assigned to you
       unassigned_from_self: The application has been removed from your list
       sent_back: The application has been sent back to the provider
+      completed: The application has been marked as complete
     important:
       title: Important
       state_has_changed: This application has already been assigned to someone else.
       no_next_to_assign: There are no new applications to be reviewed at this time. Please try again later.
       already_sent_back: This application has already been sent back to the provider.
-      cannot_send_back_when_completed: This application has already been completed.
+      already_completed: This application has already been marked as complete.
+      cannot_send_back_when_completed: This application has already been marked as complete.
 
   sessions:
     new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     get :open, on: :collection
     get :closed, on: :collection
     get :history, on: :member
+    put :complete, on: :member
     resource :reassign, only: [:new, :create]
     resource :return, only: [:new, :create]
   end

--- a/spec/aggregates/reviewing/complete_spec.rb
+++ b/spec/aggregates/reviewing/complete_spec.rb
@@ -8,7 +8,24 @@ RSpec.describe Reviewing::Complete do
   include_context 'with review'
 
   before do
+    allow(DatastoreApi::Requests::UpdateApplication).to receive(:new).with(
+      {
+        application_id: application_id,
+        payload: true,
+        member: :complete
+      }
+    ).and_return(return_request)
+
     Reviewing::ReceiveApplication.new(application_id:).call
+  end
+
+  let(:return_request) do
+    instance_double(
+      DatastoreApi::Requests::UpdateApplication,
+      call: JSON.parse(
+        LaaCrimeSchemas.fixture(1.0, name: 'application_returned').read
+      )
+    )
   end
 
   let(:user_id) { SecureRandom.uuid }

--- a/spec/system/reviewing/mark_application_as_complete_spec.rb
+++ b/spec/system/reviewing/mark_application_as_complete_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe 'Marking an application as complete' do
 
   let(:crime_application_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
 
-  # let(:complete_path) do
-  #   complete_crime_application_path(crime_application_id)
-  # end
-
   let(:complete_cta) { 'Mark as complete' }
 
   before do
@@ -19,6 +15,9 @@ RSpec.describe 'Marking an application as complete' do
     let(:assignee_id) { User.find_by(auth_oid: current_user_auth_oid).id }
 
     before do
+      allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
+        .and_return(instance_double(DatastoreApi::Requests::UpdateApplication, call: {}))
+
       Assigning::AssignToUser.new(
         assignment_id: crime_application_id,
         user_id: assignee_id,
@@ -42,7 +41,7 @@ RSpec.describe 'Marking an application as complete' do
 
     it 'shows success flash message' do
       click_button(complete_cta)
-      expect(page).to have_content('The application has marked as complete')
+      expect(page).to have_content('The application has been marked as complete')
     end
 
     context 'with errors Reviewing::' do

--- a/spec/system/reviewing/mark_application_as_complete_spec.rb
+++ b/spec/system/reviewing/mark_application_as_complete_spec.rb
@@ -1,0 +1,71 @@
+
+require 'rails_helper'
+
+RSpec.describe 'Marking an application as complete' do
+  include_context 'with stubbed search'
+
+  let(:crime_application_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
+
+  let(:new_return_path) do
+    new_crime_application_return_path(crime_application_id)
+  end
+
+  let(:mark_application_as_complete) { 'Mark as complete' }
+
+  before do
+    visit '/'
+  end
+
+  context 'when assigned to the application' do
+    let(:assignee_id) { User.find_by(auth_oid: current_user_auth_oid).id }
+
+    before do
+      Assigning::AssignToUser.new(
+        assignment_id: crime_application_id,
+        user_id: assignee_id,
+        to_whom_id: assignee_id
+      ).call
+
+      click_on 'Your list'
+      click_on 'Kit Pound'
+    end
+
+    it 'the "Mark as complete" button is visable and accessible' do
+      expect { click_button(send_back_cta) }.to change { page.current_path }
+        .from(crime_application_path(crime_application_id)).to(
+          new_return_path
+        )
+    end
+
+    # describe 'clicking the link' do
+    #   descibe 'when successful' do
+      #   before do
+      #     click link
+      #   end
+    #
+      #   it 'should flash a success message to the user' do
+      #      # expect page to have correct flash message
+      #   end
+      #
+      #   it 'should reflect the status change on the application show page' do
+      #   end
+    #   end
+    #
+    #   descibe 'when unsuccessful' do
+      #   before do
+      #     click link
+      #   end
+      #   it 'should flash an unsuccessful message to the user' do
+      #      # expect page to have correct flash message
+      #   end
+      #
+      #   it 'should not change the status on the application show page' do
+      #   end
+    #   end
+    # end
+
+    # context 'with errors Closing::' do
+    #   ... closing specific errors
+    # end
+  end
+end

--- a/spec/system/reviewing/send_back_to_provider_spec.rb
+++ b/spec/system/reviewing/send_back_to_provider_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe 'Send an application back to the provider' do
 
     describe 'CannotSendBackWhenCompleted' do
       let(:error_class) { Reviewing::CannotSendBackWhenCompleted }
-      let(:message) { 'This application has already been completed' }
+      let(:message) { 'This application has already been marked as complete' }
 
       it 'notifies that the application has already been completed' do
         expect(page).to have_content message


### PR DESCRIPTION
## Description of change
Mark as complete triggers a call to the datastore to update the application status
User is redirected to Your list if successful with a success flash message shown
User is left on current page if unsuccessful with an unsuccessful flash message shown

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-149

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
