### PR TITLE
CRIMRE-151 Show completed on the closed tab.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 46dd417bbb3a30d5b8ecdd0652e6f0d7a0dd86b2
+  revision: 79de69687adb7f596206e3835f5b77ba867a99ea
   specs:
     laa-criminal-legal-aid-schemas (0.1.1)
       dry-struct
@@ -123,8 +123,6 @@ GEM
       railties (>= 6.0.0)
     date (3.3.3)
     debug (1.7.1)
-      irb (>= 1.5.0)
-      reline (>= 0.3.1)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dotenv (2.8.1)
@@ -193,9 +191,6 @@ GEM
     importmap-rails (1.1.5)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
-    io-console (0.6.0)
-    irb (1.6.2)
-      reline (>= 0.3.0)
     json (2.6.3)
     json-jwt (1.16.1)
       activesupport (>= 4.2)
@@ -332,8 +327,6 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.6.1)
-    reline (0.3.2)
-      io-console (~> 0.5)
     rexml (3.2.5)
     rspec-core (3.12.0)
       rspec-support (~> 3.12.0)

--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -13,7 +13,7 @@ class CrimeApplicationsController < ApplicationController
 
   def closed
     set_search(
-      filter: ApplicationSearchFilter.new(application_status: 'sent_back'),
+      filter: ApplicationSearchFilter.new(application_status: 'closed'),
       sorting: Sorting.new(sort_by: 'reviewed_at', sort_direction: 'descending')
     )
 

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -10,17 +10,28 @@ module Types
   DateTime = DateTime | JSON::DateTime
 
   #
-  # Map of review application statuses to LaaCrimeSchemas::Types:APPLICATION_STATUSES
+  # Map of review status groups to LaaCrimeSchemas::Types:REVIEW_APPLICATION_STATUSES
   #
-  REVIEW_APPLICATION_STATUSES = {
-    'open' => [Types::ApplicationStatus['submitted']],
-    'completed' => ['completed'], # NOTE: completed status does no yet exist in datastore/schema
-    'sent_back' => [Types::ApplicationStatus['returned'], Types::ApplicationStatus['superseded']],
-    'all' => APPLICATION_STATUSES
+  REVIEW_STATUS_GROUPS = {
+    'open' => [
+      Types::ReviewApplicationStatus['application_received'],
+      Types::ReviewApplicationStatus['ready_for_assessment']
+    ],
+    'closed' => [
+      Types::ReviewApplicationStatus['assessment_completed'],
+      Types::ReviewApplicationStatus['returned_to_provider']
+    ],
+    'completed' => [
+      Types::ReviewApplicationStatus['assessment_completed']
+    ],
+    'sent_back' => [
+      Types::ReviewApplicationStatus['returned_to_provider']
+    ],
+    'all' => REVIEW_APPLICATION_STATUSES
   }.freeze
 
-  ReviewApplicationStatus = String.default('open'.freeze).enum(
-    *REVIEW_APPLICATION_STATUSES.keys
+  ReviewStatusGroup = String.default('open'.freeze).enum(
+    *REVIEW_STATUS_GROUPS.keys
   )
 
   USER_ROLES = %w[

--- a/app/models/application_search_filter.rb
+++ b/app/models/application_search_filter.rb
@@ -1,6 +1,6 @@
 class ApplicationSearchFilter < ApplicationStruct
-  attribute? :assigned_status, Types::Params::Nil | Types::AssignedStatus | Types::Uuid
-  attribute? :application_status, Types::ReviewApplicationStatus
+  attribute? :assigned_status, Types::AssignedStatus | Types::Uuid
+  attribute? :application_status, Types::ReviewStatusGroup
   attribute? :search_text, Types::Params::Nil | Types::Params::String
   attribute? :submitted_after, Types::Params::Nil | Types::Params::Date
   attribute? :submitted_before, Types::Params::Nil | Types::Params::Date
@@ -27,7 +27,7 @@ class ApplicationSearchFilter < ApplicationStruct
   # Includes 'Open', 'Completed', 'Sent back to provider' or 'All applications'
   # Values can be "open", "completed", "sent_back", "all"
   def application_status_options
-    Types::REVIEW_APPLICATION_STATUSES.keys.map do |status|
+    Types::REVIEW_STATUS_GROUPS.keys.map do |status|
       [I18n.t(status, scope: 'values.review_status'), status]
     end
   end
@@ -44,7 +44,7 @@ class ApplicationSearchFilter < ApplicationStruct
       applicant_date_of_birth:,
       application_id_in:,
       application_id_not_in:,
-      status:,
+      review_status:,
       submitted_after:,
       submitted_before:,
       search_text:
@@ -75,11 +75,11 @@ class ApplicationSearchFilter < ApplicationStruct
   end
 
   #
-  # returns the value of the DatastoreApi Search "status" constraint
+  # returns the value of the DatastoreApi Search "review_status" constraint
   # according to the #application_status
   #
-  def status
-    Types::REVIEW_APPLICATION_STATUSES.fetch(application_status)
+  def review_status
+    Types::REVIEW_STATUS_GROUPS.fetch(application_status)
   end
 
   #

--- a/app/models/reporting/workload_report.rb
+++ b/app/models/reporting/workload_report.rb
@@ -48,7 +48,7 @@ module Reporting
     end
 
     def closed_applications_by_age
-      filter = ApplicationSearchFilter.new(application_status: 'sent_back')
+      filter = ApplicationSearchFilter.new(application_status: 'closed')
       counts = DailyCount.new(filter:, number_of_days:).counts
       counts.map { |count| Cell.new(count) }
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,6 +147,7 @@ en:
       open: Open
       sent_back: Sent back to provider
       completed: Completed
+      closed: Closed
       all: All applications
     assigned_status:
       assigned: All assigned

--- a/spec/models/application_search_filter_spec.rb
+++ b/spec/models/application_search_filter_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ApplicationSearchFilter do
         applicant_date_of_birth: nil,
         application_id_in: [],
         application_id_not_in: [],
-        status: ['submitted'],
+        review_status: %w[application_received ready_for_assessment],
         submitted_after: nil,
         submitted_before: nil,
         search_text: nil
@@ -87,7 +87,7 @@ RSpec.describe ApplicationSearchFilter do
           submitted_before: Date.parse('2022-12-21'),
           search_text: 'David 100003',
           application_id_not_in: [],
-          status: %w[returned superseded]
+          review_status: %w[returned_to_provider]
         }
       end
 

--- a/spec/system/searching/filter_by_status_spec.rb
+++ b/spec/system/searching/filter_by_status_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Search applications status filter' do
   end
 
   it "can choose from 'Open', 'Completed', 'Sent back to provider' or 'All applications'" do
-    choices = ['Open', 'Completed', 'Sent back to provider', 'All applications']
+    choices = ['Open', 'Closed', 'Completed', 'Sent back to provider', 'All applications']
     expect(page).to have_select(filter_field, options: choices)
   end
 


### PR DESCRIPTION
## Description of change

Show completed applications on the closed tab.
Include completed in the status search filter.
Use review_status instead of status for datastore queries.

## Link to relevant ticket
[CRIMRE-151](https://dsdmoj.atlassian.net/browse/CRIMRE-151)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="564" alt="Screenshot 2023-02-17 at 10 30 27" src="https://user-images.githubusercontent.com/34935/219619822-8c2b7d23-5024-4832-aec5-1b0f676fc194.png">
<img width="976" alt="Screenshot 2023-02-17 at 10 30 03" src="https://user-images.githubusercontent.com/34935/219619830-914800e9-8f85-4b0c-a3c8-6bf2759c62ce.png">

## How to manually test the feature


[CRIMRE-151]: https://dsdmoj.atlassian.net/browse/CRIMRE-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ