### PR TITLE
CRIMRE-177 Spike sns callback for submission events

### DIFF
--- a/app/aggregates/reviewing/commands/receive_application.rb
+++ b/app/aggregates/reviewing/commands/receive_application.rb
@@ -1,10 +1,11 @@
 module Reviewing
   class ReceiveApplication < Command
     attribute :application_id, Types::Uuid
+    attribute? :correlation_id, Types::Uuid.optional
 
     def call
       with_review do |review|
-        review.receive_application(application_id:)
+        review.receive_application(application_id:, correlation_id:)
       end
     end
   end

--- a/app/aggregates/reviewing/review.rb
+++ b/app/aggregates/reviewing/review.rb
@@ -14,10 +14,13 @@ module Reviewing
 
     alias application_id id
 
-    def receive_application(application_id:)
+    def receive_application(application_id:, correlation_id: nil)
       raise AlreadyReceived unless @state == :submitted
 
+      causation_id = correlation_id
+
       apply ApplicationReceived.new(
+        metadata: { correlation_id:, causation_id: },
         data: { application_id: }
       )
     end

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,0 +1,27 @@
+module Api
+  class EventsController < ActionController::API
+    #
+    # TODO extract to middleware if we go down this route....
+    # TODO: verify message
+    #
+    def create
+      #
+      # Only care about Notifcations for now
+      # return 200 for other types in case SNS needs it to move on on
+      #
+      type = request.headers.fetch('x-amz-sns-message-type')
+      head :ok and return unless type == 'Notification'
+
+      application_id = JSON.parse(params['Message'])['id']
+      message_id = request.headers.fetch('x-amz-sns-message-id')
+      correlation_id = message_id
+
+      Reviewing::ReceiveApplication.call(application_id:, correlation_id:)
+
+      head :created
+    rescue Reviewing::AlreadyReceived
+      # return okay so SNS can move on if already recieved.
+      head :ok
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,10 @@ Rails.application.routes.draw do
     post :next_application, on: :collection
   end
 
+  namespace :api do
+    resources :events, only: [:create]
+  end
+
   mount RailsEventStore::Browser => "/event_browser" if Rails.env.development?
   root 'assigned_applications#index'
 end

--- a/spec/requests/api/events_spec.rb
+++ b/spec/requests/api/events_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::Events' do
+  let(:sns_message_id) { SecureRandom.uuid }
+
+  let(:headers) do
+    {
+      'x-amz-sns-message-type' => 'Notification',
+      'x-amz-sns-message-id' => sns_message_id
+    }
+  end
+
+  let(:application_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
+
+  let(:notification_body) do
+    {
+      'Type' => 'Notification',
+      'MessageId' => sns_message_id,
+      'TopicArn' => 'arn:aws:sns:us-west-2:123456789012:MyTopic',
+      'Subject' => 'apply.submission',
+      'Message' => LaaCrimeSchemas.fixture(1.0).read,
+      'Timestamp' => '2012-05-02T00:54:06.655Z',
+      'SignatureVersion' => '1',
+      'Signature' => 'EXAMPLEw6JRN...',
+      'SigningCertURL' => 'https://sns.us-west-2.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem',
+      'UnsubscribeURL' => 'https://sns.us-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-west-2:123456789012:MyTopic:c9135db0-26c4-47ec-8998-413945fb5a96'
+    }
+  end
+
+  def do_request
+    post('/api/events', params: notification_body, headers: headers)
+  end
+
+  def review
+    Reviewing::LoadReview.call(application_id:)
+  end
+
+  describe 'SNS Nofification callback' do
+    let(:review_state) { -> { Reviewing::LoadReview.call(application_id:).state } }
+
+    it 'creates an ApplicationReceived event' do
+      expect { do_request }.to change { review.state }.from(:submitted).to(:open)
+
+      expect(response).to have_http_status :created
+    end
+
+    it 'idempotent' do
+      do_request
+      expect { do_request }.not_to(change { review.state })
+
+      expect(response).to have_http_status :ok
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Add a test endpoint for 'apply.submission' events from SNS.

## Link to relevant ticket
[CRIMRE-177](https://dsdmoj.atlassian.net/browse/CRIMRE-177)

## Notes for reviewer

Very, very spikey. Experiment to see what, if any, messages we get when we add an endpoint to an SNS.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-177]: https://dsdmoj.atlassian.net/browse/CRIMRE-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ