### PR TITLE
Show an empty list when user does not have assignments

### DIFF
--- a/app/controllers/assigned_applications_controller.rb
+++ b/app/controllers/assigned_applications_controller.rb
@@ -1,5 +1,7 @@
 class AssignedApplicationsController < ApplicationController
   def index
+    return unless assignments_count.positive?
+
     set_search(
       filter: ApplicationSearchFilter.new(assigned_status: current_user_id)
     )

--- a/app/views/assigned_applications/index.html.erb
+++ b/app/views/assigned_applications/index.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full govuk-!-margin-bottom-1">
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-1"><%= t '.heading' %></h1>
-    <p><%= t '.your_assignments', count: @search.total %></p>
+    <p><%= t '.your_assignments', count: assignments_count %></p>
   </div>
 </div>
 
@@ -23,7 +23,7 @@
   </div>
 </div>
 
-<% unless @search.results.empty? %>
+<% if assignments_count > 0 %>
   <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <table class="govuk-table app-dashboard-table">

--- a/spec/system/assigning/viewing_your_assigned_applications_spec.rb
+++ b/spec/system/assigning/viewing_your_assigned_applications_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe 'Viewing your assigned application' do
     end
   end
 
+  context 'when no application are assigned' do
+    before do
+      visit '/'
+    end
+
+    it 'shows how many assignments' do
+      expect(page).to have_content '0 saved applications'
+      expect(page).to have_content 'Your list (0)'
+    end
+  end
+
   context 'when one application is assigned' do
     let(:stubbed_search_results) do
       [
@@ -112,7 +123,7 @@ RSpec.describe 'Viewing your assigned application' do
 
     it 'shows the assignment in the counts' do
       expect(page).to have_content 'Your list (1)'
-      expect(page).to have_content '0 saved application'
+      expect(page).to have_content '1 saved application'
     end
   end
 end

--- a/spec/system/closed_applications_dashboard_spec.rb
+++ b/spec/system/closed_applications_dashboard_spec.rb
@@ -36,7 +36,10 @@ RSpec.describe 'Closed Applications Dashboard' do
   end
 
   it 'shows only closed applications' do
-    assert_api_searched_with_filter({ status: 'sent_back' })
+    assert_api_searched_with_filter(
+      { application_status: 'closed' },
+      sorting: Sorting.new(sort_by: 'reviewed_at', sort_direction: 'descending')
+    )
   end
 
   it 'includes the page title' do

--- a/spec/system/searching/filter_by_status_spec.rb
+++ b/spec/system/searching/filter_by_status_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe 'Search applications status filter' do
   describe 'search by:' do
     describe 'default' do
       it 'filters by status "open"' do
-        assert_api_searched_with_filter(:application_status, 'open')
         expect(page).to have_select(filter_field, selected: 'Open')
       end
     end


### PR DESCRIPTION
## Description of change

Fixes a bug which caused all open applications to be listed on 'Your list' if the user didn't have any assignments.

## Link to relevant ticket
https://github.com/ministryofjustice/laa-review-criminal-legal-aid/issues/131

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
