### PR TITLE
CRIMRE-177-handle-all-potential-message-format

### DIFF
--- a/spec/requests/api/events_spec.rb
+++ b/spec/requests/api/events_spec.rb
@@ -50,6 +50,47 @@ RSpec.describe 'Api::Events' do
     end
   end
 
+  describe 'SNS Nofification callback with raw_message_delivery' do
+    let(:headers) do
+      {
+        'x-amz-sns-message-type' => 'Notification',
+        'x-amz-sns-message-id' => sns_message_id,
+        'x-amz-sns-rawdelivery' => 'true'
+      }
+    end
+
+    let(:body) { LaaCrimeSchemas.fixture(1.0).read }
+
+    it 'creates an ApplicationReceived event' do
+      expect { do_request }.to change { review.state }.from(:submitted).to(:open)
+
+      expect(response).to have_http_status :created
+    end
+  end
+
+  describe 'SNS Nofification callback with raw_message_delivery and message object' do
+    let(:headers) do
+      {
+        'x-amz-sns-message-type' => 'Notification',
+        'x-amz-sns-message-id' => sns_message_id,
+        'x-amz-sns-rawdelivery' => 'true'
+      }
+    end
+
+    let(:body) do
+      {
+        data: JSON.parse(LaaCrimeSchemas.fixture(1.0).read),
+        event_name: 'apply.submitted'
+      }.to_json
+    end
+
+    it 'creates an ApplicationReceived event' do
+      expect { do_request }.to change { review.state }.from(:submitted).to(:open)
+
+      expect(response).to have_http_status :created
+    end
+  end
+
   describe 'SNS Subscription Confirmation' do
     let(:headers) do
       {


### PR DESCRIPTION
## Description of change
Handle all potential SNS message formats.

## Link to relevant ticket

## Notes for reviewer

SNS currently uses raw message format which results in the callback body being the crime application json.
This  pr adds support for this, as well as the aws default for standard message format.

It also adds support for the proposed message format which uses raw format but as an object as follows:

```ruby
  {event_name: "apply.submission", data: {id: application_id, ....}}
```

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
