### PR TITLE
Show application_received events in history

### DIFF
--- a/app/aggregates/reviewing/commands/load_review.rb
+++ b/app/aggregates/reviewing/commands/load_review.rb
@@ -1,9 +1,15 @@
 module Reviewing
   class LoadReview < Command
     def call
-      repository.load(
-        Review.new(application_id), stream_name
-      )
+      review = repository.load(Review.new(application_id), stream_name)
+
+      # Ensure applications are received before being returned
+      if review.state.nil?
+        review.receive_application(application_id:)
+        repository.store(review, stream_name)
+      end
+
+      review
     end
   end
 end

--- a/app/aggregates/reviewing/errors.rb
+++ b/app/aggregates/reviewing/errors.rb
@@ -2,6 +2,9 @@ module Reviewing
   class AlreadyReceived < StandardError
   end
 
+  class NotReceived < StandardError
+  end
+
   class AlreadySentBack < StandardError
   end
 

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -41,15 +41,15 @@ module Api
       head :ok
     end
 
-    #
-    # TODO: simplify when notification message format decided.
-    #
     def application_id
+      message.dig('data', 'id')
+    end
+
+    def message
       if request.headers['x-amz-sns-rawdelivery'] == 'true'
-        data = request_body.fetch('data', request_body)
-        data.fetch('id')
+        request_body
       else
-        JSON.parse(request_body.fetch('Message')).fetch('id')
+        JSON.parse(request_body.fetch('Message'))
       end
     end
 

--- a/app/models/application_history_item.rb
+++ b/app/models/application_history_item.rb
@@ -5,21 +5,25 @@ class ApplicationHistoryItem < ApplicationStruct
   attribute :user_name, Types::String
   attribute :timestamp, Types::Nominal::DateTime
   attribute :event_type, Types::String
-  attribute? :event_data, Types::Hash
+  attribute :event_data, Types::Hash
 
   def to_partial_path
     ["#{super}s", event_type.underscore.tr('/', '_')].join '/'
   end
 
   class << self
-    def from_event(event)
-      user_id = event.data.fetch(:user_id)
-      new(
-        user_name: User.name_for(user_id),
-        timestamp: event.timestamp,
-        event_type: event.event_type,
-        event_data: event.data
-      )
+    def from_event(event, application)
+      if event.event_type == 'Reviewing::ApplicationReceived'
+        user_name = application.legal_rep_name
+        timestamp = application.submitted_at
+      else
+        user_name = User.name_for(event.data.fetch(:user_id))
+        timestamp = event.timestamp
+      end
+
+      event_data = event.data
+      event_type = event.event_type
+      new(user_name:, timestamp:, event_type:, event_data:)
     end
   end
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -8,6 +8,13 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
     applicant.full_name
   end
 
+  def legal_rep_name
+    [
+      provider_details.legal_rep_first_name,
+      provider_details.legal_rep_last_name
+    ].join ' '
+  end
+
   delegate :date_of_birth, to: :applicant, prefix: true
 
   def means_type

--- a/spec/aggregates/reviewing/receive_application_spec.rb
+++ b/spec/aggregates/reviewing/receive_application_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe Reviewing::ReceiveApplication do
 
   it 'changes the state from :nil to :received' do
     expect { command.call }.to change { review.state }
-      .from(:submitted).to(:open)
+      .from(nil).to(:open)
   end
 end

--- a/spec/aggregates/reviewing/send_back_spec.rb
+++ b/spec/aggregates/reviewing/send_back_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Reviewing::SendBack do
   end
 
   before do
+    Reviewing::ReceiveApplication.new(application_id:).call
+
     allow(DatastoreApi::Requests::UpdateApplication).to receive(:new).with(
       {
         application_id: application_id,
@@ -13,8 +15,6 @@ RSpec.describe Reviewing::SendBack do
       member: :return
       }
     ).and_return(return_request)
-
-    Reviewing::ReceiveApplication.new(application_id:).call
   end
 
   let(:return_request) do

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -13,22 +13,45 @@ RSpec.describe CrimeApplication do
     it { is_expected.to eq Date.parse('2011-06-09') }
   end
 
-  describe '#means_type' do
-    subject(:means_type) { application.means_type }
-
-    it { is_expected.to eq :passported }
-  end
-
   describe '#applicant_name' do
     subject(:applicant_name) { application.applicant_name }
 
     it { is_expected.to eq 'Kit Pound' }
   end
 
+  describe '#assignee_name' do
+    subject(:assignee_name) { application.assignee_name }
+
+    it { is_expected.to be_nil }
+
+    context 'when assigned' do
+      before do
+        user_id = SecureRandom.uuid
+        allow(Assigning::LoadAssignment).to receive(:call) { assignment }
+        allow(assignment).to receive(:assignee_id) { user_id }
+        allow(User).to receive(:name_for).with(user_id).and_return('John Deere')
+      end
+
+      it { is_expected.to eq('John Deere') }
+    end
+  end
+
   describe '#history' do
     subject(:history) { application.history }
 
     it { is_expected.to be_a ApplicationHistory }
+  end
+
+  describe '#legal_rep_name' do
+    subject(:legal_rep_name) { application.legal_rep_name }
+
+    it { is_expected.to eq 'John Doe' }
+  end
+
+  describe '#means_type' do
+    subject(:means_type) { application.means_type }
+
+    it { is_expected.to eq :passported }
   end
 
   describe '#reviewable_by?' do
@@ -62,7 +85,7 @@ RSpec.describe CrimeApplication do
   describe '#review_status' do
     subject(:review_status) { application.review_status }
 
-    it { is_expected.to be(:submitted) }
+    it { is_expected.to be(:open) }
   end
 
   describe '#reviewed_at' do
@@ -85,23 +108,6 @@ RSpec.describe CrimeApplication do
       end
 
       it { is_expected.to eq('David Brown') }
-    end
-  end
-
-  describe '#assignee_name' do
-    subject(:assignee_name) { application.assignee_name }
-
-    it { is_expected.to be_nil }
-
-    context 'when assigned' do
-      before do
-        user_id = SecureRandom.uuid
-        allow(Assigning::LoadAssignment).to receive(:call) { assignment }
-        allow(assignment).to receive(:assignee_id) { user_id }
-        allow(User).to receive(:name_for).with(user_id).and_return('John Deere')
-      end
-
-      it { is_expected.to eq('John Deere') }
     end
   end
 

--- a/spec/shared_contexts/with_review.rb
+++ b/spec/shared_contexts/with_review.rb
@@ -5,8 +5,7 @@ RSpec.shared_context 'with review', shared_context: :metadata do
 
   def review
     repository.load(
-      Reviewing::Review.new(application_id),
-      "Reviewing$#{application_id}"
+      Reviewing::Review.new(application_id), "Reviewing$#{application_id}"
     )
   end
 

--- a/spec/system/closed_applications_dashboard_spec.rb
+++ b/spec/system/closed_applications_dashboard_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe 'Closed Applications Dashboard' do
 
   before do
     visit '/'
+
+    Reviewing::ReceiveApplication.call(application_id:)
+
     return_details = ReturnDetails.new(
       reason: ReturnDetails::RETURN_REASONS.first,
       details: 'Detailed reason'


### PR DESCRIPTION
## Description of change

Show application_received events in history.

## Link to relevant ticket
[CRIMRE-180](https://dsdmoj.atlassian.net/browse/CRIMRE-180)

## Notes for reviewer

These were previously fake events. 

In production environments, review will be notified via SNS that an application has been submitted. 

This notification service can be replicated in development (see datastore readme). However, to support contexts where an SNS service is not configured, review will create an application_received event when an application is first accessed by a user on review. 

The timestamp shown on the history for application_received events is the application's submittted_at and not the event's timestamp.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-180]: https://dsdmoj.atlassian.net/browse/CRIMRE-180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ