### PR TITLE
Crimre 153 resubmission history

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -46,14 +46,16 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
   def parent
     return nil if parent_id.nil?
 
-    CrimeApplication.find(parent_id)
+    @parent ||= CrimeApplication.find(parent_id)
   end
 
   def all_histories
+    return @all_histories if @all_histories
+
     histories = [history]
     histories += parent.all_histories if parent
 
-    histories
+    @all_histories = histories
   end
 
   private

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -43,6 +43,19 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
     end
   end
 
+  def parent
+    return nil if parent_id.nil?
+
+    CrimeApplication.find(parent_id)
+  end
+
+  def all_histories
+    histories = [history]
+    histories += parent.all_histories if parent
+
+    histories
+  end
+
   private
 
   def applicant

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -45,6 +45,7 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
 
   def parent
     return nil if parent_id.nil?
+    return nil if parent_id == id
 
     @parent ||= CrimeApplication.find(parent_id)
   end

--- a/app/views/application_history_items/_reviewing_application_received.html.erb
+++ b/app/views/application_history_items/_reviewing_application_received.html.erb
@@ -1,3 +1,7 @@
 <strong>
-  <%= t('reviewing.application_received', scope: 'event.description') %>
+  <% if current_page_application_id == application.id %>
+    <%= t('reviewing.application_received', scope: 'event.description') %>
+  <% else %>
+    <%= link_to t('reviewing.application_received', scope: 'event.description'), crime_application_path(application.id) %>
+  <% end %>
 </strong>

--- a/app/views/crime_applications/history.html.erb
+++ b/app/views/crime_applications/history.html.erb
@@ -25,8 +25,10 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <% @crime_application.history.items.each do |item| %>
-        <%= render partial: item, layout: 'history_item', as: :item, locals: { application: @crime_application } %>
+      <% @crime_application.all_histories.each do |history| %>
+        <% history.items.each do |item| %>
+          <%= render partial: item, layout: 'history_item', as: :item, locals: { current_page_application_id: @crime_application.id, application: history.application } %>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/spec/fixtures/files/crime_apply_data/applications/148df27d-4710-4c5b-938c-bb132eb040ca.json
+++ b/spec/fixtures/files/crime_apply_data/applications/148df27d-4710-4c5b-938c-bb132eb040ca.json
@@ -1,0 +1,72 @@
+{
+  "id": "148df27d-4710-4c5b-938c-bb132eb040ca",
+  "parent_id": "5aa4c689-6fb5-47ff-9567-5efe7f8ac211",
+  "reference": "5230234344",
+  "schema_version": "1.0",
+  "status": "submitted",
+  "created_at": "2023-01-14T16:58:15.000+00:00",
+  "date_stamp": "2022-11-21T16:19:00.000+00:00",
+  "submitted_at": "2023-01-14T16:58:15.000+00:00",
+  "provider_details": {
+    "office_code": "1",
+    "legal_rep_first_name": "Jack",
+    "legal_rep_last_name": "Wagyu",
+    "legal_rep_telephone": "07098765602"
+  },
+  "client_details": {
+    "applicant": {
+      "home_address": {
+        "address_line_one": "1",
+        "address_line_two": "",
+        "city": "London",
+        "country": "London",
+        "postcode": "SW1A 2AA"
+      },
+      "first_name": "Ella",
+      "last_name": "FITZGERALD",
+      "full_name": "Ella FITZGERALD",
+      "nino": "JC123458B",
+      "date_of_birth": "1980-06-01",
+      "telephone_number": "07612345649",
+      "correspondence_address": {
+        "address_line_one": "Other House",
+        "address_line_two": "Second Road",
+        "city": "London",
+        "country": "London",
+        "postcode": "EC2A 2AA"
+      },
+      "correspondence_address_type": "other_address"
+    }
+  },
+  "interests_of_justice": [
+    {
+      "reason": "Justification provided by provider again.",
+      "type": "loss_of_liberty"
+    }
+  ],
+  "case_details": {
+    "case_type": "summary_only",
+    "codefendants": [],
+    "offences": [
+      {
+        "class": "Class C or B",
+        "dates": [
+          {
+            "date_from": "2020-12-12",
+            "date_to": null
+          }
+        ],
+        "name": "Robbery"
+      }
+    ],
+    "hearing_court_name": "Caernarfon Crown Court",
+    "hearing_date": "2023-12-12",
+    "urn": "12AB3456789"
+  },
+  "return_details": {
+    "reason": "clarification_required",
+    "details": "It is unclear what you are referring to by 'high risk' in the interests of justice",
+    "returned_at": "2023-01-25T16:21:55.418Z"
+  },
+  "application_type": "initial_application"
+}

--- a/spec/init/api_data.rb
+++ b/spec/init/api_data.rb
@@ -2,6 +2,7 @@ RSpec.configure do |config|
   application_ids = %w[
     1aa4c689-6fb5-47ff-9567-5eee7f8ac2cc
     5aa4c689-6fb5-47ff-9567-5efe7f8ac211
+    148df27d-4710-4c5b-938c-bb132eb040ca
   ]
 
   config.before do

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -42,6 +42,44 @@ RSpec.describe CrimeApplication do
     it { is_expected.to be_a ApplicationHistory }
   end
 
+  describe '#all_histories' do
+    subject(:history) { application.all_histories }
+
+    context 'when initital submission' do
+      it { is_expected.to eq [application.history] }
+    end
+  end
+
+  describe '#parent' do
+    subject(:parent) { application.parent }
+
+    context 'when an initital submission' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'when a re-submission' do
+      let(:parent_id) { SecureRandom.uuid }
+      let(:attributes) { JSON.parse(LaaCrimeSchemas.fixture(1.0).read).merge({ 'parent_id' => parent_id }) }
+      let(:parent) { instance_double(described_class) }
+
+      before do
+        allow(described_class).to receive(:find).with(parent_id) { parent }
+      end
+
+      it { is_expected.to be parent }
+    end
+
+    context 'when parent id is same as the id' do
+      let(:attributes) do
+        JSON.parse(LaaCrimeSchemas.fixture(1.0).read).merge(
+          { 'parent_id' => '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
+        )
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe '#legal_rep_name' do
     subject(:legal_rep_name) { application.legal_rep_name }
 

--- a/spec/models/reporting/processed_report_spec.rb
+++ b/spec/models/reporting/processed_report_spec.rb
@@ -1,7 +1,4 @@
 require 'rails_helper'
-RSpec.configure do |config|
-  config.include ActiveSupport::Testing::TimeHelpers
-end
 
 describe Reporting::ProcessedReport do
   subject(:report) { described_class.new }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,6 +38,9 @@ RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :rack_test
   end
+
+  # For time travel.
+  config.include ActiveSupport::Testing::TimeHelpers
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ SimpleCov.start 'rails' do
   coverage_criterion :branch
   # primary_coverage :branch
   minimum_coverage 100
-  add_group 'Views', 'app/views'
+  add_filter 'app/views'
   add_filter 'app/mailers/application_mailer.rb'
   add_filter 'app/jobs/application_job.rb'
   add_filter 'config/initializers'

--- a/spec/system/viewing_an_application/history_when_a_resubmission_spec.rb
+++ b/spec/system/viewing_an_application/history_when_a_resubmission_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe "Viewing a resubmitted application's history" do
+  let(:parent_id) { SecureRandom.uuid }
+  let(:application_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
+
+  before do
+    visit '/'
+
+    travel_to Time.zone.now.yesterday
+
+    allow(DatastoreApi::Requests::UpdateApplication).to receive(:new) {
+      instance_double(DatastoreApi::Requests::UpdateApplication, call: {})
+    }
+
+    user = User.create(
+      first_name: 'Fred',
+      last_name: 'Smitheg',
+      auth_oid: '976658f9-f3d5-49ec-b0a9-485ff8b308fa',
+      email: 'Fred.Smitheg@justice.gov.uk'
+    )
+
+    Reviewing::ReceiveApplication.new(
+      application_id: parent_id,
+      submitted_at: Time.zone.now.to_s
+    ).call
+
+    Assigning::AssignToUser.new(
+      user_id: user.id,
+      to_whom_id: user.id,
+      assignment_id: parent_id
+    ).call
+
+    return_details = ReturnDetails.new(
+      reason: 'evidence_issue',
+      details: 'September bank statement required'
+    )
+
+    Reviewing::SendBack.new(
+      user_id: user.id,
+      application_id: parent_id,
+      return_details: return_details.attributes
+    ).call
+
+    travel_back
+
+    Reviewing::ReceiveApplication.new(
+      application_id: application_id,
+      parent_id: parent_id,
+      submitted_at: Time.zone.now.to_s
+    ).call
+
+    visit history_crime_application_path(application_id)
+  end
+
+  it "includes the previous submission's history" do
+    # TODO update to include previous history
+    expected_content = "Monday 24 Oct 09:50 John Doe Application submitted"
+
+    within('tbody.govuk-table__body') do
+      expect(page).to have_content(expected_content)
+    end
+  end
+end

--- a/spec/system/viewing_an_application/history_when_a_resubmission_spec.rb
+++ b/spec/system/viewing_an_application/history_when_a_resubmission_spec.rb
@@ -1,17 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe "Viewing a resubmitted application's history" do
-  let(:parent_id) { SecureRandom.uuid }
-  let(:application_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
+  let(:parent_id) { '5aa4c689-6fb5-47ff-9567-5efe7f8ac211' }
+  let(:application_id) { '148df27d-4710-4c5b-938c-bb132eb040ca' }
 
   before do
     visit '/'
 
     travel_to Time.zone.now.yesterday
-
-    allow(DatastoreApi::Requests::UpdateApplication).to receive(:new) {
-      instance_double(DatastoreApi::Requests::UpdateApplication, call: {})
-    }
 
     user = User.create(
       first_name: 'Fred',
@@ -30,6 +26,10 @@ RSpec.describe "Viewing a resubmitted application's history" do
       to_whom_id: user.id,
       assignment_id: parent_id
     ).call
+
+    allow(DatastoreApi::Requests::UpdateApplication).to receive(:new) {
+      instance_double(DatastoreApi::Requests::UpdateApplication, call: {})
+    }
 
     return_details = ReturnDetails.new(
       reason: 'evidence_issue',
@@ -53,12 +53,11 @@ RSpec.describe "Viewing a resubmitted application's history" do
     visit history_crime_application_path(application_id)
   end
 
-  it "includes the previous submission's history" do
-    # TODO update to include previous history
-    expected_content = "Monday 24 Oct 09:50 John Doe Application submitted"
-
+  it 'includes a link to the previous version of the application in the application history' do
     within('tbody.govuk-table__body') do
-      expect(page).to have_content(expected_content)
+      expect { click_on('Application submitted') }.to change { page.current_path }
+        .from(history_crime_application_path(application_id))
+        .to(crime_application_path(parent_id))
     end
   end
 end


### PR DESCRIPTION
## Description of change
Recursively iterate through parent ids to collate all application history items
Built history for all items
Link to previous superseded versions via respective history application received items

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-153

## Notes for reviewer

## Screenshots of changes (if applicable)

![image](https://user-images.githubusercontent.com/45827968/221917723-9d4bf59c-e1a7-4d58-8dec-7df1f1950b69.png)
![image](https://user-images.githubusercontent.com/45827968/221917811-bac2bdcd-aa8e-460b-9bcc-cde130bcee8d.png)

## How to manually test the feature
Submit from apply
Assign to self, and return in review
Resubmit from apply
View application and application history
