### PR TITLE
CRIMRE-193 only auth extant users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_user_id
-    warden.user.first
+    warden.user.first.fetch('id')
   end
 
   def authenticate_user!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,5 +20,43 @@ class User < ApplicationRecord
         I18n.t('values.deleted_user_name')
       end
     end
+
+    #
+    # TODO find a better home.
+    #
+    def authenticate!(auth_info)
+      authenticate_and_update!(auth_info) || authenticate_and_activate!(auth_info)
+    end
+
+    def authenticate_and_update!(info)
+      user = User.find_by(auth_oid: info.fetch('auth_oid'))
+
+      return nil unless user
+
+      user.update(
+        first_name: info['first_name'],
+        last_name: info['last_name'],
+        email: info['email'],
+        last_auth_at: Time.zone.now
+      )
+
+      user
+    end
+
+    def authenticate_and_activate!(info)
+      user = User.find_by email: info['email'], auth_oid: nil, first_auth_at: nil
+
+      return nil unless user
+
+      user.update(
+        auth_oid: info.fetch('auth_oid'),
+        first_name: info['first_name'],
+        last_name: info['last_name'],
+        last_auth_at: Time.zone.now,
+        first_auth_at: Time.zone.now
+      )
+
+      user
+    end
   end
 end

--- a/db/migrate/20230301132756_add_last_auth_at_to_users.rb
+++ b/db/migrate/20230301132756_add_last_auth_at_to_users.rb
@@ -1,0 +1,6 @@
+class AddLastAuthAtToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :last_auth_at, :timestamp
+    add_column :users, :first_auth_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_24_092833) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_01_132756) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -59,6 +59,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_24_092833) do
     t.string "last_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "last_auth_at", precision: nil
+    t.datetime "first_auth_at", precision: nil
     t.index ["auth_oid"], name: "index_users_on_auth_oid", unique: true
   end
 

--- a/lib/warden/strategies/azure_ad.rb
+++ b/lib/warden/strategies/azure_ad.rb
@@ -2,26 +2,13 @@ module Warden
   module Strategies
     class AzureAd < Warden::Strategies::Base
       def authenticate!
-        omniauth_user = env['omniauth.auth']
+        info = env.dig('omniauth.auth', 'info')
 
-        if omniauth_user
-          info = env['omniauth.auth']['info']
-
-          success! find_and_update_user(info)
+        if info && (user = User.authenticate!(info))
+          success! user
         else
           fail!
         end
-      end
-
-      def find_and_update_user(info)
-        User.upsert(
-          {
-            auth_oid: info.fetch('auth_oid'),
-            first_name: info['first_name'],
-            last_name: info['last_name']
-          },
-          unique_by: :auth_oid
-        ).first.fetch('id')
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,4 +23,99 @@ RSpec.describe User do
       it { is_expected.to eq 'John Deere' }
     end
   end
+
+  describe '.authenticate!' do
+    subject(:authenticate!) { described_class.authenticate!(auth_info) }
+
+    let(:auth_info) do
+      {
+        'auth_oid' => SecureRandom.hex,
+        'email' => 'test@example.com',
+        'first_name' => 'Jo',
+        'last_name' => 'TEST'
+      }
+    end
+
+    context 'when user does not exist in database' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'when a matching active user is found' do
+      let(:user) { instance_double(described_class, update: true) }
+      let(:expected_attributes) do
+        {
+          first_name: 'Jo',
+          last_name: 'TEST',
+          email: 'test@example.com',
+          last_auth_at: Time.zone.now
+        }
+      end
+
+      before do
+        freeze_time
+        allow(described_class).to receive(:find_by).with(
+          { auth_oid: auth_info['auth_oid'] }
+        ).and_return user
+      end
+
+      it 'returns the active user' do
+        expect(authenticate!).to be user
+      end
+
+      it "sets the user's name, email and last_auth_at" do
+        authenticate!
+        expect(user).to have_received(:update).with expected_attributes
+      end
+    end
+  end
+
+  describe 'authenticate_and_activate!' do
+    subject(:authenticate_and_activate!) do
+      described_class.authenticate_and_activate!(auth_info)
+    end
+
+    let(:auth_info) do
+      {
+        'auth_oid' => SecureRandom.hex,
+        'email' => 'test@example.com',
+        'first_name' => 'Jo',
+        'last_name' => 'TEST'
+      }
+    end
+
+    context 'when a user pending activation does not exist in database' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'when a user pending activation exists in database' do
+      let(:user) { instance_double(described_class, update: true) }
+
+      let(:expected_attributes) do
+        {
+          first_name: 'Jo',
+          last_name: 'TEST',
+          auth_oid: auth_info.fetch('auth_oid'),
+          first_auth_at: Time.zone.now,
+          last_auth_at: Time.zone.now
+        }
+      end
+
+      before do
+        freeze_time
+
+        allow(described_class).to receive(:find_by)
+          .with({ email: auth_info['email'], auth_oid: nil, first_auth_at: nil })
+          .and_return user
+      end
+
+      it 'returns the active user' do
+        expect(authenticate_and_activate!).to be user
+      end
+
+      it "sets the user's name, auth_oid, first_auth_at and last_auth_at" do
+        authenticate_and_activate!
+        expect(user).to have_received(:update).with(expected_attributes)
+      end
+    end
+  end
 end

--- a/spec/requests/azure_ad_logout_spec.rb
+++ b/spec/requests/azure_ad_logout_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'OmniAuth Endpoints' do
       get 'https://www.example.com/auth/azure_ad/callback'
     end
 
-    let(:user) { User.find(request.env['warden'].user) }
+    let(:user) { User.find(request.env['warden'].user['id']) }
 
     it 'authenticates the user' do
       expect(request.env['warden'].authenticated?(:user)).to be true

--- a/spec/shared_contexts/logged_in_user.rb
+++ b/spec/shared_contexts/logged_in_user.rb
@@ -1,5 +1,7 @@
 RSpec.shared_context 'with a logged in user', shared_context: :metadata do
   before do
+    User.find_or_create_by(auth_oid: current_user_auth_oid)
+
     auth_hash = OmniAuth::AuthHash.new(
       {
         provider: 'azure_ad',


### PR DESCRIPTION
## Description of change

Only authenticate users if they exist in the review database. 
Active users are authenticated if they are found by auth_oid.
Users pending activation are authenticated if they are found by email address.
Pending activation users are activated on authentication.
Once activated a user cannot be found by email address (in the context of authentication).

## Link to relevant ticket
[CRIMRE-193](https://dsdmoj.atlassian.net/browse/CRIMRE-193)

## Notes for reviewer

Be good to find out what sort of logging/monitoring is expected around authentication. I'd like to move User.authenticate! into a service or an authentication aggregate.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-193]: https://dsdmoj.atlassian.net/browse/CRIMRE-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ