### PR TITLE
Crimre 190 add user management index page

### DIFF
--- a/app/controllers/admin/manage_users_controller.rb
+++ b/app/controllers/admin/manage_users_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class ManageUsersController < ApplicationController
-    def index; end
+    def index
+      @users = User.all
+    end
   end
 end

--- a/app/controllers/admin/manage_users_controller.rb
+++ b/app/controllers/admin/manage_users_controller.rb
@@ -1,0 +1,5 @@
+module Admin
+  class ManageUsersController < ApplicationController
+    def index; end
+  end
+end

--- a/app/views/admin/manage_users/index.html.erb
+++ b/app/views/admin/manage_users/index.html.erb
@@ -1,0 +1,9 @@
+<% title t(".page_title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">
+      <%= t ".heading" %>
+    </h1>
+  </div>
+</div>

--- a/app/views/admin/manage_users/index.html.erb
+++ b/app/views/admin/manage_users/index.html.erb
@@ -1,9 +1,41 @@
-<% title t(".page_title") %>
+<% title t('.page_title') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">
-      <%= t ".heading" %>
+      <%= t '.heading' %>
     </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full govuk-!-margin-bottom-3">
+    <%= link_to t('.buttons.add_new_user'), '#', class: 'govuk-button govuk-button--primary' %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <table class="govuk-table">
+      <caption class="govuk-table__caption"><%= t '.table.caption' %></caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header"><%= t '.table.headings.email' %></th>
+          <th scope="col" class="govuk-table__header"><%= t '.table.headings.manage_others' %></th>
+          <th scope="col" class="govuk-table__header"><%= t '.table.headings.actions' %></th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @users.each do |user| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= user.email %></td>
+            <td class="govuk-table__cell">TODO</td>
+            <td class="govuk-table__cell">
+              <%= link_to t('.buttons.edit'), '#', class: 'govuk-link' %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,6 +206,7 @@ en:
         application_received: Application submitted
         completed: Application completed
 
+
   assigned_applications:
     index:
       page_title: Your list
@@ -252,6 +253,12 @@ en:
     search_results_table:
       table_headings:
         <<: *TABLE_HEADINGS
+
+  admin:
+    manage_users:
+      index:
+        page_title: Manage users
+        heading: Manage users
 
   crime_applications:
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -259,6 +259,15 @@ en:
       index:
         page_title: Manage users
         heading: Manage users
+        buttons:
+          add_new_user: Add new user
+          edit: Edit
+        table:
+          caption: Existing users
+          headings:
+            email: Email
+            manage_others: Manage other users
+            actions: Actions
 
   crime_applications:
     index:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,10 @@ Rails.application.routes.draw do
     post :next_application, on: :collection
   end
 
+  namespace :admin do
+    resources :manage_users, only: [:index]
+  end
+
   namespace :api do
     resources :events, only: [:create]
   end

--- a/spec/system/manage_users/viewing_spec.rb
+++ b/spec/system/manage_users/viewing_spec.rb
@@ -12,17 +12,19 @@ RSpec.describe 'Manage Users Dashboard' do
     expect(page).to have_content 'Manage users'
   end
 
-  # it 'includes the button to add new user' do
-  #   expect(page).to have_content 'Add new user'
-  # end
-  #
-  # it 'includes the correct headings' do
-  #   column_headings = page.first('.app-manage-users-table thead tr').text.squish
-  #
-  #   expect(column_headings).to eq('Email Manage other users Actions')
-  # end
-  #
-  # it 'shows the correct information' do
-  #   expect(page).to have_content('Joe.EXAMPLE@justice.gov.uk')
-  # end
+  it 'includes the button to add new user' do
+    add_new_user_button = page.first('.govuk-button').text.squish
+    expect(add_new_user_button).to have_content 'Add new user'
+  end
+
+  it 'includes the correct headings' do
+    column_headings = page.first('.govuk-table thead tr').text.squish
+
+    expect(column_headings).to eq('Email Manage other users Actions')
+  end
+
+  it 'shows the correct information' do
+    first_data_row = page.first('.govuk-table tbody tr').text.squish
+    expect(first_data_row).to have_content('Joe.EXAMPLE@justice.gov.uk TODO Edit')
+  end
 end

--- a/spec/system/manage_users/viewing_spec.rb
+++ b/spec/system/manage_users/viewing_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'Manage Users Dashboard' do
   include_context 'with a logged in user'
 
   before do
+    visit '/'
     visit '/admin/manage_users'
   end
 

--- a/spec/system/manage_users/viewing_spec.rb
+++ b/spec/system/manage_users/viewing_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'Manage Users Dashboard' do
+  include_context 'with a logged in user'
+
+  before do
+    visit '/admin/manage_users'
+  end
+
+  it 'includes the page heading' do
+    expect(page).to have_content 'Manage users'
+  end
+
+  # it 'includes the button to add new user' do
+  #   expect(page).to have_content 'Add new user'
+  # end
+  #
+  # it 'includes the correct headings' do
+  #   column_headings = page.first('.app-manage-users-table thead tr').text.squish
+  #
+  #   expect(column_headings).to eq('Email Manage other users Actions')
+  # end
+  #
+  # it 'shows the correct information' do
+  #   expect(page).to have_content('Joe.EXAMPLE@justice.gov.uk')
+  # end
+end


### PR DESCRIPTION
## Description of change
Adds basic index page for user managment under /admin/manage_users + controller specs etc. 

## Link to relevant ticket
[CRIMRE-190](https://dsdmoj.atlassian.net/browse/CRIMRE-190)

## Screenshots of changes (if applicable)

### After changes:
<img width="1233" alt="Screenshot 2023-03-02 at 17 26 56" src="https://user-images.githubusercontent.com/13377553/222505486-ac0f7b4f-8a9a-49c0-b250-0c55c1da3134.png">

## How to manually test the feature
- Mannually visit /admin/manage_users