### PR TITLE
Restrict users to see nav option and access user admin only if allowed

### DIFF
--- a/app/controllers/admin/manage_users_controller.rb
+++ b/app/controllers/admin/manage_users_controller.rb
@@ -1,7 +1,13 @@
 module Admin
   class ManageUsersController < ApplicationController
     def index
-      @users = User.all
+      if current_user.can_manage_others
+        @users = User.all
+      else
+        flash[:important] = :cannot_access
+
+        redirect_to assigned_applications_path
+      end
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!
   helper_method :current_user_id
-  helper_method :current_user_name
+  helper_method :current_user
   helper_method :assignments_count
 
   private
@@ -18,8 +18,8 @@ class ApplicationController < ActionController::Base
     warden.user.first.fetch('id')
   end
 
-  def current_user_name
-    @current_user_name || warden.user.first.values_at('first_name', 'last_name').join(' ')
+  def current_user
+    @current_user ||= User.find(current_user_id)
   end
 
   def authenticate_user!

--- a/app/views/admin/manage_users/index.html.erb
+++ b/app/views/admin/manage_users/index.html.erb
@@ -29,7 +29,7 @@
         <% @users.each do |user| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><%= user.email %></td>
-            <td class="govuk-table__cell">TODO</td>
+            <td class="govuk-table__cell"><%= t(user.can_manage_others, scope: 'values') %></td>
             <td class="govuk-table__cell">
               <%= link_to t('.buttons.edit'), '#', class: 'govuk-link' %>
             </td>

--- a/app/views/layouts/_header_navigation.html.erb
+++ b/app/views/layouts/_header_navigation.html.erb
@@ -1,10 +1,12 @@
-  <nav aria-label="Menu" class="govuk-header__navigation">
-    <ul id="navigation" class="govuk-header__navigation-list">
-      <li class="govuk-header__navigation-item app-header__auth-user">
-        <%= current_user_name %>
-      </li>
+<nav aria-label="Menu" class="govuk-header__navigation">
+  <ul id="navigation" class="govuk-header__navigation-list">
+    <li class="govuk-header__navigation-item app-header__auth-user">
+      <%= current_user.name %>
+    </li>
+    <% if current_user.can_manage_others %>
       <li class="govuk-header__navigation-item">
         <%= link_to t('.manage_users'), admin_manage_users_path, class: 'govuk-header__link' %>
       </li>
-    </ul>
-  </nav>
+    <% end %>
+  </ul>
+</nav>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
       already_sent_back: This application has already been sent back to the provider.
       already_completed: This application has already been marked as complete.
       cannot_send_back_when_completed: This application has already been marked as complete.
+      cannot_access: Only authorised users can access the admin page
 
   sessions:
     new:

--- a/spec/system/header_nav_spec.rb
+++ b/spec/system/header_nav_spec.rb
@@ -10,10 +10,28 @@ RSpec.describe 'Header navigation' do
     expect(current_user).to eq('Joe EXAMPLE')
   end
 
-  it 'takes you to user management dashboard when you click "Manage users"' do
-    click_link('Manage users')
+  context 'when user does not have access to manage other users' do
+    before do
+      visit '/'
+    end
 
-    heading_text = page.first('.govuk-heading-xl').text
-    expect(heading_text).to eq('Manage users')
+    it 'does not have a link to manage users' do
+      header = page.first('.govuk-header__navigation-list').text
+      expect(header).not_to include('Manage users')
+    end
+  end
+
+  context 'when user does have access to manage other users' do
+    before do
+      User.update(current_user_id, can_manage_others: true)
+      visit '/'
+    end
+
+    it 'takes you to user management dashboard when you click "Manage users"' do
+      click_link('Manage users')
+
+      heading_text = page.first('.govuk-heading-xl').text
+      expect(heading_text).to eq('Manage users')
+    end
   end
 end

--- a/spec/system/manage_users/viewing_spec.rb
+++ b/spec/system/manage_users/viewing_spec.rb
@@ -3,28 +3,48 @@ require 'rails_helper'
 RSpec.describe 'Manage Users Dashboard' do
   include_context 'with a logged in user'
 
-  before do
-    visit '/'
-    visit '/admin/manage_users'
+  context 'when user does not have access manage other users' do
+    before do
+      visit '/'
+      visit '/admin/manage_users'
+    end
+
+    it 'redirects to Your list page' do
+      heading_text = page.first('.govuk-heading-xl').text
+      expect(heading_text).to eq('Your list')
+    end
+
+    it 'show access denied flash message' do
+      expect(page).to have_content('Only authorised users can access the admin page')
+    end
   end
 
-  it 'includes the page heading' do
-    expect(page).to have_content 'Manage users'
-  end
+  context 'when user does have access to manage other users' do
+    before do
+      User.update(current_user_id, can_manage_others: true)
+      visit '/'
+      visit '/admin/manage_users'
+    end
 
-  it 'includes the button to add new user' do
-    add_new_user_button = page.first('.govuk-button').text.squish
-    expect(add_new_user_button).to have_content 'Add new user'
-  end
+    it 'includes the page heading' do
+      heading_text = page.first('.govuk-heading-xl').text
+      expect(heading_text).to eq('Manage users')
+    end
 
-  it 'includes the correct headings' do
-    column_headings = page.first('.govuk-table thead tr').text.squish
+    it 'includes the button to add new user' do
+      add_new_user_button = page.first('.govuk-button').text
+      expect(add_new_user_button).to have_content 'Add new user'
+    end
 
-    expect(column_headings).to eq('Email Manage other users Actions')
-  end
+    it 'includes the correct table headings' do
+      column_headings = page.first('.govuk-table thead tr').text.squish
 
-  it 'shows the correct information' do
-    first_data_row = page.first('.govuk-table tbody tr').text.squish
-    expect(first_data_row).to have_content('Joe.EXAMPLE@justice.gov.uk TODO Edit')
+      expect(column_headings).to eq('Email Manage other users Actions')
+    end
+
+    it 'shows the correct table content' do
+      first_data_row = page.first('.govuk-table tbody tr').text
+      expect(first_data_row).to have_content('Joe.EXAMPLE@justice.gov.uk Yes Edit')
+    end
   end
 end


### PR DESCRIPTION
## Description of change

- Add conditionality to manage_users_controller to only allow users that can manage users to the dashboard - redirect to Your list and flash message
- Add can_manage_others attribute to Manage users table
- Conditionally hide Manage users link in header nav to those allowed to access

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-199

## Notes for reviewer
Check the link is not present, and that accessing` /admin/manage_users` directly redirects and flashes message

Then to be able to see the link, and access manage users:
- `rails c`
- `User.first.update(can_manage_others: true)`

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1199" alt="image" src="https://user-images.githubusercontent.com/45827968/223122674-18adac35-83b6-4480-be0a-562e65d63b8f.png">


