### PR TITLE
CRIMRE-200 make email case insensitive

### DIFF
--- a/db/migrate/20230307122915_make_users_email_case_insensitive.rb
+++ b/db/migrate/20230307122915_make_users_email_case_insensitive.rb
@@ -1,0 +1,13 @@
+class MakeUsersEmailCaseInsensitive < ActiveRecord::Migration[7.0]
+  def up
+    enable_extension 'citext'
+    change_column :users, :email, :citext
+    add_index :users, :email, unique: true
+    add_index :users, :auth_subject_id, unique: true
+  end
+
+  def down
+    change_column :users, :email, :string
+    disable_extension 'citext'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_06_151554) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_07_122915) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
@@ -54,7 +55,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_06_151554) do
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "auth_oid"
-    t.string "email"
+    t.citext "email"
     t.string "first_name"
     t.string "last_name"
     t.datetime "created_at", null: false
@@ -64,6 +65,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_06_151554) do
     t.string "auth_subject_id"
     t.boolean "can_manage_others", default: false, null: false
     t.datetime "deactivated_at", precision: nil
+    t.index ["auth_subject_id"], name: "index_users_on_auth_subject_id", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
   add_foreign_key "current_assignments", "users"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,43 @@ RSpec.describe User do
     end
   end
 
+  describe '#email' do
+    let(:email) { 'Jo.Example@example.com' }
+    let(:user) { described_class.create!(email:) }
+
+    before { user }
+
+    it 'preserves the case it was created with' do
+      expect(user.email).to eq email
+    end
+
+    it 'is case insensitive when queried' do
+      query_email = email.dup.downcase
+      expect(described_class.find_by(email: query_email).email).to eq email
+    end
+
+    it 'has case insensitive uniqueness enforced by the db' do
+      expect { described_class.create!(email: email.downcase) }.to(
+        raise_error(ActiveRecord::RecordNotUnique,
+                    /Key \(email\)=\(jo.example@example.com\) already exists/)
+      )
+    end
+  end
+
+  describe '#auth_subject_id' do
+    let(:auth_subject_id) { SecureRandom.uuid }
+    let(:user) { described_class.create!(auth_subject_id:) }
+
+    before { user }
+
+    it 'has uniqueness enforced by the db' do
+      expect { described_class.create!(auth_subject_id:) }.to(
+        raise_error(ActiveRecord::RecordNotUnique,
+                    /Key \(auth_subject_id\)=\(#{auth_subject_id}\) already exists./)
+      )
+    end
+  end
+
   describe '.name_for(:id)' do
     subject(:name_for) { described_class.name_for(user_id) }
 


### PR DESCRIPTION
## Description of change
User email are case insensitive when queried
User email has a case insensitive uniqueness constraint
User auth_subject_id has a uniqueness constraint

## Link to relevant ticket
https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMRE/boards/960?selectedIssue=CRIMRE-200

## Notes for reviewer
The auth provider sends emails with uppercase characters. Users tend to provide emails in lowercase.  
Also, users are uniq by email, this uniqueness MUST ignore case.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
