### PR TITLE
CRIMRE-196 admin can deactivate a user.

### DIFF
--- a/app/controllers/admin/deactivate_users_controller.rb
+++ b/app/controllers/admin/deactivate_users_controller.rb
@@ -1,0 +1,15 @@
+module Admin
+  class DeactivateUsersController < ApplicationController
+    def new
+      @user = User.find(params[:manage_user_id])
+    end
+
+    def create
+      @user = User.find(params[:manage_user_id])
+      @user.deactivate!
+
+      flash[:success] = :user_deactivated
+      redirect_to admin_manage_users_path
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   scope :pending_authentication, -> { where(first_auth_at: nil, auth_subject_id: nil) }
 
   def name
-    [first_name, last_name].join(' ')
+    [first_name, last_name].flatten.join(' ')
   end
 
   def deactivated?

--- a/app/views/admin/deactivate_users/new.html.erb
+++ b/app/views/admin/deactivate_users/new.html.erb
@@ -1,0 +1,34 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= t 'confirmations.deactivate_user', user_name: @user.name %>
+    </h1>
+
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        <%= t 'warnings.deactivate_user', user_name: @user.name %>
+      </strong>
+    </div>
+
+    <div class="govuk-button-group">
+      <%= form_with(
+            url: admin_manage_user_deactivate_users_path(@user),
+            method: :post,
+            data: { turbo: 'false' }
+          ) do |f| %>
+        <%= f.submit t('calls_to_action.confirm_deactivation'), class: 'govuk-button'%>
+      <% end %>
+
+      <%= button_to(
+            t('calls_to_action.abandon_deactivation'),
+            admin_manage_users_path,
+            method: :get,
+            class: 'govuk-button govuk-button--warning'
+          ) %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/manage_users/edit.html.erb
+++ b/app/views/admin/manage_users/edit.html.erb
@@ -11,7 +11,7 @@
   <div class="govuk-grid-row">
     <p class="govuk-body">
       <%= t '.email' %><br>
-      <%= @user.email.downcase %>
+      <%= @user.email %>
     </p>
   </div>
 </div>

--- a/app/views/admin/manage_users/index.html.erb
+++ b/app/views/admin/manage_users/index.html.erb
@@ -30,12 +30,14 @@
       <tbody class="govuk-table__body">
         <% @users.each do |user| %>
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><%= user.email.downcase %></td>
+            <td class="govuk-table__cell"><%= user.email %></td>
             <td class="govuk-table__cell"><%= t(user.can_manage_others, scope: 'values') %></td>
             <td class="govuk-table__cell">
-              <%= link_to t('.buttons.edit'), edit_admin_manage_user_path(user), class: 'govuk-link' %>
-              <% unless user.deactivated? || user.id == current_user_id%>
-                <%= link_to t('.buttons.deactivate'), new_admin_manage_user_deactivate_users_path(user), class: 'govuk-link' %>
+              <% unless user.id == current_user_id %>
+                <%= link_to t('.buttons.edit'), edit_admin_manage_user_path(user), class: 'govuk-link' %>
+                <% unless user.deactivated? %>
+                  <%= link_to t('.buttons.deactivate'), new_admin_manage_user_deactivate_users_path(user), class: 'govuk-link' %>
+                <% end %>
               <% end %>
             </td>
           </tr>

--- a/app/views/admin/manage_users/index.html.erb
+++ b/app/views/admin/manage_users/index.html.erb
@@ -34,6 +34,9 @@
             <td class="govuk-table__cell"><%= t(user.can_manage_others, scope: 'values') %></td>
             <td class="govuk-table__cell">
               <%= link_to t('.buttons.edit'), edit_admin_manage_user_path(user), class: 'govuk-link' %>
+              <% unless user.deactivated? || user.id == current_user_id%>
+                <%= link_to t('.buttons.deactivate'), new_admin_manage_user_deactivate_users_path(user), class: 'govuk-link' %>
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,7 @@ en:
       completed: The application has been marked as complete
       new_user_created: A new user has been created
       user_updated: User has been updated
+      user_deactivated: The user has been deactivated
     important:
       title: Important
       state_has_changed: This application has already been assigned to someone else.
@@ -181,9 +182,11 @@ en:
 
   calls_to_action:
     abandon_reassign_to_self: No, do not reassign
+    abandon_deactivation: No, do not deactivate
     assign_to_self: Assign to myself
     clear_search: Clear
     confirm_reassign_to_self: Yes, reassign
+    confirm_deactivation: Yes, deactivate
     reassign_to_self: Reassign to myself
     search: Search
     unassign_from_self: Remove from your list
@@ -194,8 +197,10 @@ en:
     send_back: Send back to provider
   confirmations:
     reassign_to_self_html: Are you sure you want to reassign this application from <strong>%{from_whom_name}</strong> to your list?
+    deactivate_user: Are you sure you want to deactivate %{user_name}?
   warnings:
     reassign_to_self: This will remove the application from your colleague's list
+    deactivate_user: This will mean %{user_name} can no longer access this service.
 
   shared:
     subnavigation:
@@ -263,6 +268,9 @@ en:
         <<: *TABLE_HEADINGS
 
   admin:
+    deactivate_users:
+      new:
+        page_title: Confirm deactivation
     manage_users:
       index:
         page_title: Manage users
@@ -270,6 +278,7 @@ en:
         buttons:
           add_new_user: Add new user
           edit: Edit
+          deactivate: Deactivate 
         table:
           caption: Existing users
           headings:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,9 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
-    resources :manage_users, only: [:index, :new, :create, :edit, :update]
+    resources :manage_users, only: [:index, :new, :create, :edit, :update] do
+      resource :deactivate_users, only: [:new, :create]
+    end
   end
 
   namespace :api do

--- a/spec/shared_contexts/with_a_logged_in_admin_user.rb
+++ b/spec/shared_contexts/with_a_logged_in_admin_user.rb
@@ -2,7 +2,7 @@ RSpec.shared_context 'with a logged in admin user', shared_context: :metadata do
   include_context 'with a logged in user'
 
   let(:current_user) do
-    User.create(
+    User.create!(
       email: 'Joe.ADMIN_EXAMPLE@justice.gov.uk',
       first_name: 'Joe',
       last_name: 'ADMIN_EXAMPLE',

--- a/spec/shared_contexts/with_a_logged_in_admin_user.rb
+++ b/spec/shared_contexts/with_a_logged_in_admin_user.rb
@@ -1,32 +1,14 @@
 RSpec.shared_context 'with a logged in admin user', shared_context: :metadata do
-  before do
-    User.find_or_create_by(
+  include_context 'with a logged in user'
+
+  let(:current_user) do
+    User.create(
       email: 'Joe.ADMIN_EXAMPLE@justice.gov.uk',
+      first_name: 'Joe',
+      last_name: 'ADMIN_EXAMPLE',
+      auth_subject_id: current_user_auth_subject_id,
+      auth_oid: SecureRandom.uuid,
       can_manage_others: true
     )
-
-    auth_hash = OmniAuth::AuthHash.new(
-      {
-        provider: 'azure_ad',
-        uid: current_user_auth_oid,
-        info: {
-          auth_oid: SecureRandom.uuid,
-          auth_subject_id: current_user_auth_subject_id,
-          email: 'Joe.ADMIN_EXAMPLE@justice.gov.uk',
-          first_name: 'Joe',
-          last_name: 'ADMIN_EXAMPLE'
-        }
-      }
-    )
-
-    OmniAuth.config.mock_auth[:azure_ad] = auth_hash
-  end
-
-  let(:current_user_auth_oid) do
-    SecureRandom.uuid
-  end
-
-  let(:current_user_auth_subject_id) do
-    SecureRandom.uuid
   end
 end

--- a/spec/shared_contexts/with_a_logged_in_user.rb
+++ b/spec/shared_contexts/with_a_logged_in_user.rb
@@ -1,17 +1,15 @@
 RSpec.shared_context 'with a logged in user', shared_context: :metadata do
   before do
-    User.find_or_create_by(id: current_user_id, email: 'Joe.EXAMPLE@justice.gov.uk')
-
     auth_hash = OmniAuth::AuthHash.new(
       {
         provider: 'azure_ad',
         uid: current_user_auth_oid,
         info: {
           auth_oid: SecureRandom.uuid,
-          auth_subject_id: current_user_auth_subject_id,
-          email: 'Joe.EXAMPLE@justice.gov.uk',
-          first_name: 'Joe',
-          last_name: 'EXAMPLE'
+          auth_subject_id: current_user.auth_subject_id,
+          email: current_user.email,
+          first_name: current_user.first_name,
+          last_name: current_user.last_name
         }
       }
     )
@@ -19,11 +17,25 @@ RSpec.shared_context 'with a logged in user', shared_context: :metadata do
     OmniAuth.config.mock_auth[:azure_ad] = auth_hash
   end
 
-  let(:current_user_auth_oid) do
-    SecureRandom.uuid
+  let(:current_user) do
+    User.create(
+      email: 'Joe.EXAMPLE@justice.gov.uk',
+      first_name: 'Joe',
+      last_name: 'EXAMPLE',
+      auth_subject_id: current_user_auth_subject_id,
+      auth_oid: SecureRandom.uuid
+    )
   end
 
-  let(:current_user_id) { SecureRandom.uuid }
+  let(:current_user_auth_oid) do
+    current_user.auth_oid
+  end
+
+  let(:current_user_id) { current_user.id }
+
+  let(:logged_in_user) do
+    User.create_by(email: 'Joe.EXAMPLE@justice.gov.uk')
+  end
 
   let(:current_user_auth_subject_id) do
     'c0020ca2-a412-4c4e-9aab-6de9c6aed52a'

--- a/spec/system/manage_users/deactivate_a_user_spec.rb
+++ b/spec/system/manage_users/deactivate_a_user_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe 'Deactivate a user from the manage users dashboard' do
+  include_context 'with a logged in admin user'
+
+  let(:active_user) { User.create!(first_name: 'Zoe', last_name: 'Blogs') }
+  let(:confirm_path) { new_admin_manage_user_deactivate_users_path(active_user) }
+
+  before do
+    active_user
+    visit '/'
+    visit '/admin/manage_users'
+  end
+
+  describe 'clicking on "Deactivate"' do
+    before { click_on('Deactivate') }
+
+    it 'prompts to confirm the action' do
+      expect(page).to have_content(
+        'Are you sure you want to deactivate Zoe Blogs?'
+      )
+    end
+
+    it 'warns about the impact of deactivating' do
+      within('div.govuk-warning-text') do
+        expect(page).to have_content(
+          '! Warning This will mean Zoe Blogs can no longer access this service.'
+        )
+      end
+    end
+
+    describe 'clicking on "Yes, deactivate"' do
+      it 'redirects to the manage user list' do
+        expect { click_on('Yes, deactivate') }.to(
+          change { page.current_path }.from(confirm_path).to(admin_manage_users_path)
+        )
+      end
+
+      it 'shows the success notice' do
+        click_on('Yes, deactivate')
+
+        within('.govuk-notification-banner--success') do
+          expect(page).to have_content('The user has been deactivated')
+        end
+      end
+
+      it 'deactivates the user' do
+        expect { click_on('Yes, deactivate') }.to(
+          change { active_user.reload.deactivated? }.from(false).to(true)
+        )
+      end
+    end
+
+    describe 'clicking on "No, do not deactivate"' do
+      it 'redirects to the manage user list' do
+        expect { click_on('No, do not deactivate') }.to(
+          change { page.current_path }.from(confirm_path).to(admin_manage_users_path)
+        )
+      end
+
+      it 'does not deactivate the user' do
+        expect { click_on('No, do not deactivate') }.not_to(
+          change { active_user.reload.deactivated? }.from(false)
+        )
+      end
+    end
+  end
+end

--- a/spec/system/manage_users/deactivate_a_user_spec.rb
+++ b/spec/system/manage_users/deactivate_a_user_spec.rb
@@ -3,8 +3,23 @@ require 'rails_helper'
 RSpec.describe 'Deactivate a user from the manage users dashboard' do
   include_context 'with a logged in admin user'
 
-  let(:active_user) { User.create!(first_name: 'Zoe', last_name: 'Blogs') }
+  let(:active_user) { user }
   let(:confirm_path) { new_admin_manage_user_deactivate_users_path(active_user) }
+
+  let(:user) do
+    User.create!(
+      first_name: 'Zoe',
+      last_name: 'Blogs',
+      email: 'Zoe.Blogs@example.com'
+    )
+  end
+
+  let(:user_row) do
+    find(
+      :xpath,
+      "//table[@class='govuk-table']//tr[contains(td[1], '#{user.email}')]"
+    )
+  end
 
   before do
     active_user
@@ -13,7 +28,11 @@ RSpec.describe 'Deactivate a user from the manage users dashboard' do
   end
 
   describe 'clicking on "Deactivate"' do
-    before { click_on('Deactivate') }
+    before do
+      within user_row do
+        click_on('Deactivate')
+      end
+    end
 
     it 'prompts to confirm the action' do
       expect(page).to have_content(

--- a/spec/system/manage_users/edit_user_spec.rb
+++ b/spec/system/manage_users/edit_user_spec.rb
@@ -2,18 +2,35 @@ require 'rails_helper'
 
 RSpec.describe 'Edit users from manage users dashboard' do
   include_context 'with a logged in admin user'
+  let(:user) do
+    User.create!(
+      first_name: 'Zoe',
+      last_name: 'Blogs',
+      email: 'Zoe.Blogs@example.com'
+    )
+  end
+
+  let(:user_row) do
+    find(
+      :xpath,
+      "//table[@class='govuk-table']//tr[contains(td[1], '#{user.email}')]"
+    )
+  end
 
   before do
+    user
     visit '/'
     visit '/admin/manage_users'
-    first(:link, 'Edit').click
+    within(user_row) do
+      click_link 'Edit'
+    end
   end
 
   it 'loads the correct page' do
     heading = first('h1').text
 
     expect(heading).to have_content 'Edit a user'
-    expect(page).to have_field('can-manage-others-true-field', checked: false)
+    expect(page).to have_field('Give access to manage other users', checked: false)
   end
 
   it 'allows a users to cancel the editing of a user' do
@@ -50,9 +67,7 @@ RSpec.describe 'Edit users from manage users dashboard' do
     end
 
     it 'updates can manage others value to Yes' do
-      row = find(:xpath, "//table[@class='govuk-table']//tr[contains(td[1], 'joe.example@justice.gov.uk')]")
-
-      expect(row).to have_text('joe.example@justice.gov.uk Yes')
+      expect(user_row).to have_text("#{user.email} Yes")
     end
   end
 
@@ -60,7 +75,7 @@ RSpec.describe 'Edit users from manage users dashboard' do
     before do
       check 'Give access to manage other users'
       click_button 'Save'
-      all(:link, 'Edit')[1].click
+      first(:link, 'Edit').click
       uncheck 'Give access to manage other users'
       click_button 'Save'
     end
@@ -74,9 +89,7 @@ RSpec.describe 'Edit users from manage users dashboard' do
     end
 
     it 'updates can manage others value to No' do
-      row = find(:xpath, "//table[@class='govuk-table']//tr[contains(td[1], 'joe.example@justice.gov.uk')]")
-
-      expect(row).to have_text('joe.example@justice.gov.uk No')
+      expect(user_row).to have_text("#{user.email} No")
     end
   end
 end

--- a/spec/system/manage_users/viewing_spec.rb
+++ b/spec/system/manage_users/viewing_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Manage Users Dashboard' do
 
     it 'shows the correct table content' do
       first_data_row = page.first('.govuk-table tbody tr').text
-      expect(first_data_row).to have_content('joe.example@justice.gov.uk Yes Edit')
+      expect(first_data_row).to have_content(current_user.email)
     end
   end
 end


### PR DESCRIPTION
## Description of change

Admin can deactivate a user.

## Link to relevant ticket
[CRIMRE-196](https://dsdmoj.atlassian.net/browse/CRIMRE-196)

## Notes for reviewer

Deactivated users cannot access the service but remain in the database (so are seen in history etc).

## Screenshots of changes (if applicable)


### Before changes:

### After changes:
<img width="1033" alt="Screenshot 2023-03-08 at 12 12 15" src="https://user-images.githubusercontent.com/34935/223712755-8f35577f-be91-4e38-aba7-c51dffbcc8f1.png">

<img width="711" alt="Screenshot 2023-03-08 at 12 11 43" src="https://user-images.githubusercontent.com/34935/223712777-7d3119f3-5fd1-414a-be91-bf5a74100281.png">

<img width="997" alt="Screenshot 2023-03-08 at 12 11 55" src="https://user-images.githubusercontent.com/34935/223712797-23c304e1-53c0-44ec-a6a3-49916be8f623.png">


## How to manually test the feature


[CRIMRE-196]: https://dsdmoj.atlassian.net/browse/CRIMRE-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ