### PR TITLE
Crimre 180 new users have to be unique

### DIFF
--- a/app/forms/admin/new_user_form.rb
+++ b/app/forms/admin/new_user_form.rb
@@ -16,12 +16,17 @@ module Admin
       # seems to be issue with DFE form builder
       boolean_can_manage_others = can_manage_others ? true : false
 
-      user = User.new(
-        email: email,
-        can_manage_others: boolean_can_manage_others
-      )
+      begin
+        user = User.new(
+          email: email,
+          can_manage_others: boolean_can_manage_others
+        )
 
-      user.save
+        user.save
+      rescue ActiveRecord::RecordNotUnique
+        errors.add(:email, :uniqueness)
+        false
+      end
     end
   end
 end

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -11,6 +11,7 @@ en:
       email:
         blank: Please enter an email
         invalid: Invalid email format
+        uniqueness: User already exists
 
     error_summary:
       heading: There is a problem on this page

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,4 +39,3 @@ def print_page
   formatted_html = doc.to_xhtml(indent: 2)
   puts formatted_html
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,3 +31,12 @@ RSpec.configure do |config|
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.profile_examples = true
 end
+
+def print_page
+  require 'nokogiri'
+  html = page.html
+  doc = Nokogiri::HTML.parse(html)
+  formatted_html = doc.to_xhtml(indent: 2)
+  puts formatted_html
+end
+

--- a/spec/system/manage_users/add_user_spec.rb
+++ b/spec/system/manage_users/add_user_spec.rb
@@ -65,13 +65,17 @@ RSpec.describe 'Add users from manage users dashboard' do
     end
 
     it 'errors if the user is not unique / already exists' do
+      add_two_of_the_same_user
+      error_message = first('#admin-new-user-form-email-error').text.squish
+      expect(error_message).to have_text('User already exists')
+    end
+
+    def add_two_of_the_same_user
       fill_in 'Email', with: 'jane@example.com'
       click_button 'Add user'
       click_on 'Add new user'
       fill_in 'Email', with: 'jane@example.com'
       click_button 'Add user'
-      error_message = first('#admin-new-user-form-email-error').text.squish
-      expect(error_message).to have_text('User already exists')
     end
   end
 end

--- a/spec/system/manage_users/add_user_spec.rb
+++ b/spec/system/manage_users/add_user_spec.rb
@@ -63,5 +63,15 @@ RSpec.describe 'Add users from manage users dashboard' do
 
       expect(error_message).to have_text('Invalid email format')
     end
+
+    it 'errors if the user is not unique / already exists' do
+      fill_in 'Email', with: 'jane@example.com'
+      click_button 'Add user'
+      click_on 'Add new user'
+      fill_in 'Email', with: 'jane@example.com'
+      click_button 'Add user'
+      error_message = first('#admin-new-user-form-email-error').text.squish
+      expect(error_message).to have_text('User already exists')
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Follow up of [PR 155](https://github.com/ministryofjustice/laa-review-criminal-legal-aid/pull/155). Handles the error state when an admin tries to add a user that already exists on the system.

Also adds a convenience method that pretty prints `page.html` as a readable html document rather than a long string which is hard to parse.

## Screenshots of changes (if applicable)

### After changes:
<img width="651" alt="Screenshot 2023-03-09 at 12 38 52" src="https://user-images.githubusercontent.com/13377553/224025558-957c9bfe-2d4e-489c-a324-74abd3acacfa.png">

## How to manually test the feature
- try to add a user that already exists - you should see the error message as show in the screenshot.