### PR TITLE
CRIMRE-236 fix oidc auth callback on staging

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -20,11 +20,13 @@ Rails.application.config.middleware.use OmniAuth::Builder do
       response_type: :code,
       client_options: {
         identifier: ENV.fetch('OMNIAUTH_AZURE_CLIENT_ID', nil),
-        secret: ENV.fetch('OMNIAUTH_AZURE_CLIENT_SECRET', nil)
+        secret: ENV.fetch('OMNIAUTH_AZURE_CLIENT_SECRET', nil),
+        redirect_uri: ENV.fetch('OMNIAUTH_AZURE_REDIRECT_URI', '/auth/azure_ad/callback')
       },
       discovery: true,
       pkce: true,
       issuer: "https://login.microsoftonline.com/#{tenant_id}/v2.0",
+      extra_authorize_params: { tenant: tenant_id }
     }
   )
 end

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -11,4 +11,4 @@ data:
   DATASTORE_API_ROOT: https://criminal-applications-datastore-staging.apps.live.cloud-platform.service.justice.gov.uk
   OMNIAUTH_AZURE_CLIENT_ID: 5d1ba28b-234a-44e1-9464-f5bec5228bfc
   OMNIAUTH_AZURE_TENANT_ID: c6874728-71e6-41fe-a9e1-2e8c36776ad8
-
+  OMNIAUTH_AZURE_REDIRECT_URI: https://laa-review-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk/auth/azure_ad/callback


### PR DESCRIPTION
## Description of change

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMRE-236

## Notes for reviewer

Unlike the Oauth2 gem, the [omniauth_openid_connect](https://github.com/omniauth/omniauth_openid_connect) requires the full callback uri to be specified.

If it is not specified, it will revert to using localhost.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
