### PR TITLE
Specify redirect_uri for azure_ad

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -6,8 +6,6 @@
 #
 DATABASE_URL=postgresql://postgres@localhost/laa-review-criminal-legal-aid
 
-DEVELOPMENT_HOST=laa-review-criminal-legal-aid.test
-
 # Local datastore endpoint
 DATASTORE_API_ROOT=http://localhost:3003
 # Local datastore API shared secret for JWT auth
@@ -18,3 +16,5 @@ DATASTORE_API_AUTH_SECRET=foobar
 # speak to the team to get these 
 # OMNIAUTH_AZURE_CLIENT_ID:
 # OMNIAUTH_AZURE_TENANT_ID: 
+ 
+# OMNIAUTH_AZURE_REDIRECT_URI=https://localhost:3000/users/auth/azure_ad/callback

--- a/.env.test
+++ b/.env.test
@@ -9,6 +9,7 @@ DATABASE_URL=postgresql://postgres@localhost/laa-review-criminal-legal-aid-test
 OMNIAUTH_AZURE_CLIENT_ID='TestAzureClientID'
 OMNIAUTH_AZURE_CLIENT_SECRET='TestAzureClientSecret'
 OMNIAUTH_AZURE_TENANT_ID='TestAzureTenantID'
+OMNIAUTH_AZURE_REDIRECT_URI='https://www.example.com/users/auth/azure_ad/callback'
 
 DATASTORE_API_ROOT=https://datastore-api-stub.test
 DATASTORE_API_AUTH_SECRET=foobar

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -36,7 +36,8 @@ Devise.setup do |config|
       response_type: :code,
       client_options: {
         identifier: ENV.fetch('OMNIAUTH_AZURE_CLIENT_ID', nil),
-        secret: ENV.fetch('OMNIAUTH_AZURE_CLIENT_SECRET', nil)
+        secret: ENV.fetch('OMNIAUTH_AZURE_CLIENT_SECRET', nil),
+        redirect_uri: ENV.fetch('OMNIAUTH_AZURE_REDIRECT_URI', nil)
       },
       discovery: true,
       pkce: true,

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -11,4 +11,4 @@ data:
   DATASTORE_API_ROOT: https://criminal-applications-datastore-staging.apps.live.cloud-platform.service.justice.gov.uk
   OMNIAUTH_AZURE_CLIENT_ID: 5d1ba28b-234a-44e1-9464-f5bec5228bfc
   OMNIAUTH_AZURE_TENANT_ID: c6874728-71e6-41fe-a9e1-2e8c36776ad8
-  OMNIAUTH_AZURE_REDIRECT_URI: https://laa-review-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk/auth/azure_ad/callback
+  OMNIAUTH_AZURE_REDIRECT_URI: https://laa-review-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk/users/auth/azure_ad/callback

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ Rails.application.routes.draw do
 
   get 'users/auth/failure', to: 'errors#forbidden'
 
-
   get 'application_not_found', to: 'errors#application_not_found'
   get 'unhandled', to: 'errors#unhandled'
   get 'forbidden', to: 'errors#forbidden'


### PR DESCRIPTION
Specify azure_ad return_uri

## Description of change

Having to specify the return_uri adds a configuration burden. 
It seemed not to be necessary when using Devise, however the host url does not seem to be being set consistently.
This change reverts to specifying the return_uri per deployment, and in doing so should hopefully fix authentication on staging.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
