### PR TITLE
CRIMRE-248 update ready for assessment status in datastore

### DIFF
--- a/app/aggregates/reviewing/commands/mark_as_ready.rb
+++ b/app/aggregates/reviewing/commands/mark_as_ready.rb
@@ -8,6 +8,12 @@ module Reviewing
         with_review do |review|
           review.mark_as_ready(user_id:)
         end
+
+        DatastoreApi::Requests::UpdateApplication.new(
+          application_id: application_id,
+          payload: true,
+          member: :mark_as_ready
+        ).call
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,7 +178,7 @@ en:
       open: default
       sent_back: red
       completed: green
-      marked_as_ready: default
+      marked_as_ready: blue
 
   calls_to_action:
     abandon_reassign_to_self: No, do not reassign

--- a/spec/system/reviewing/mark_application_as_complete_spec.rb
+++ b/spec/system/reviewing/mark_application_as_complete_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Marking an application as complete' do
   include_context 'with an existing application'
 
-  let(:complete_cta) { 'Mark as complete' }
+  let(:complete_cta) { 'Mark as completed' }
 
   before do
     visit '/'
@@ -31,8 +31,8 @@ RSpec.describe 'Marking an application as complete' do
       click_on 'Kit Pound'
     end
 
-    it 'has a visable "Mark as complete" CTA' do
-      expect(page).to have_content('Mark as complete')
+    it 'has a visable "Mark as completed" CTA' do
+      expect(page).to have_content('Mark as completed')
     end
 
     it 'redirects to the correct page' do
@@ -96,7 +96,7 @@ RSpec.describe 'Marking an application as complete' do
       click_on('Kit Pound')
     end
 
-    it 'the "Mark as complete" button is not visable' do
+    it 'the "Mark as completed" button is not visable' do
       expect(page).not_to have_button(complete_cta)
     end
   end

--- a/spec/system/reviewing/mark_application_as_ready_spec.rb
+++ b/spec/system/reviewing/mark_application_as_ready_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe 'Marking an application as ready for assessment' do
     let(:assignee_id) { current_user_id }
 
     before do
+      allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
+        .and_return(instance_double(DatastoreApi::Requests::UpdateApplication, call: {}))
+
       Assigning::AssignToUser.new(
         assignment_id: crime_application_id,
         user_id: assignee_id,

--- a/spec/system/reviewing/send_back_to_provider_spec.rb
+++ b/spec/system/reviewing/send_back_to_provider_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe 'Send an application back to the provider' do
       end
 
       it 'does not show the CTAs' do
-        expect(page).not_to have_content('Mark as complete')
+        expect(page).not_to have_content('Mark as completed')
       end
     end
   end

--- a/spec/system/viewing_an_application/that_is_assigned_to_me_spec.rb
+++ b/spec/system/viewing_an_application/that_is_assigned_to_me_spec.rb
@@ -20,14 +20,22 @@ RSpec.describe 'Viewing an application that is assigned to me' do
   describe 'Conditional display of review buttons' do
     it 'displays mark as ready button as default' do
       expect(page).to have_content('Mark as ready')
-      expect(page).not_to have_content('Mark as complete')
+      expect(page).not_to have_content('Mark as completed')
     end
 
-    it 'displays mark as complete button if application is marked as ready' do
-      click_button 'Mark as ready'
-      visit crime_application_path(application_id)
-      expect(page).to have_content('Mark as complete')
-      expect(page).not_to have_content('Mark as ready')
+    context 'when the application is already marked as ready' do
+      before do
+        allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
+          .and_return(instance_double(DatastoreApi::Requests::UpdateApplication, call: {}))
+
+        click_button 'Mark as ready'
+        visit crime_application_path(application_id)
+      end
+
+      it 'displays mark as completed button if application is marked as ready' do
+        expect(page).to have_content('Mark as completed')
+        expect(page).not_to have_content('Mark as ready')
+      end
     end
   end
 end

--- a/spec/system/viewing_an_application/that_is_assigned_to_somone_else_spec.rb
+++ b/spec/system/viewing_an_application/that_is_assigned_to_somone_else_spec.rb
@@ -31,6 +31,6 @@ RSpec.describe 'Viewing an application that is assigned to someone else' do
 
   it 'does not show the review buttons' do
     expect(page).not_to have_content('Mark as ready')
-    expect(page).not_to have_content('Mark as complete')
+    expect(page).not_to have_content('Mark as completed')
   end
 end

--- a/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Viewing an application unassigned, open application' do
   end
 
   it 'does not show the CTAs' do
-    expect(page).not_to have_content('Mark as complete')
+    expect(page).not_to have_content('Mark as completed')
   end
 
   context 'with optional fields not provided' do


### PR DESCRIPTION
## Description of change

- Makes a request to update the status of an application to ready for assessment in the datastore when an application has been marked as ready for assessment in the client
- Also changes colour of ready for assessment tag to blue from default blue

## Link to relevant ticket
[CRIMRE-248](https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMRE/boards/960?modal=detail&selectedIssue=CRIMRE-248)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1144" alt="Screenshot 2023-03-27 at 15 27 06" src="https://user-images.githubusercontent.com/51047911/228524964-9c1179cf-e277-4ffb-853e-43466a6cea99.png">

### After changes:
<img width="937" alt="Screenshot 2023-03-29 at 12 42 31" src="https://user-images.githubusercontent.com/51047911/228524992-7cb1cc35-b00e-4260-8ba8-046831557077.png">

## How to manually test the feature


[CRIMRE-248]: https://dsdmoj.atlassian.net/browse/CRIMRE-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ