### PR TITLE
[CRIMRE-238] Add split case reason when returning application

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
   revision: 79de69687adb7f596206e3835f5b77ba867a99ea
   specs:
-    laa-criminal-legal-aid-schemas (0.1.1)
+    laa-criminal-legal-aid-schemas (0.1.2)
       dry-struct
       json-schema (~> 3.0.0)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,7 +21,7 @@ en:
       timestamp: '%A %-d %b %H:%M'  # Monday 21 Nov 12:20
 
   phase_banner:
-    text: This is an MVP. Some things may not work as expected. 
+    text: This is an MVP. Some things may not work as expected.
     alpha: alpha
   flash:
     success:
@@ -45,10 +45,10 @@ en:
       cannot_send_back_when_marked_as_ready: This application has already been marked as ready for assessment.
       cannot_access: Only authorised users can access the admin page.
     # flash.notice is only used by Devise and is treated as success.
-    notice: 
+    notice:
       title: Success
     # flash.notice is only used by Devise and is treated as important.
-    alert: 
+    alert:
       title: Important
 
   primary_navigation:
@@ -292,7 +292,7 @@ en:
         buttons:
           add_new_user: Add new user
           edit: Edit
-          deactivate: Deactivate 
+          deactivate: Deactivate
         table:
           caption: Existing users
           headings:
@@ -313,7 +313,7 @@ en:
             hint_text: "Enter the user's DOM1 email"
           checkbox:
             label: Give access to manage other users
-      edit: 
+      edit:
         page_title: Edit a user
         heading: Edit a user
         email: Email
@@ -364,4 +364,3 @@ en:
   pagination:
     previous: Previous
     next: Next
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,6 +179,7 @@ en:
       duplicate_application: Duplicate application
       case_concluded: Case has already concluded
       provider_request: Provider request
+      split_case: The case has been split so we need justification for all offences
     color:
       submitted: default
       open: default


### PR DESCRIPTION
## Description of change
Adds new 'split case' to list of return reasons

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-238

## Notes for reviewer
Text in figma has multiple versions so took one of them - likely be revised soon.

## Screenshots of changes (if applicable)

### Before changes:
N/A

### After changes:
<img width="609" alt="Screenshot 2023-03-31 at 14 38 51" src="https://user-images.githubusercontent.com/47113046/229141474-e44c7fe0-1dc2-49e6-b3be-9e41e47cb513.png">

## How to manually test the feature
Go to Applications, scroll to the bottom and click 'Send back to provider'