### PR TITLE
CRIMRE-214 workload report content update

### DIFF
--- a/app/models/reporting/workload_report.rb
+++ b/app/models/reporting/workload_report.rb
@@ -11,8 +11,8 @@ module Reporting
       Table.new(
         {
           days_passed:,
-          open_applications_by_age:,
-          closed_applications_by_age:
+          received_applications_by_age:,
+          open_applications_by_age:
         }
       )
     end
@@ -25,8 +25,8 @@ module Reporting
       reports.map { |report| Cell.new(report.total_open, numeric: true) }
     end
 
-    def closed_applications_by_age
-      reports.map { |report| Cell.new(report.total_closed, numeric: true) }
+    def received_applications_by_age
+      reports.map { |report| Cell.new(report.total_received, numeric: true) }
     end
 
     #

--- a/app/models/reporting/workload_report.rb
+++ b/app/models/reporting/workload_report.rb
@@ -2,9 +2,10 @@ module Reporting
   class WorkloadReport
     include Reportable
 
-    def initialize(number_of_days: 4, day_zero: Time.zone.now.to_date)
+    def initialize(number_of_days: 4, day_zero: Time.zone.now.to_date, last_row_limit_in_days: 10)
       @number_of_days = number_of_days
       @day_zero = day_zero
+      @last_row_limit_in_days = last_row_limit_in_days
     end
 
     def table
@@ -19,7 +20,7 @@ module Reporting
 
     private
 
-    attr_reader :number_of_days, :day_zero
+    attr_reader :number_of_days, :day_zero, :last_row_limit_in_days
 
     def open_applications_by_age
       reports.map { |report| Cell.new(report.total_open, numeric: true) }
@@ -36,7 +37,7 @@ module Reporting
     # 0 days
     # 1 day
     # 2 days
-    # 3 or more days
+    # between 3(#number_of_days) and (#last_row_limit_in_days)
     #
     #
     def days_passed
@@ -72,12 +73,27 @@ module Reporting
       end
     end
 
+    # The date of the youngest business day not included in the last
+    # row counts.
+    def last_row_cut_off_date
+      @last_row_cut_off_date ||= BusinessDay.new(
+        age_in_business_days: last_row_limit_in_days + 1,
+        day_zero: day_zero
+      ).date
+    end
+
     #
     # The last row of the report differs from the preceding rows in that it
-    # includes the counts for all earlier dates.
+    # includes the counts for the previous business days up to and including the
+    # #number_of_days_limit business day period.
     #
     def last_day_or_more_report
-      scope = Reporting::ReceivedOnReport.where('business_day <= ?', business_days.last.date)
+      scope = Reporting::ReceivedOnReport.where(
+        'business_day > ? AND business_day <= ? ',
+        last_row_cut_off_date,
+        business_days.last.date
+      )
+
       total_received = scope.sum(:total_received)
       total_closed = scope.sum(:total_closed)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,7 +111,7 @@ en:
   table_headings: &TABLE_HEADINGS
     applicant_name: Applicant
     reference: Ref. no.
-    days_passed: Days passed
+    days_passed: Business days since applications were received
     time_passed: Days passed
     received_at: Date received
     submitted_at: Date received
@@ -119,8 +119,8 @@ en:
     caseworker: Caseworker
     closed_by: Closed by
     status: Status
-    open_applications_by_age: Open applications
-    closed_applications_by_age: Closed applications
+    open_applications_by_age: "Applications still\xA0open"
+    received_applications_by_age: Applications received 
     processed_on: Closed on
     applications_closed: Closed applications
 
@@ -161,7 +161,7 @@ en:
     days_passed:
       one: 1 day
       other: "%{count} days"
-      last: "%{count} or more days"
+      last: "Between %{count} and 9 days"
     review_status:
       submitted: Open
       open: Open
@@ -197,7 +197,7 @@ en:
     search: Search
     unassign_from_self: Remove from your list
     view_all_open_applications: View all open applications
-    view_daily_count: View by days passed
+    view_daily_count: Check when applications were received 
     view_closed_on_count: View by date closed
     mark_complete: Mark as completed
     send_back: Send back to provider

--- a/spec/models/reporting/workload_report_spec.rb
+++ b/spec/models/reporting/workload_report_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Reporting::WorkloadReport do
 
     it 'has column headers' do
       expect(report.table.headers.map(&:content)).to eq(
-        ['Days passed', 'Open applications', 'Closed applications']
+        ['Business days since applications were received', 'Applications received', 'Applications still open']
       )
     end
 
@@ -44,25 +44,25 @@ RSpec.describe Reporting::WorkloadReport do
       expect(report.table.rows.size).to eq(4)
     end
 
-    it 'row headers with "0 days", "1 day", "2 days", and "3 or more days"' do
+    it 'row headers with "0 days", "1 day", "2 days", and "Between 3 and 9 days"' do
       expect(report.table.rows.map(&:first).map(&:content)).to eq(
-        ['0 days', '1 day', '2 days', '3 or more days']
+        ['0 days', '1 day', '2 days', 'Between 3 and 9 days']
       )
     end
 
     describe 'data' do
       subject(:columns) { report.table.rows.map { |r| r[1, 2] }.transpose }
 
-      describe 'open applications' do
-        subject(:open_counts) { columns.first.map(&:content) }
+      describe 'received applications' do
+        subject(:received_counts) { columns.first.map(&:content) }
 
-        it { is_expected.to eq([5, 0, 4, 3]) }
+        it { is_expected.to eq([10, 8, 5, 1054]) }
       end
 
-      describe 'closed applications' do
-        subject(:closed_counts) { columns.last.map(&:content) }
+      describe 'open applications' do
+        subject(:open_counts) { columns.last.map(&:content) }
 
-        it { is_expected.to eq([5, 8, 1, 1051]) }
+        it { is_expected.to eq([5, 0, 4, 3]) }
       end
     end
   end

--- a/spec/models/reporting/workload_report_spec.rb
+++ b/spec/models/reporting/workload_report_spec.rb
@@ -12,8 +12,9 @@ RSpec.describe Reporting::WorkloadReport do
       ['2023-01-03', 8, 8],
       ['2022-12-30', 5, 1],
       ['2022-12-29', 4, 3],
-      ['2021-01-04', 50, 49],
-      ['2020-01-04', 1000, 999]
+      ['2022-12-17', 50, 49],
+      ['2022-12-16', 1000, 999],
+      ['2022-12-15', 10_000, 1]
     ].map do |business_day, total_received, total_closed|
       { business_day:, total_received:, total_closed: }
     end

--- a/spec/system/assigning/get_next_application_spec.rb
+++ b/spec/system/assigning/get_next_application_spec.rb
@@ -22,4 +22,25 @@ RSpec.describe 'Assigning an application to myself' do
       expect(page).to have_content('There are no new applications to be reviewed')
     end
   end
+
+  context 'when multiple caseworkes "get next" the same appliction' do
+    let(:stubbed_search_results) do
+      [
+        ApplicationSearchResult.new(
+          applicant_name: 'Kit Pound',
+          resource_id: '696dd4fd-b619-4637-ab42-a5f4565bcf4a',
+          reference: 120_398_120,
+          status: 'submitted',
+          submitted_at: '2022-10-27T14:09:11.000+00:00'
+        )
+      ]
+    end
+
+    it 'shows an error when there is no next application' do
+      visit '/'
+      click_on 'Get next application'
+      expect(page).to have_content('Your list')
+      expect(page).to have_content('There are no new applications to be reviewed')
+    end
+  end
 end

--- a/spec/system/reporting/workload_report_spec.rb
+++ b/spec/system/reporting/workload_report_spec.rb
@@ -7,8 +7,11 @@ RSpec.describe 'Workload Report' do
   end
 
   it 'shows the correct column headers' do
+    expected_column_headers = 'Business days since applications ' \
+                              'were received Applications received Applications still open'
+
     within('table thead tr') do
-      expect(page).to have_content 'Days passed Open applications Closed applications'
+      expect(page).to have_content expected_column_headers
     end
   end
 
@@ -32,7 +35,7 @@ RSpec.describe 'Workload Report' do
 
   it 'shows the correct row headers for the last row' do
     within all('table tbody th')[3] do
-      expect(page).to have_content '3 or more days'
+      expect(page).to have_content 'Between 3 and 9 days'
     end
   end
 end


### PR DESCRIPTION
## Description of change
- add latest column headers
- remove closed applications total
- add applications received total
- only show the counts up to the last nine days in the final row

## Link to relevant ticket

[CRIMRE-214](https://dsdmoj.atlassian.net/browse/CRIMRE-214)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="750" alt="Screenshot 2023-04-04 at 12 57 19" src="https://user-images.githubusercontent.com/34935/229784550-5563b283-0849-46ce-8049-565c8dc5aa2a.png">


### After changes:

<img width="818" alt="Screenshot 2023-04-04 at 12 57 01" src="https://user-images.githubusercontent.com/34935/229784684-bf752648-b415-4d91-8226-9f91bb596e0b.png">


## How to manually test the feature


[CRIMRE-214]: https://dsdmoj.atlassian.net/browse/CRIMRE-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ