### PR TITLE
Add ioj passport, update show application view and fixtures

### DIFF
--- a/app/views/crime_applications/_client_details.html.erb
+++ b/app/views/crime_applications/_client_details.html.erb
@@ -21,6 +21,14 @@
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
+      <%= t(:other_names, scope: 'crime_applications.labels') %>
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= client_details.applicant.other_names.presence || t(:not_provided, scope: 'crime_applications.values') %>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
       <%= t(:date_of_birth, scope: 'crime_applications.labels') %>
     </dt>
     <dd class="govuk-summary-list__value">
@@ -40,11 +48,7 @@
       <%= t(:telephone_number, scope: 'crime_applications.labels') %>
     </dt>
     <dd class="govuk-summary-list__value">
-      <% if client_details.applicant.telephone_number.present? %>
-        <%= client_details.applicant.telephone_number %>
-      <% else %>
-        <%= t(:not_provided, scope: 'crime_applications.values') %>
-      <% end %>
+      <%= client_details.applicant.telephone_number.presence || t(:not_provided, scope: 'crime_applications.values') %>
     </dd>
   </div>
   <div class="govuk-summary-list__row">

--- a/app/views/crime_applications/_interests_of_justice.html.erb
+++ b/app/views/crime_applications/_interests_of_justice.html.erb
@@ -14,15 +14,29 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-  <% interests_of_justice.each do |interest_of_justice| %>
-      <tr class="govuk-table__row">
-        <td scope="row" class="govuk-table__cell">
-          <%= t(interest_of_justice.type, scope: 'crime_applications.values') %>
-        </td>
-        <td class="govuk-table__cell">
-          <%= interest_of_justice.reason %>
-        </td>
-      </tr>
+    <% if crime_application.ioj_passport.present? %>
+      <% crime_application.ioj_passport.each do |passport| %>
+        <tr class="govuk-table__row">
+          <td scope="row" class="govuk-table__cell">
+            <%= t(passport, scope: 'crime_applications.values') %>
+          </td>
+          <td class="govuk-table__cell">
+            <span class="moj-badge moj-badge--blue"><%= t(:passported, scope: 'crime_applications.values') %></span>
+          </td>
+        </tr>
+      <% end %>
+    <% else %>
+      <% crime_application.interests_of_justice.each do |interest_of_justice| %>
+        <tr class="govuk-table__row">
+          <td scope="row" class="govuk-table__cell">
+            <%= t(interest_of_justice.type, scope: 'crime_applications.values') %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= interest_of_justice.reason %>
+          </td>
+        </tr>
+      <% end %>
     <% end %>
+
   </tbody>
 </table>

--- a/app/views/crime_applications/_overview.html.erb
+++ b/app/views/crime_applications/_overview.html.erb
@@ -28,11 +28,7 @@
       <%= t(:urn, scope: 'crime_applications.labels') %>
     </dt>
     <dd class="govuk-summary-list__value">
-      <% if overview.case_details.urn %>
-        <%= overview.case_details.urn %>
-      <% else %>
-        <%= t(:not_provided, scope: 'crime_applications.values') %>
-      <% end %>
+      <%= overview.case_details.urn.presence || t(:not_provided, scope: 'crime_applications.values') %>
     </dd>
   </div>
 

--- a/app/views/crime_applications/show.html.erb
+++ b/app/views/crime_applications/show.html.erb
@@ -9,7 +9,7 @@
     <%= render partial: 'case_details', object: @crime_application.case_details %>
     <%= render partial: 'offences', object: @crime_application.case_details.offences %>
     <%= render partial: 'codefendants', object: @crime_application.case_details.codefendants %>
-    <%= render partial: 'interests_of_justice', object: @crime_application.interests_of_justice %>
+    <%= render partial: 'interests_of_justice', locals: { crime_application: @crime_application } %>
     <%= render partial: 'provider_details', object: @crime_application.provider_details %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,7 @@ en:
     end_on: Date to
     first_name: First name
     last_name: Last name
+    other_names: Other names
     case_type: Case type
     national_insurance_number: National Insurance number
     date_of_birth: Date of birth
@@ -154,6 +155,8 @@ en:
     expert_examination: Expert examination
     interest_of_another: Interest of another
     other: Other
+    passported: Passported
+    on_age_under18: Client is under 18
     today: Today
     yesterday: Yesterday
     day_before_yesterday: Day before yesterday

--- a/spec/fixtures/files/crime_apply_data/applications/148df27d-4710-4c5b-938c-bb132eb040ca.json
+++ b/spec/fixtures/files/crime_apply_data/applications/148df27d-4710-4c5b-938c-bb132eb040ca.json
@@ -38,6 +38,7 @@
       "correspondence_address_type": "other_address"
     }
   },
+  "ioj_passport": [],
   "interests_of_justice": [
     {
       "reason": "Justification provided by provider again.",

--- a/spec/fixtures/files/crime_apply_data/applications/1aa4c689-6fb5-47ff-9567-5eee7f8ac2cc.json
+++ b/spec/fixtures/files/crime_apply_data/applications/1aa4c689-6fb5-47ff-9567-5eee7f8ac2cc.json
@@ -26,6 +26,7 @@
       "correspondence_address_type": "home_address"
     }
   },
+  "ioj_passport": [],
   "interests_of_justice": [
     {
       "reason": "Justification provided by provider.",
@@ -49,7 +50,7 @@
     ],
     "hearing_court_name": "Caernarfon Crown Court",
     "hearing_date": "2023-12-12",
-    "urn": null
+    "urn": ""
   },
   "application_type": "initial_application"
 }

--- a/spec/fixtures/files/crime_apply_data/applications/5aa4c689-6fb5-47ff-9567-5efe7f8ac211.json
+++ b/spec/fixtures/files/crime_apply_data/applications/5aa4c689-6fb5-47ff-9567-5efe7f8ac211.json
@@ -37,12 +37,8 @@
       "correspondence_address_type": "other_address"
     }
   },
-  "interests_of_justice": [
-    {
-      "reason": "Justification provided by provider.",
-      "type": "loss_of_liberty"
-    }
-  ],
+  "ioj_passport": ["on_age_under18"],
+  "interests_of_justice": [],
   "case_details": {
     "case_type": "summary_only",
     "codefendants": [],

--- a/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -40,6 +40,20 @@ RSpec.describe 'Viewing an application unassigned, open application' do
     expect(page).not_to have_content('Mark as completed')
   end
 
+  context 'with interest of justice reason' do
+    it 'shows reason' do
+      expect(page).to have_content('Loss of liberty')
+    end
+  end
+
+  context 'with ioj passport' do
+    let(:application_id) { '5aa4c689-6fb5-47ff-9567-5efe7f8ac211' }
+
+    it 'shows passport reason' do
+      expect(page).to have_content('Client is under 18')
+    end
+  end
+
   context 'with optional fields not provided' do
     let(:application_id) { '1aa4c689-6fb5-47ff-9567-5eee7f8ac2cc' }
 
@@ -52,11 +66,15 @@ RSpec.describe 'Viewing an application unassigned, open application' do
       expect(page).to have_content('Unique reference number Not provided')
     end
 
+    it 'shows that other names were not provided' do
+      expect(page).to have_content('Other names Not provided')
+    end
+
     it 'shows that the client telephone number was not provided' do
       expect(page).to have_content('UK Telephone number Not provided')
     end
 
-    it 'shows that the client homw address was not provided' do
+    it 'shows that the client home address was not provided' do
       expect(page).to have_content('Home address Not provided')
     end
   end


### PR DESCRIPTION
## Description of change
Add conditional to interest of justice section to list IOJ passport types with passported badge instead of IOJ reason type and justification 

Update show application view to present 'Not provided' for optional fields that were not input on Apply - to make explicit to caseworker that these were not sent. 
Update fixture and test to ensure that this reflects the return values when input not provided (i.e. "" not null) - to prevent evergreen test. 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-38

## Notes for reviewer
We only know the value for under 18 passport, this will need updating for when we have bypassed on offence 

## Screenshots of changes (if applicable)

### Before changes:
<img width="740" alt="image" src="https://user-images.githubusercontent.com/45827968/229829124-734b8f0e-e3f1-42bc-8a45-b12fcebe6d79.png">

### After changes:
<img width="800" alt="image" src="https://user-images.githubusercontent.com/45827968/229828978-c39def69-7d88-4e9c-aa4c-86c463e4d1ab.png">


## How to manually test the feature
