### PR TITLE
Notification headers have no full stop

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,18 +37,18 @@ en:
     important:
       title: Important
       reassigned_to_someone_else: 
-        - This application has not been assigned to you.
+        - This application has not been assigned to you
         - It was assigned to someone else before you confirmed reassigning.
       unassigned_before_confirm:
-        - This application has not been assigned to you.
+        - This application has not been assigned to you
         - It was unassigned before you confirmed reassigning.
-      no_next_to_assign: There are no new applications to be reviewed at this time. Please try again later.
-      already_sent_back: This application has already been sent back to the provider.
-      already_completed: This application has already been marked as complete.
-      already_marked_as_ready: The application has already been marked as ready for assessment.
-      cannot_send_back_when_completed: This application has already been marked as complete.
-      cannot_send_back_when_marked_as_ready: This application has already been marked as ready for assessment.
-      cannot_access: Only authorised users can access the admin page.
+      no_next_to_assign: There are no new applications to be reviewed at this time
+      already_sent_back: This application has already been sent back to the provider
+      already_completed: This application has already been marked as complete
+      already_marked_as_ready: The application has already been marked as ready for assessment
+      cannot_send_back_when_completed: This application has already been marked as complete
+      cannot_send_back_when_marked_as_ready: This application has already been marked as ready for assessment
+      cannot_access: Only authorised users can access the admin page
     # flash.notice is only used by Devise and is treated as success.
     notice:
       title: Success

--- a/spec/system/assigning/reassign_an_application_confirmation_errors_spec.rb
+++ b/spec/system/assigning/reassign_an_application_confirmation_errors_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Reassigning an application confirmation errors' do
       click_on('Yes, reassign')
 
       expect(page).to have_notification_banner(
-        text: 'This application has not been assigned to you.',
+        text: 'This application has not been assigned to you',
         details: 'It was assigned to someone else before you confirmed reassigning.'
       )
     end
@@ -104,7 +104,7 @@ RSpec.describe 'Reassigning an application confirmation errors' do
       click_on('Yes, reassign')
 
       expect(page).to have_notification_banner(
-        text: 'This application has not been assigned to you.',
+        text: 'This application has not been assigned to you',
         details: 'It was unassigned before you confirmed reassigning.'
       )
     end


### PR DESCRIPTION
## Description of change

Notification headers should not have a full stop.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
