### PR TITLE
CRIMRE-232 use custom OmniAuth strategy when local

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -13,10 +13,15 @@ DATASTORE_API_ROOT=http://localhost:3003
 # and the datastore has the same env value
 DATASTORE_API_AUTH_SECRET=foobar
 
-## speak to the team to get these
-# OMNIAUTH_AZURE_CLIENT_ID:
-# OMNIAUTH_AZURE_TENANT_ID:
-# OMNIAUTH_AZURE_REDIRECT_URI=https://localhost:3000/users/auth/azure_ad/callback
+# Use dev_auth instead of azure_ad
+DEV_AUTH_ENABLED=true
+
+# To use AzureAD in devlopment set the following
+# DEV_AUTH_ENABLED=false
+# OMNIAUTH_AZURE_CLIENT_ID=.......
+# OMNIAUTH_AZURE_TENANT_ID=.......
+# OMNIAUTH_AZURE_CLIENT_SECRET=......
+# OMNIAUTH_AZURE_REDIRECT_URI=.......
 
 # Notify API change here to test actual Notify calls in Dev
 GOVUK_NOTIFY_API_KEY=notify-api-key

--- a/.env.test
+++ b/.env.test
@@ -11,6 +11,8 @@ OMNIAUTH_AZURE_CLIENT_SECRET='TestAzureClientSecret'
 OMNIAUTH_AZURE_TENANT_ID='TestAzureTenantID'
 OMNIAUTH_AZURE_REDIRECT_URI='https://www.example.com/users/auth/azure_ad/callback'
 
+DEV_AUTH_ENABLED=true
+
 DATASTORE_API_ROOT=https://datastore-api-stub.test
 DATASTORE_API_AUTH_SECRET=foobar
 GOVUK_NOTIFY_API_KEY=notify-api-key

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'dry-schema'
 gem 'dry-struct'
 
 gem 'devise'
+gem 'omniauth'
 gem 'omniauth_openid_connect'
 gem 'omniauth-rails_csrf_protection'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -542,6 +542,7 @@ DEPENDENCIES
   kaminari (~> 1.2)
   laa-criminal-applications-datastore-api-client!
   laa-criminal-legal-aid-schemas!
+  omniauth
   omniauth-rails_csrf_protection
   omniauth_openid_connect
   pg (~> 1.4)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ You can also compile assets manually with `rails dartsass:build` at any time, an
 
 If you ever feel something is not right with the CSS or JS, run `rails assets:clobber` to purge the local cache.
 
+**5. Authenticating a user locally**
+
+After clicking "Sign in," you will be shown a list of all users in the local database. Select one to sign in as that user.
+
+To add users, select a user that can manage others and use the user management interface. A seed admin user is created by default (run ```bundle exec rails db:seed``` if none are listed). To ensure that the user's name is set correctly on first authorization, use the format "Firstname.Lastname@example.com."
+
+The last user in the list is "Not.Authorised@example.com." Select this user to simulate a non-authorized authenticated user.
+
+This authentication strategy can be disabled locally by setting ```DEV_AUTH_ENABLED=false```
+
 ## Local development with the temporary API gem
 
 The app utilises [puma-dev](https://github.com/puma/puma-dev) for local development.

--- a/app/controllers/users/dev_auth_controller.rb
+++ b/app/controllers/users/dev_auth_controller.rb
@@ -1,0 +1,11 @@
+module Users
+  class DevAuthController < Devise::SessionsController
+    layout 'external'
+
+    def new
+      redirect_to application_not_found_path and return unless FeatureFlags.dev_auth.enabled?
+
+      @emails = User.all.order(last_auth_at: :desc).pluck(:email) << OmniAuth::Strategies::DevAuth::NO_AUTH_EMAIL
+    end
+  end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -10,8 +10,10 @@ module Users
       end
     end
 
-    def failure
-      redirect_to forbidden_path
+    private
+
+    def after_omniauth_failure_path_for(_scope)
+      forbidden_path
     end
   end
 end

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -26,8 +26,9 @@ class FeatureFlags
 
   def initialize
     @env_name = HostEnv.env_name
-    @config = YAML.load_file(
-      Rails.root.join('config/settings.yml')
+
+    @config = YAML.load(
+      ERB.new(settings_file).result
     ).fetch('feature_flags', {}).with_indifferent_access.freeze
   end
 
@@ -45,5 +46,11 @@ class FeatureFlags
 
   def respond_to_missing?(name, _include_private = false)
     config.key?(name) || super
+  end
+
+  private
+
+  def settings_file
+    Rails.root.join('config/settings.yml').read
   end
 end

--- a/app/lib/omni_auth/strategies/dev_auth.rb
+++ b/app/lib/omni_auth/strategies/dev_auth.rb
@@ -1,0 +1,67 @@
+module OmniAuth
+  module Strategies
+    class DevAuth
+      # IMPORTANT NOTE: This OmniAuth strategy is intended for local
+      # development purposes only.
+      #
+      # When a user clicks the "Sign in" button with this strategy,
+      # they are directed to the DevAuth form where they can select
+      # the email of an existing user to log in as. To add an admin
+      # user, run "bundle exec rails db:seed" if it has not been
+      # done already.
+      #
+      # The list of user emails includes a Non Authorised user's
+      # email (NO_AUTH_EMAIL), which developers can use to simulate
+      # a non-authorised authenticated user.
+      #
+      # During the callback phase, this strategy searches for a user
+      # with the given email address in the local database. If a user
+      # with a matching email address is found and is authenticated,
+      # the strategy constructs an auth hash based on the user's
+      # information in the database.
+      #
+      # In cases where the strategy is unable to find an authenticated
+      # user with the given email address, it sets an auth_subject_id
+      # and guesses the user's first and last name based on the email
+      # address.
+
+      include OmniAuth::Strategy
+
+      NO_AUTH_EMAIL = 'Not.Authorised@example.com'.freeze
+
+      uid { auth_subject_id }
+      credentials { { expires_in: 12.hours } }
+      info { { email:, first_name:, last_name: } }
+
+      def request_phase
+        redirect('/dev_auth')
+      end
+
+      private
+
+      def email
+        @email ||= request.params.fetch('email')
+      end
+
+      def user
+        @user ||= User.find_by(email:)
+      end
+
+      def auth_subject_id
+        user&.auth_subject_id || SecureRandom.uuid
+      end
+
+      def first_name
+        user&.first_name || names_from_email.first
+      end
+
+      def last_name
+        user&.last_name || names_from_email.last
+      end
+
+      def names_from_email
+        @names_from_email ||= email.split('@').first.split('.')
+      end
+    end
+  end
+end

--- a/app/lib/omni_auth/strategies/dev_auth.rb
+++ b/app/lib/omni_auth/strategies/dev_auth.rb
@@ -4,23 +4,13 @@ module OmniAuth
       # IMPORTANT NOTE: This OmniAuth strategy is intended for local
       # development purposes only.
       #
-      # When a user clicks the "Sign in" button with this strategy,
-      # they are directed to the DevAuth form where they can select
-      # the email of an existing user to log in as. To add an admin
-      # user, run "bundle exec rails db:seed" if it has not been
-      # done already.
-      #
-      # The list of user emails includes a Non Authorised user's
-      # email (NO_AUTH_EMAIL), which developers can use to simulate
-      # a non-authorised authenticated user.
-      #
       # During the callback phase, this strategy searches for a user
       # with the given email address in the local database. If a user
-      # with a matching email address is found and is authenticated,
+      # with a matching email address is found and is authorised,
       # the strategy constructs an auth hash based on the user's
       # information in the database.
       #
-      # In cases where the strategy is unable to find an authenticated
+      # In cases where the strategy is unable to find an authorised
       # user with the given email address, it sets an auth_subject_id
       # and guesses the user's first and last name based on the email
       # address.
@@ -33,6 +23,7 @@ module OmniAuth
       credentials { { expires_in: 12.hours } }
       info { { email:, first_name:, last_name: } }
 
+      # Redirect to the dev_auth form, so that a user can be selected.
       def request_phase
         redirect('/dev_auth')
       end

--- a/app/views/users/dev_auth/new.html.erb
+++ b/app/views/users/dev_auth/new.html.erb
@@ -1,0 +1,7 @@
+<% title t('landing.page_title') %>
+
+<%= govuk_warning_text(text: 'This is a mock sign in page for use in local development only') %>
+<%= form_with url: user_azure_ad_omniauth_callback_path, data: { turbo: 'false' } do |f| %>
+  <%= f.govuk_select(:email, @emails, label: { text: 'Pick an account:' }) %>
+  <%= f.govuk_submit t('calls_to_action.sign_in') %>
+<% end %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,2 +1,3 @@
 <% title t('landing.page_title') %>
+
 <%= govuk_start_button(text: t('calls_to_action.sign_in'), href: user_azure_ad_omniauth_authorize_path, as_button: true) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,20 +2,24 @@ Rails.application.routes.draw do
   get :health, to: 'healthcheck#show'
   get :ping,   to: 'healthcheck#ping'
 
-  get 'users/auth/failure', to: 'errors#forbidden'
-
   get 'application_not_found', to: 'errors#application_not_found'
   get 'unhandled', to: 'errors#unhandled'
   get 'forbidden', to: 'errors#forbidden'
 
-  devise_for :users,
+  devise_for(
+    :users,
     controllers: {
       omniauth_callbacks: 'users/omniauth_callbacks'
     }
+  )
 
   devise_scope :user do
     unauthenticated :user do
       root 'users/sessions#new', as: :unauthenticated_root
+
+      if FeatureFlags.dev_auth.enabled?
+        get 'dev_auth', to: 'users/dev_auth#new'
+      end
     end
 
     authenticated :user do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,3 +3,7 @@ feature_flags:
     local: true
     staging: true
     production: false
+  dev_auth:
+    local: <%= ENV.fetch("DEV_AUTH_ENABLED", false) %>
+    staging: false
+    production: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,6 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+#
+#
+User.create(email: "Dev.User@example.com", can_manage_others: true)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,8 +19,6 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 
-OmniAuth.config.test_mode = true
-
 Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument('--headless')

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'Authentication Session Initialisation' do
+  before do
+    OmniAuth.config.test_mode = true
+  end
+
+  after do
+    OmniAuth.config.test_mode = false
+  end
+
   include Devise::Test::IntegrationHelpers
 
   let(:auth_callback) do

--- a/spec/system/authenticating/dev_auth_spec.rb
+++ b/spec/system/authenticating/dev_auth_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe 'Authenticating with the DevAuth strategy' do
+  before do
+    # With system specs, the current_users is logged in by default.
+    sign_out(current_user)
+  end
+
+  let(:user) { nil }
+
+  describe 'clicking the "Sign in" button' do
+    before do
+      user
+      visit '/'
+      click_button 'Sign in'
+    end
+
+    it 'shows the dev auth page' do
+      expect(page).to have_current_path '/dev_auth'
+      expect(page).to have_content 'This is a mock sign in page for use in local development only'
+    end
+
+    context 'when the "Not Authorised" user is chosen' do
+      before do
+        select OmniAuth::Strategies::DevAuth::NO_AUTH_EMAIL
+        click_button 'Sign in'
+      end
+
+      it 'redirects to the forbidden page' do
+        expect(page).to have_content 'Access to this service is restricted'
+        expect(page).to have_current_path '/forbidden'
+      end
+    end
+
+    context 'when an authorised, but not yet authenticated, user is selected' do
+      let(:user) { User.create!(email: 'Zoe.Doe@example.com') }
+
+      before do
+        select user.email
+        click_button 'Sign in'
+      end
+
+      it 'signs in the user' do
+        expect(page).to have_content 'Zoe Doe'
+        expect(page).to have_content 'Your list'
+      end
+
+      it 'guesses the name from the email' do
+        expect(user.reload.name).to eq('Zoe Doe')
+      end
+
+      it 'sets the auth subject id' do
+        expect(user.reload.auth_subject_id).not_to be_nil
+      end
+    end
+
+    context 'when an authorised, authenticated, user is selected' do
+      let(:auth_subject_id) { SecureRandom.uuid }
+      let(:user) do
+        User.create!(
+          email: 'Zoe.Doe@example.com',
+          last_name: 'Dowe',
+          auth_subject_id: auth_subject_id
+        )
+      end
+
+      before do
+        select user.email
+        click_button 'Sign in'
+      end
+
+      it 'signs in as the user' do
+        expect(page).to have_content 'Zoe Dowe'
+        expect(page).to have_content 'Your list'
+      end
+
+      it 'does not change user\'s name or auth_subject_id' do
+        user_after_auth = user.reload
+        expect(user_after_auth.name).to eq('Zoe Dowe')
+        expect(user_after_auth.auth_subject_id).to eq(auth_subject_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- creates a custom DevAuth Omniauth strategy
- use DevAuth by default in development/test
- add an admin  user to db seed

## Description of change

## Link to relevant ticket

[CRIMRE-232](https://dsdmoj.atlassian.net/browse/CRIMRE-232)

## Notes for reviewer

Removes the need for AzureAd in development. 

Allows a developer to authenticate with any user in their database.

To use AzureAD in development set  DEV_AUTH_ENABLED=false

Includes a NonAuth'd user so developers can attempt to sign in with a non-authorised but authenticated user.

I've attempted to do this with minimal changes to the authentication code.

## Screenshots of changes (if applicable)

### Before changes:

<img width="780" alt="Screenshot 2023-04-14 at 13 18 24" src="https://user-images.githubusercontent.com/34935/232094271-686747ec-a1cd-4c8a-9c7b-0a5808b26d15.png">


### After changes:

<img width="1048" alt="Screenshot 2023-04-14 at 16 55 00" src="https://user-images.githubusercontent.com/34935/232094158-624850a3-3689-4b3b-a92e-2417e9ac1da7.png">


## How to manually test the feature


[CRIMRE-232]: https://dsdmoj.atlassian.net/browse/CRIMRE-232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ