### PR TITLE
[CRIMRE-277] Add SNS Topic check

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -20,3 +20,6 @@ DATASTORE_API_AUTH_SECRET=foobar
 
 # Notify API change here to test actual Notify calls in Dev
 GOVUK_NOTIFY_API_KEY=notify-api-key
+
+# MAAT SNS Subscription Topic ARN
+# MAAT_SNS_TOPIC_ARN=set_in_infrastructure

--- a/.env.test
+++ b/.env.test
@@ -14,3 +14,5 @@ OMNIAUTH_AZURE_REDIRECT_URI='https://www.example.com/users/auth/azure_ad/callbac
 DATASTORE_API_ROOT=https://datastore-api-stub.test
 DATASTORE_API_AUTH_SECRET=foobar
 GOVUK_NOTIFY_API_KEY=notify-api-key
+
+MAAT_SNS_TOPIC_ARN=arn:aws:sns:eu-west-2:444455556666:ImportantMaatTopic

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -79,8 +79,19 @@ module Api
 
     def verify_request_authenticity
       return head :unauthorized if request_body.blank?
+      return head :unauthorized unless valid_topic?
 
       message_verifier.authenticate!(request_body.to_json)
+    end
+
+    def valid_topic?
+      raise ArgumentError, 'Environment MAAT_SNS_TOPIC_ARN not set' if ENV['MAAT_SNS_TOPIC_ARN'].blank?
+
+      topic_arn.present? && (topic_arn == ENV['MAAT_SNS_TOPIC_ARN'].strip)
+    end
+
+    def topic_arn
+      @topic_arn ||= request_body.fetch('TopicArn', '').strip
     end
 
     def raw_request_delivery?

--- a/spec/requests/api/events_spec.rb
+++ b/spec/requests/api/events_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Api::Events' do
       'Type' => nil,
       'Token' => '2336412f37f',
       'MessageId' => nil,
-      'TopicArn' => 'arn:aws:sns:us-west-2:123456789012:MyTopic',
+      'TopicArn' => 'arn:aws:sns:eu-west-2:444455556666:ImportantMaatTopic',
       'Subject' => nil,
       'Message' => '',
       'Timestamp' => '2012-05-02T00:54:06.655Z',
@@ -83,7 +83,6 @@ RSpec.describe 'Api::Events' do
     let(:body) do
       standard_sns_message.merge(
         'Type' => 'Notification',
-        'TopicArn' => 'arn:aws:sns:us-west-2:123456789012:MyTopic',
         'Subject' => 'apply.submission',
         'Message' => message.to_json
       )
@@ -186,7 +185,6 @@ RSpec.describe 'Api::Events' do
     let(:body) do
       standard_sns_message.merge(
         'Type' => 'Notification',
-        'TopicArn' => 'arn:aws:sns:us-west-2:123456789012:MyTopic',
         'Subject' => 'apply.submission',
         'Message' => message.to_json,
         'SigningCertURL' => 'https://sns.us-west-2.amazonaws.com/BAD-PUBLIC-CERT.pem'
@@ -210,6 +208,16 @@ RSpec.describe 'Api::Events' do
 
     it 'returns unauthorized' do
       post('/api/events', params: body.to_json, headers: headers)
+      expect(response).to have_http_status :unauthorized
+    end
+  end
+
+  describe 'Unrecognised TopicArn' do
+    let(:body) { standard_sns_message.merge('TopicArn' => 'arn:NotAMaatTopic') }
+
+    it 'returns unauthorized' do
+      do_request
+
       expect(response).to have_http_status :unauthorized
     end
   end


### PR DESCRIPTION
Places canonical topic into environment presumably set in infrastructure code

## Description of change
Checks whether incoming message is a message we should care about

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-277

## Notes for reviewer
Assumes there is a single valid SNS Topic we wish to subscribe to set as an environment variable.

Assumes the environment variable is set during infrastructure setup and is fixed (i.e. does not change regularly)

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
