### PR TITLE
[CRIME-258] Go back fix

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
 <% end %>
 
 <% content_for(:back_link) do %>
-  <%= link_to 'Back', :back, class: 'govuk-back-link' %>
+  <%= link_to 'Back', 'javascript:history.back()', class: 'govuk-back-link'  %>
 <% end %>
 
 <% content_for(:content) do %>


### PR DESCRIPTION
## Description of change
Prevents back-and-forth loop behaviour when viewing an application/application history

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-258

## Notes for reviewer
Similar discussion here: https://stackoverflow.com/questions/620962/back-browser-action-in-ruby-on-rails


## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Go top open applications, View an application, click 'Application History' and then on 'Application Details' and then 'Application History' and then click on the small `< Back` link (just above the case title) a few times, you should arrive back on the open applications page.