### PR TITLE
Update value of Assigned to: label when no one is assigned

### DIFF
--- a/app/views/crime_applications/_assignment.html.erb
+++ b/app/views/crime_applications/_assignment.html.erb
@@ -6,7 +6,7 @@
         <%= crime_application.reviewer_name %>
       <% else %>
         <strong><%= t(:assigned_to, scope: 'crime_applications.labels') %></strong>
-        <%= crime_application.assignee_name || t(:unassigned, scope: 'values.assigned_status') %>
+        <%= crime_application.assignee_name || t(:no_one, scope: 'values') %>
       <% end %>
     </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,6 +135,7 @@ en:
     "false": "No"
     not_provided: Not provided
     deleted_user_name: '[deleted]'
+    no_one: no one
     initial_application: Initial application
     home_address: Same as home address
     provider_address: Same as provider address

--- a/spec/system/assigning/assign_an_application_to_myself_spec.rb
+++ b/spec/system/assigning/assign_an_application_to_myself_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe 'Assigning an application to myself' do
     click_on('Kit Pound')
   end
 
-  it 'shows "Assigned to Unassigned"' do
+  it 'shows "Assigned to: no one"' do
     expect(page).to have_content(
-      'Assigned to: Unassigned'
+      'Assigned to: no one'
     )
   end
 

--- a/spec/system/assigning/reassign_an_application_confirmation_errors_spec.rb
+++ b/spec/system/assigning/reassign_an_application_confirmation_errors_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'Reassigning an application confirmation errors' do
       unassign
 
       click_on('Yes, reassign')
-      expect(page).to have_content 'Assigned to: Unassigned'
+      expect(page).to have_content 'Assigned to: no one'
     end
   end
 end

--- a/spec/system/assigning/reassign_an_application_to_myself_spec.rb
+++ b/spec/system/assigning/reassign_an_application_to_myself_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Reassigning an application to myself' do
     click_on('Kit Pound')
   end
 
-  it 'shows "Assigned to Assignee Name"' do
+  it 'shows "Assigned to: Assignee Name"' do
     expect(page).to have_content("Assigned to: #{assignee.name}")
   end
 

--- a/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Viewing an application unassigned, open application' do
   end
 
   it 'shows that the application is unassigned' do
-    expect(page).to have_content('Assigned to: Unassigned')
+    expect(page).to have_content('Assigned to: no one')
   end
 
   it 'includes button to assign' do


### PR DESCRIPTION
## Description of change
Update value of Assigned to: label when no one is assigned - from "Unassigned" to "no one"
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-265
## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="738" alt="image" src="https://user-images.githubusercontent.com/45827968/232508963-b6a07002-faf5-4496-b993-0d191310c61c.png">

### After changes:
<img width="758" alt="image" src="https://user-images.githubusercontent.com/45827968/232509237-d0f10c19-5e91-41b0-8e4d-128626cc08b4.png">

## How to manually test the feature
