### PR TITLE
CRIMRE-267-Updated headers in the application table for all open applications

### DIFF
--- a/app/models/reporting/table.rb
+++ b/app/models/reporting/table.rb
@@ -13,7 +13,7 @@ module Reporting
     def headers
       @headers ||= table_hash.keys.map do |header|
         Cell.new(
-          I18n.t(header, scope: :table_headings),
+          I18n.t(header, scope: 'table_headings.workload_report'),
           header: true,
           numeric: numeric_column?(header)
         )

--- a/app/models/reporting/workload_report.rb
+++ b/app/models/reporting/workload_report.rb
@@ -31,7 +31,7 @@ module Reporting
     end
 
     #
-    # Business days since application was received header column for table.
+    # Business days since application were received header column for table.
     # Returns an array of header cells with contents:
     #
     # 0 days

--- a/app/models/reporting/workload_report.rb
+++ b/app/models/reporting/workload_report.rb
@@ -31,7 +31,7 @@ module Reporting
     end
 
     #
-    # Days passed header column for table.
+    # Business days since application was received header column for table.
     # Returns an array of header cells with contents:
     #
     # 0 days

--- a/app/views/application/_table_header.html.erb
+++ b/app/views/application/_table_header.html.erb
@@ -1,7 +1,7 @@
 <%= content_tag(:th, scope: 'col', class: 'govuk-table__header', id: table_header.column_name, aria: { sort: table_header.sort_state }) do %>
   <% if table_header.sortable? %>
-    <%= button_to table_header.name, nil, params: base_params.merge(table_header.sorting_params), method: sort_form_method %>
+    <%= button_to sanitize(table_header.name), nil, params: base_params.merge(table_header.sorting_params), method: sort_form_method %>
   <% else %>
-    <%= table_header.name %>
+    <%= sanitize table_header.name %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,20 +115,21 @@ en:
     application_status: Status
 
   table_headings: &TABLE_HEADINGS
-    applicant_name: Applicants name
+    applicant_name: Applicant's name
     reference: Reference number
-    days_passed: Business days since application was received
-    time_passed: Business days since application was received
+    time_passed: "Business days since <br>application\xA0was\xA0received"
     received_at: Date received
     submitted_at: Date received
     reviewed_at: Date closed
     caseworker: Caseworker
     closed_by: Closed by
     status: Status
-    open_applications_by_age: "Applications still\xA0open"
-    received_applications_by_age: Applications received 
-    processed_on: Closed on
-    applications_closed: Closed applications
+    workload_report:
+      days_passed: Business days since applications were received
+      received_applications_by_age: Applications received 
+      open_applications_by_age: "Applications still\xA0open"
+      processed_on: Closed on
+      applications_closed: Closed applications
 
   values: &VALUES
     "true": "Yes"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,7 +115,7 @@ en:
     application_status: Status
 
   table_headings: &TABLE_HEADINGS
-    applicant_name: Applicant’s name
+    applicant_name: Applicants name
     reference: Reference number
     days_passed: Business days since application was received
     time_passed: Business days since application was received

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,10 +115,10 @@ en:
     application_status: Status
 
   table_headings: &TABLE_HEADINGS
-    applicant_name: Applicant
-    reference: Ref. no.
-    days_passed: Business days since applications were received
-    time_passed: Days passed
+    applicant_name: Applicant’s name
+    reference: Reference number
+    days_passed: Business days since application was received
+    time_passed: Business days since application was received
     received_at: Date received
     submitted_at: Date received
     reviewed_at: Date closed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -207,7 +207,7 @@ en:
     reassign_to_self: Reassign to myself
     search: Search
     unassign_from_self: Remove from your list
-    view_all_open_applications: View all open applications
+    view_all_open_applications: Check all open applications
     view_daily_count: Check when applications were received 
     view_closed_on_count: View by date closed
     mark_complete: Mark as completed
@@ -249,7 +249,7 @@ en:
       page_title: Your list
       heading: Your list
       get_next: Review next application
-      open_applications: View all open applications
+      open_applications: Check all open applications
       your_assignments:
         zero: No applications are assigned to you for review.
         one: 1 application is assigned to you for review.

--- a/spec/models/reporting/workload_report_spec.rb
+++ b/spec/models/reporting/workload_report_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Reporting::WorkloadReport do
 
     it 'has column headers' do
       expect(report.table.headers.map(&:content)).to eq(
-        ['Business days since application was received', 'Applications received', 'Applications still open']
+        ['Business days since applications were received', 'Applications received', 'Applications still open']
       )
     end
 

--- a/spec/models/reporting/workload_report_spec.rb
+++ b/spec/models/reporting/workload_report_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Reporting::WorkloadReport do
 
     it 'has column headers' do
       expect(report.table.headers.map(&:content)).to eq(
-        ['Business days since applications were received', 'Applications received', 'Applications still open']
+        ['Business days since application was received', 'Applications received', 'Applications still open']
       )
     end
 

--- a/spec/system/assigning/viewing_your_assigned_applications_spec.rb
+++ b/spec/system/assigning/viewing_your_assigned_applications_spec.rb
@@ -71,6 +71,14 @@ RSpec.describe 'Viewing your assigned application' do
       expect(page).to have_content '2 applications are assigned to you for review.'
     end
 
+    it 'includes the correct headings' do
+      column_headings = page.first('.app-dashboard-table thead tr').text.squish
+
+      # rubocop:disable Layout/LineLength
+      expect(column_headings).to eq("Applicant's name Reference number Date received Business days since application was received")
+      # rubocop:enable Layout/LineLength
+    end
+
     describe 'sortable table headers' do
       subject(:column_sort) do
         page.find('thead tr th#submitted_at')['aria-sort']

--- a/spec/system/assigning/viewing_your_assigned_applications_spec.rb
+++ b/spec/system/assigning/viewing_your_assigned_applications_spec.rb
@@ -89,9 +89,9 @@ RSpec.describe 'Viewing your assigned application' do
     end
   end
 
-  context 'when using the all applications link' do
+  context 'when using the check all applications link' do
     before do
-      click_on('View all open applications')
+      click_on('Check all open applications')
     end
 
     it 'proceeds to the correct page' do

--- a/spec/system/closed_applications_dashboard_spec.rb
+++ b/spec/system/closed_applications_dashboard_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Closed Applications Dashboard' do
   it 'includes the correct headings' do
     column_headings = page.first('.app-dashboard-table thead tr').text.squish
 
-    expect(column_headings).to eq('Applicants name Reference number Date received Date closed Closed by Status')
+    expect(column_headings).to eq("Applicant's name Reference number Date received Date closed Closed by Status")
   end
 
   it 'shows the correct information' do

--- a/spec/system/closed_applications_dashboard_spec.rb
+++ b/spec/system/closed_applications_dashboard_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Closed Applications Dashboard' do
   it 'includes the correct headings' do
     column_headings = page.first('.app-dashboard-table thead tr').text.squish
 
-    expect(column_headings).to eq('Applicant Ref. no. Date received Date closed Closed by Status')
+    expect(column_headings).to eq('Applicants name Reference number Date received Date closed Closed by Status')
   end
 
   it 'shows the correct information' do

--- a/spec/system/open_applications_dashboard_spec.rb
+++ b/spec/system/open_applications_dashboard_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe 'Open Applications Dashboard' do
     column_headings = page.first('.app-dashboard-table thead tr').text.squish
 
     # rubocop:disable Layout/LineLength
-    expect(column_headings).to eq('Applicants name Reference number Date received Business days since application was received Caseworker')
+    expect(column_headings).to eq("Applicant's name Reference number Date received Business days since application was received Caseworker")
+    # rubocop:enable Layout/LineLength
   end
-  # rubocop:enable Layout/LineLength
 
   it 'shows the correct information' do
     first_row_text = page.first('.app-dashboard-table tbody tr').text

--- a/spec/system/open_applications_dashboard_spec.rb
+++ b/spec/system/open_applications_dashboard_spec.rb
@@ -15,8 +15,10 @@ RSpec.describe 'Open Applications Dashboard' do
   it 'includes the correct headings' do
     column_headings = page.first('.app-dashboard-table thead tr').text.squish
 
-    expect(column_headings).to eq('Applicant Ref. no. Date received Days passed Caseworker')
+    # rubocop:disable Layout/LineLength
+    expect(column_headings).to eq('Applicants name Reference number Date received Business days since application was received Caseworker')
   end
+  # rubocop:enable Layout/LineLength
 
   it 'shows the correct information' do
     first_row_text = page.first('.app-dashboard-table tbody tr').text

--- a/spec/system/reporting/workload_report_spec.rb
+++ b/spec/system/reporting/workload_report_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'Workload Report' do
   end
 
   it 'shows the correct column headers' do
-    expected_column_headers = 'Business days since application ' \
-                              'was received Applications received Applications still open'
+    expected_column_headers = 'Business days since applications ' \
+                              'were received Applications received Applications still open'
     within('table thead tr') do
       expect(page).to have_content expected_column_headers
     end

--- a/spec/system/reporting/workload_report_spec.rb
+++ b/spec/system/reporting/workload_report_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe 'Workload Report' do
   end
 
   it 'shows the correct column headers' do
-    expected_column_headers = 'Business days since applications ' \
-                              'were received Applications received Applications still open'
-
+    expected_column_headers = 'Business days since application ' \
+                              'was received Applications received Applications still open'
     within('table thead tr') do
       expect(page).to have_content expected_column_headers
     end

--- a/spec/system/searching/search_filters_and_results_spec.rb
+++ b/spec/system/searching/search_filters_and_results_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Search Page' do
     column_headings = page.first('.app-dashboard-table thead tr').text.squish
 
     expect(column_headings).to eq(
-      'Applicants name Reference number Date received Date closed Caseworker Status'
+      "Applicant's name Reference number Date received Date closed Caseworker Status"
     )
   end
 

--- a/spec/system/searching/search_filters_and_results_spec.rb
+++ b/spec/system/searching/search_filters_and_results_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Search Page' do
     column_headings = page.first('.app-dashboard-table thead tr').text.squish
 
     expect(column_headings).to eq(
-      'Applicant Ref. no. Date received Date closed Caseworker Status'
+      'Applicants name Reference number Date received Date closed Caseworker Status'
     )
   end
 


### PR DESCRIPTION
## Description of change

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-267

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="990" alt="image" src="https://user-images.githubusercontent.com/106679087/232526022-7036bd59-a2d2-486e-a4f3-4b6e0e6ef5e9.png">

### After changes:
![image](https://user-images.githubusercontent.com/106679087/233071370-7b74c96d-6a28-42db-8650-c2ed4ee33a88.png)

## How to manually test the feature
- User logs into portal
- User go to the All open applications page
- User should see that the following headers in the table above screenshot have been updated
- Changed ‘Applicant’ to ‘Applicant’s name'
- Changed ‘Ref. no.’ to ‘Reference number’
- Changed ‘Days passed’ to ‘Business days since application was received’
