### PR TITLE
Move status above reference

### DIFF
--- a/app/views/crime_applications/_review_overview.html.erb
+++ b/app/views/crime_applications/_review_overview.html.erb
@@ -1,5 +1,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <div class="govuk-!-margin-top-5">
+      <span class="govuk-tag govuk-tag--<%= t(crime_application.review_status, scope: 'values.color') %> govuk-!-margin-bottom-4">
+        <%= t(crime_application.review_status, scope: 'values.review_status') %>
+      </span>
+    </div>
+
     <p class="govuk-body-l govuk-!-margin-bottom-2">
       <span class="govuk-!-margin-right-2" id="reference-number">
         <%= crime_application.reference %>
@@ -10,10 +16,6 @@
     <h2 class="govuk-heading-xl govuk-!-margin-bottom-4">
       <%= crime_application.applicant_name %>
     </h2>
-
-    <span class="govuk-tag govuk-tag--<%= t(crime_application.review_status, scope: 'values.color') %> govuk-!-margin-bottom-6">
-      <%= t(crime_application.review_status, scope: 'values.review_status') %>
-    </span>
 
     <%= render partial: 'assignment', locals: { crime_application: } %>
   </div>


### PR DESCRIPTION
## Description of change
Moves the status above the reference number as per the designs

## Link to relevant ticket
[CRIMRE-291](https://dsdmoj.atlassian.net/browse/CRIMRE-291)

## Screenshots of changes (if applicable)

### Before changes:
<img width="953" alt="Screenshot 2023-04-18 at 13 53 16" src="https://user-images.githubusercontent.com/13377553/232783486-09196e81-44b2-48dd-b13e-3450ee8558d8.png">

### After changes:
<img width="943" alt="Screenshot 2023-04-18 at 13 58 11" src="https://user-images.githubusercontent.com/13377553/232784682-af7f7ea4-5df5-4592-aa4d-aa9989a7f46f.png">

## How to manually test the feature
- open application show page
- status should be above the reference number
- also check that the spacing looks right to you against the designs.


[CRIMRE-291]: https://dsdmoj.atlassian.net/browse/CRIMRE-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ