### PR TITLE
REVIEW-CRIMINAL-LEGAL-AID-4 Update Schema Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.1.5'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 1054d16bcd6f4debc66083af56f8742c02b47659
+  revision: 933253dc37dc20c51efe962418c59f4d8bf8c75b
+  tag: v0.1.5
   specs:
     laa-criminal-legal-aid-schemas (0.1.4)
       dry-struct

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CrimeApplication do
   describe '#applicant_date_of_birth' do
     subject(:applicant_date_of_birth) { application.applicant_date_of_birth }
 
-    it { is_expected.to eq Date.parse('2011-06-09') }
+    it { is_expected.to eq Date.parse('2001-06-09') }
   end
 
   describe '#applicant_name' do


### PR DESCRIPTION
## Description of change

Update to use latest schema gem.

## Link to relevant ticket

FIXES: https://ministryofjustice.sentry.io/issues/4105872851/events/802e273436184fe9b9283e04be1e8756/

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
