### PR TITLE
CRIMRE-269-Updated the wording for open and closed application totals

### DIFF
--- a/app/views/crime_applications/index.html.erb
+++ b/app/views/crime_applications/index.html.erb
@@ -11,7 +11,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <div class="govuk-body">
-      <%= t('.total', count: @search.total) %>
+      <% if action_name == "closed" %>
+        <%= t('.total_closed', count: @search.total) %>
+      <% else %>
+        <%= t('.total_open', count: @search.total) %>
+      <%end%>
     </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -343,6 +343,13 @@ en:
       total:
         one: 1 application
         other: "%{count} applications"
+      total_open: 
+        zero: There are no open applications that need to be reviewed.
+        one: There is 1 open application that needs to be reviewed.
+        other: "There are %{count} open applications that need to be reviewed."
+      total_closed: 
+        one: There is 1 closed application that has been completed or sent back to the provider.
+        other: "There are %{count} closed applications that have been completed or sent back to the provider."
     show:
       page_title: Application
       heading: Application

--- a/spec/system/closed_applications_dashboard_spec.rb
+++ b/spec/system/closed_applications_dashboard_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Closed Applications Dashboard' do
   end
 
   it 'has the correct count' do
-    expect(page).to have_content('1 application')
+    expect(page).to have_content('There is 1 closed application that has been completed or sent back to the provider.')
   end
 
   it 'can be used to navigate to an application' do

--- a/spec/system/open_applications_dashboard_spec.rb
+++ b/spec/system/open_applications_dashboard_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Open Applications Dashboard' do
   end
 
   it 'has the correct count' do
-    expect(page).to have_content('2 applications')
+    expect(page).to have_content('There are 2 open applications that need to be reviewed.')
   end
 
   it 'can be used to navigate to an application' do


### PR DESCRIPTION
## Description of change

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-268
https://dsdmoj.atlassian.net/browse/CRIMRE-269

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
![image](https://user-images.githubusercontent.com/106679087/233100164-1959baf1-d9a3-4ead-b6e4-2dca9edbd1fc.png)

![image](https://user-images.githubusercontent.com/106679087/233100415-dd2968b6-0c38-47bc-a18e-0d6d592ca8cd.png)

### After changes:
![image](https://user-images.githubusercontent.com/106679087/233109178-43922fbb-3c59-415c-af2e-2e68b339d824.png)

![image](https://user-images.githubusercontent.com/106679087/233100527-6afc1836-9e1c-45f0-82b6-20f0b5a47c14.png)

## How to manually test the feature
- User logs into portal
- User clicks on either 'All open applications' or 'Closed applications'
- User should see underneath either heading on the page 'All open applications' or 'Closed applications' the following text         "There are [number] open applications that need to be reviewed" or "There are [number] closed applications that have been completed or sent back to the provider."

