### PR TITLE
Update date range formatting

### DIFF
--- a/app/views/crime_applications/_offences.html.erb
+++ b/app/views/crime_applications/_offences.html.erb
@@ -29,7 +29,8 @@
           <td class="govuk-table__cell">
               <%= l date.date_from, format: :compact %>
               <% if date.date_to %>
-                - <%= l date.date_to, format: :compact %>
+              <%= t('crime_applications.values.to') %>
+              <%= l date.date_to, format: :compact %>
               <% end %>
           </td>
         </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -149,6 +149,7 @@ en:
     appeal_to_crown_court: Appeal to crown court
     appeal_to_crown_court_with_changes: Appeal to crown court with changes in financial circumstances
     class: Class
+    to: to
     conflict_of_interest:
       "yes": CONFLICT
       "no": ''


### PR DESCRIPTION
## Description of change
Update date range formatting from "10/10/2022 - 11/10/2022" to "10/10/2022 to 11/10/2022"

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-274

## Notes for reviewer
Got agreement from Liv that the date wrapping over 2 lines is ok 
## Screenshots of changes (if applicable)

### Before changes:
<img width="689" alt="image" src="https://user-images.githubusercontent.com/45827968/233130191-5b069897-4463-4d67-b5ff-8887fbc5abb4.png">

### After changes:
<img width="709" alt="image" src="https://user-images.githubusercontent.com/45827968/233129948-d856fc3b-3fb5-4d14-8770-a7d0f7d164fb.png">

## How to manually test the feature
