### PR TITLE
CRIMAP-328 Switch datastore URL to internal svc

### DIFF
--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -8,7 +8,7 @@ data:
   RACK_ENV: production
   RAILS_ENV: production
   RAILS_SERVE_STATIC_FILES: enabled
-  DATASTORE_API_ROOT: https://criminal-applications-datastore-staging.apps.live.cloud-platform.service.justice.gov.uk
+  DATASTORE_API_ROOT: http://service-staging.laa-criminal-applications-datastore-staging.svc.cluster.local
   OMNIAUTH_AZURE_CLIENT_ID: 5d1ba28b-234a-44e1-9464-f5bec5228bfc
   OMNIAUTH_AZURE_TENANT_ID: c6874728-71e6-41fe-a9e1-2e8c36776ad8
   OMNIAUTH_AZURE_REDIRECT_URI: https://laa-review-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk/users/auth/azure_ad/callback


### PR DESCRIPTION
## Description of change
We are evaluating internal cross-namespace networking between Apply/Review and Datastore.

For the time being and until we decide so, external ingress will still be available.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-328

## Notes for reviewer

## How to manually test the feature
In theory everything should continue working as before, just slightly less latency when loading lists or paginating (thus difficult to evaluate as we don't have that many records yet).