### PR TITLE
Correct mark as ready cta and routing

### DIFF
--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -68,10 +68,10 @@ class CrimeApplicationsController < ApplicationController
 
   def flash_and_redirect(key, message)
     flash[key] = I18n.t(message, scope: [:flash, key])
-    if key == :success
+    if key == :success && message == :completed
       redirect_to assigned_applications_path
     else
-      redirect_to crime_application_path(params[:crime_application_id])
+      redirect_to crime_application_path(@crime_application.id)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -214,7 +214,7 @@ en:
     view_closed_on_count: View by date closed
     mark_complete: Mark as completed
     send_back: Send back to provider
-    mark_as_ready: Mark as ready
+    mark_as_ready: Mark as ready for MAAT
     sign_out: Sign out
     sign_in: Sign in
   confirmations:

--- a/spec/system/reviewing/mark_application_as_ready_spec.rb
+++ b/spec/system/reviewing/mark_application_as_ready_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Marking an application as ready for assessment' do
   include_context 'with an existing application'
 
-  let(:ready_for_assessment_cta) { 'Mark as ready' }
+  let(:ready_for_assessment_cta) { 'Mark as ready for MAAT' }
 
   before do
     visit '/'
@@ -26,15 +26,12 @@ RSpec.describe 'Marking an application as ready for assessment' do
       click_on 'Kit Pound'
     end
 
-    it 'has a visable "Mark as ready" CTA' do
-      expect(page).to have_content('Mark as ready')
+    it 'has a visable "Mark as ready for MAAT" CTA' do
+      expect(page).to have_content('Mark as ready for MAAT')
     end
 
     it 'redirects to the correct page' do
-      expect { click_button(ready_for_assessment_cta) }.to change { page.current_path }
-        .from(crime_application_path(crime_application_id)).to(
-          assigned_applications_path
-        )
+      expect { click_button(ready_for_assessment_cta) }.not_to(change { page.current_path })
     end
 
     it 'shows success flash message' do

--- a/spec/system/viewing_an_application/that_is_assigned_to_me_spec.rb
+++ b/spec/system/viewing_an_application/that_is_assigned_to_me_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe 'Viewing an application that is assigned to me' do
   end
 
   describe 'Conditional display of review buttons' do
-    it 'displays mark as ready button as default' do
-      expect(page).to have_content('Mark as ready')
+    it 'displays mark as ready for MAAT button as default' do
+      expect(page).to have_content('Mark as ready for MAAT')
       expect(page).not_to have_content('Mark as completed')
     end
 
@@ -28,13 +28,13 @@ RSpec.describe 'Viewing an application that is assigned to me' do
         allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
           .and_return(instance_double(DatastoreApi::Requests::UpdateApplication, call: {}))
 
-        click_button 'Mark as ready'
+        click_button 'Mark as ready for MAAT'
         visit crime_application_path(application_id)
       end
 
       it 'displays mark as completed button if application is marked as ready' do
         expect(page).to have_content('Mark as completed')
-        expect(page).not_to have_content('Mark as ready')
+        expect(page).not_to have_content('Mark as ready for MAAT')
       end
     end
   end

--- a/spec/system/viewing_an_application/that_is_assigned_to_somone_else_spec.rb
+++ b/spec/system/viewing_an_application/that_is_assigned_to_somone_else_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Viewing an application that is assigned to someone else' do
   end
 
   it 'does not show the review buttons' do
-    expect(page).not_to have_content('Mark as ready')
+    expect(page).not_to have_content('Mark as ready for MAAT')
     expect(page).not_to have_content('Mark as completed')
   end
 end


### PR DESCRIPTION
## Description of change
Marking as ready should reload current page, not redirect to Your list
Change Mark as Ready cta to Mark as ready for MAAT as per designs
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-296
## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
