### PR TITLE
CRIMRE-260 fix return email

### DIFF
--- a/app/controllers/returns_controller.rb
+++ b/app/controllers/returns_controller.rb
@@ -1,6 +1,5 @@
 class ReturnsController < ApplicationController
   before_action :set_crime_application
-  after_action :send_returned_notification_email, on: :create
 
   def new
     @return_details = ReturnDetails.new
@@ -29,10 +28,6 @@ class ReturnsController < ApplicationController
   # rubocop:enable Metrics/MethodLength
 
   private
-
-  def send_returned_notification_email
-    NotifyMailer.application_returned_email(@crime_application).deliver_now
-  end
 
   def flash_and_redirect(key, message)
     flash[key] = I18n.t(message, scope: [:flash, key])

--- a/config/initializers/event_store.rb
+++ b/config/initializers/event_store.rb
@@ -1,6 +1,10 @@
 Rails.configuration.to_prepare do
   event_store = Rails.configuration.event_store = RailsEventStore::Client.new
+
+  #Notifying
+  NotifyMailer::Configuration.new.call(event_store)
   
+  #Read Models
   CurrentAssignments::Configuration.new.call(event_store)
   ReceivedOnReports::Configuration.new.call(event_store)
 end

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -8,11 +8,15 @@ RSpec.describe NotifyMailer do
     allow(Rails.configuration).to receive(:govuk_notify_templates).and_return(
       application_returned_email: 'application_returned_email_template_id'
     )
+
+    allow(CrimeApplication).to receive(:find)
+      .with(crime_application.id)
+      .and_return(crime_application)
   end
 
   describe '#application_returned_email' do
     let(:mail) do
-      described_class.application_returned_email(crime_application)
+      described_class.application_returned_email(crime_application.id)
     end
 
     it_behaves_like 'a Notify mailer', template_id: 'application_returned_email_template_id'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,6 +43,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 
   config.include_context 'with a logged in user', type: :system
+  config.include_context 'with a stubbed mailer', type: :system
 
   # Use the faster rack test by default for system specs
   config.before(:each, type: :system) do |_example|

--- a/spec/system/reviewing/send_back_to_provider_spec.rb
+++ b/spec/system/reviewing/send_back_to_provider_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe 'Send an application back to the provider' do
         end
 
         it 'calls the NotifyMailer which would send an email to a provider' do
-          expect(NotifyMailer).to have_received(:application_returned_email)
-            .with(an_instance_of(CrimeApplication))
+          click_button(send_back_cta)
+          expect(NotifyMailer).to have_received(:application_returned_email).with(crime_application_id)
           expect(mailer_double).to have_received(:deliver_now)
         end
       end
@@ -160,12 +160,17 @@ RSpec.describe 'Send an application back to the provider' do
 
     describe 'AlreadySentBack' do
       let(:error_class) { Reviewing::AlreadySentBack }
+
       let(:message) do
         'This application was already sent back to the provider'
       end
 
       it 'notifies that the application has already been sent back' do
         expect(page).to have_content message
+      end
+
+      it 'does not send the notification email' do
+        expect(NotifyMailer).not_to have_received(:application_returned_email)
       end
     end
 
@@ -175,6 +180,10 @@ RSpec.describe 'Send an application back to the provider' do
 
       it 'notifies that the application was already completed' do
         expect(page).to have_content message
+      end
+
+      it 'does not send the notification email' do
+        expect(NotifyMailer).not_to have_received(:application_returned_email)
       end
     end
   end


### PR DESCRIPTION
## Description of change

Ensures that return emails are only sent when return succeeds
Ensures that notification/emails errors do not bock an application from being returned

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-260
https://dsdmoj.atlassian.net/browse/CRIMRE-300

## Notes for reviewer

Fixes both of the above bugs.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
