### PR TITLE
CRIMRE-279 Update github CI/CD workflow

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -1,0 +1,57 @@
+name: Deploy
+description: Deploy built docker image to a kubernetes namespace
+inputs:
+  environment-name:
+    description: Environment to which the app is being deployed (staging, production, etc)
+    required: true
+  git-crypt-key:
+    description: Base64 encoded git-crypt symmetric key
+    required: true
+  ecr-url:
+    description: ECR endpoint url
+    required: true
+  kube-cert:
+    description: Kubernetes service account ca.crt
+    required: true
+  kube-token:
+    description: Kubernetes service account token
+    required: true
+  kube-cluster:
+    description: Kubernetes service account cluster
+    required: true
+  kube-namespace:
+    description: Kubernetes cluster namespace
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Unlock git-crypt secrets
+      uses: sliteteam/github-action-git-crypt-unlock@8b1fa3ccc81e322c5c45fbab261eee46513fd3f8
+      env:
+        GIT_CRYPT_KEY: ${{ inputs.git-crypt-key }}
+
+    - name: Authenticate to the cluster
+      env:
+        KUBE_CERT: ${{ inputs.kube-cert }}
+        KUBE_TOKEN: ${{ inputs.kube-token }}
+        KUBE_CLUSTER: ${{ inputs.kube-cluster }}
+        KUBE_NAMESPACE: ${{ inputs.kube-namespace }}
+      shell: bash
+      run: |
+        echo "${KUBE_CERT}" > ca.crt
+        kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
+        kubectl config set-credentials deploy-user --token=${KUBE_TOKEN}
+        kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
+        kubectl config use-context ${KUBE_CLUSTER}
+
+    - name: Update deployment image
+      env:
+        ECR_URL: ${{ inputs.ecr-url }}
+        IMAGE_TAG: ${{ github.sha }}
+      shell: bash
+      run: envsubst < config/kubernetes/${{ inputs.environment-name }}/deployment.tpl > config/kubernetes/${{ inputs.environment-name }}/deployment.yml
+
+    - name: Apply manifest files
+      shell: bash
+      run: kubectl apply -f config/kubernetes/${{ inputs.environment-name }}

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -40,19 +40,20 @@ jobs:
           bundler-cache: true
 
       - name: Find yarn cache location
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: JS package cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
+        id: yarn-cache
         with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 
       - name: Install packages with yarn
-        run: yarn install --pure-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Precompile assets
         run: bin/rails assets:precompile
@@ -65,7 +66,7 @@ jobs:
 
       - name: Upload rspec coverage (if failure)
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: rspec-coverage
           path: coverage/*
@@ -95,7 +96,7 @@ jobs:
 
       - name: Push to ECR
         id: ecr
-        uses: jwalton/gh-ecr-push@3197046958514d9f2b97073bb797ca426db8061f
+        uses: jwalton/gh-ecr-push@b10a019116283fff10914554dfe85bfb1c21d41b
         with:
           access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
           secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
@@ -112,29 +113,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Unlock git-crypt secrets
-        uses: sliteteam/github-action-git-crypt-unlock@8b1fa3ccc81e322c5c45fbab261eee46513fd3f8
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+      - name: Deploy staging
+        uses: ./.github/actions/deploy
+        with:
+          environment-name: staging
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
+          ecr-url: ${{ secrets.ECR_URL }}
+          kube-cert: ${{ secrets.KUBE_STAGING_CERT }}
+          kube-token: ${{ secrets.KUBE_STAGING_TOKEN }}
+          kube-cluster: ${{ secrets.KUBE_STAGING_CLUSTER }}
+          kube-namespace: ${{ secrets.KUBE_STAGING_NAMESPACE }}
 
-      - name: Authenticate to the cluster
-        env:
-          KUBE_CERT: ${{ secrets.KUBE_STAGING_CERT }}
-          KUBE_TOKEN: ${{ secrets.KUBE_STAGING_TOKEN }}
-          KUBE_CLUSTER: ${{ secrets.KUBE_STAGING_CLUSTER }}
-          KUBE_NAMESPACE: ${{ secrets.KUBE_STAGING_NAMESPACE }}
-        run: |
-          echo "${KUBE_CERT}" > ca.crt
-          kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
-          kubectl config set-credentials deploy-user --token=${KUBE_TOKEN}
-          kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
-          kubectl config use-context ${KUBE_CLUSTER}
+  deploy-production:
+    runs-on: ubuntu-latest
+    needs: deploy-staging
+    environment: production
 
-      - name: Update deployment image
-        env:
-          ECR_URL: ${{ secrets.ECR_URL }}
-          IMAGE_TAG: ${{ github.sha }}
-        run: envsubst < config/kubernetes/staging/deployment.tpl > config/kubernetes/staging/deployment.yml
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-      - name: Apply manifest files
-        run: kubectl apply -f config/kubernetes/staging
+      - name: Deploy production
+        uses: ./.github/actions/deploy
+        with:
+          environment-name: production
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
+          ecr-url: ${{ secrets.ECR_URL }}
+          kube-cert: ${{ secrets.KUBE_PRODUCTION_CERT }}
+          kube-token: ${{ secrets.KUBE_PRODUCTION_TOKEN }}
+          kube-cluster: ${{ secrets.KUBE_PRODUCTION_CLUSTER }}
+          kube-namespace: ${{ secrets.KUBE_PRODUCTION_NAMESPACE }}


### PR DESCRIPTION
## Description of change
Updated some outdated action versions.

DRY github workflow to allow for reusable deploy action with parameterised inputs.

Do not merge until the k8s manifests in PR #235 are merged first.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-279
