### PR TITLE
CRIMRE-300 an application ready for MAAT can be sent back

### DIFF
--- a/app/aggregates/reviewing/errors.rb
+++ b/app/aggregates/reviewing/errors.rb
@@ -23,9 +23,6 @@ module Reviewing
   class CannotSendBackWhenCompleted < StandardError
   end
 
-  class CannotSendBackWhenMarkedAsReady < StandardError
-  end
-
   class CannotMarkAsReadyWhenCompleted < StandardError
   end
 end

--- a/app/aggregates/reviewing/review.rb
+++ b/app/aggregates/reviewing/review.rb
@@ -28,7 +28,6 @@ module Reviewing
       raise NotReceived unless received?
       raise AlreadySentBack if @state.equal?(:sent_back)
       raise CannotSendBackWhenCompleted if @state.equal?(:completed)
-      raise CannotSendBackWhenMarkedAsReady if @state.equal?(:marked_as_ready)
 
       apply SentBack.new(
         data: { application_id:, user_id:, reason: }

--- a/spec/aggregates/reviewing/review_spec.rb
+++ b/spec/aggregates/reviewing/review_spec.rb
@@ -132,10 +132,9 @@ describe Reviewing::Review do
       )
     end
 
-    it 'cannot then be sent back' do
-      expect do
-        review.send_back(user_id:, reason:)
-      end.to raise_error Reviewing::CannotSendBackWhenMarkedAsReady
+    it 'can then be sent back' do
+      review.send_back(user_id:, reason:)
+      expect(review.state).to eq :sent_back
     end
   end
 end


### PR DESCRIPTION

## Description of change
Allow applications that have been marked as ready for MAAT to be sent back.

## Link to relevant ticket

[CRIMRE-300](https://dsdmoj.atlassian.net/browse/CRIMRE-300)

## Notes for reviewer

We need to support returning applications that have already been added to MAAT.

An application that has been marked as ready for MAAT and then sent back before it is actually added to MAAT will behave as if it had never been marked as ready for maat. (Although the "Mark as Ready" event will be recorded/shown in the application history.)


## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
