### PR TITLE
CRIMRE-306 Store the parent id on application recieve

### DIFF
--- a/app/aggregates/reviewing/commands/receive_application.rb
+++ b/app/aggregates/reviewing/commands/receive_application.rb
@@ -2,12 +2,13 @@ module Reviewing
   class ReceiveApplication < Command
     attribute :application_id, Types::Uuid
     attribute :submitted_at, Types::DateTime
+    attribute? :parent_id, Types::Uuid.optional
     attribute? :correlation_id, Types::Uuid.optional
     attribute? :causation_id, Types::Uuid.optional
 
     def call
       with_review do |review|
-        review.receive_application(submitted_at:)
+        review.receive_application(submitted_at:, parent_id:)
       end
     end
   end

--- a/app/aggregates/reviewing/review.rb
+++ b/app/aggregates/reviewing/review.rb
@@ -10,17 +10,18 @@ module Reviewing
       @reviewed_at = nil
       @received_at = nil
       @submitted_at = nil
+      @parent_id = nil
     end
 
-    attr_reader :id, :state, :return_reason, :reviewed_at, :reviewer_id, :submitted_at
+    attr_reader :id, :state, :return_reason, :reviewed_at, :reviewer_id, :submitted_at, :parent_id
 
     alias application_id id
 
-    def receive_application(submitted_at:)
+    def receive_application(submitted_at:, parent_id: nil)
       raise AlreadyReceived if received?
 
       apply ApplicationReceived.new(
-        data: { application_id:, submitted_at: }
+        data: { application_id:, submitted_at:, parent_id: }
       )
     end
 
@@ -59,6 +60,7 @@ module Reviewing
       @state = :open
       @received_at = event.timestamp
       @submitted_at = event.data[:submitted_at]
+      @parent_id = event.data[:parent_id]
     end
 
     on SentBack do |event|

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -35,8 +35,8 @@ module Api
     def handle_notification!
       Reviewing::ReceiveApplication.call(
         application_id:,
-        correlation_id:,
         causation_id:,
+        parent_id:,
         submitted_at:
       )
 
@@ -53,8 +53,8 @@ module Api
       message.dig('data', 'submitted_at') || Time.zone.now.to_s
     end
 
-    def correlation_id
-      message.fetch('data').fetch('parent_id', application_id)
+    def parent_id
+      message.fetch('data').fetch('parent_id', nil)
     end
 
     def causation_id

--- a/app/models/application_search_result.rb
+++ b/app/models/application_search_result.rb
@@ -4,6 +4,7 @@ class ApplicationSearchResult < ApplicationStruct
   attribute :reference, Types::Integer
   attribute :resource_id, Types::Uuid
   attribute :status, Types::String
+  attribute? :parent_id, Types::Uuid.optional
 
   include Assignable
   include Reviewable

--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -20,11 +20,16 @@ module Reviewable
 
     Reviewing::ReceiveApplication.call(
       application_id: id,
-      submitted_at: submitted_at
+      submitted_at: submitted_at,
+      parent_id: parent_id
     )
 
     @review = nil
 
     self
+  end
+
+  def status?(status)
+    review_status == status
   end
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -48,10 +48,6 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
     !reviewed? && assigned_to?(user_id)
   end
 
-  def status?(status)
-    review_status == status
-  end
-
   class << self
     def find(id)
       application = new(

--- a/spec/aggregates/reviewing/receive_application_spec.rb
+++ b/spec/aggregates/reviewing/receive_application_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Reviewing::ReceiveApplication do
   subject(:command) do
     described_class.new(
-      application_id: application_id, submitted_at: Time.zone.now.to_s
+      application_id: application_id, submitted_at: Time.zone.now.to_s, parent_id: nil
     )
   end
 

--- a/spec/requests/api/events_spec.rb
+++ b/spec/requests/api/events_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Api::Events' do
       data: {
         id: application_id,
         submitted_at: DateTime.parse('2022-10-27T14:09:11'),
-        parent_id: nil
+        parent_id: 'parent_id_uuid'
       }
     }
   end
@@ -91,6 +91,7 @@ RSpec.describe 'Api::Events' do
 
     it 'creates an ApplicationReceived event' do
       expect { do_request }.to change { review.state }.from(nil).to(:open)
+                                                      .and change { review.parent_id }.from(nil).to('parent_id_uuid')
 
       expect(response).to have_http_status :created
     end

--- a/spec/shared_contexts/with_stubbed_search.rb
+++ b/spec/shared_contexts/with_stubbed_search.rb
@@ -6,14 +6,16 @@ RSpec.shared_context 'with stubbed search', shared_context: :metadata do
         resource_id: '696dd4fd-b619-4637-ab42-a5f4565bcf4a',
         reference: 120_398_120,
         status: 'submitted',
-        submitted_at: '2022-10-27T14:09:11.000+00:00'
+        submitted_at: '2022-10-27T14:09:11.000+00:00',
+        parent_id: nil
       ),
       ApplicationSearchResult.new(
         applicant_name: 'Don JONES',
         resource_id: '1aa4c689-6fb5-47ff-9567-5eee7f8ac2cc',
         reference: 1_230_234_359,
         status: 'submitted',
-        submitted_at: '2022-11-11T16:58:15.000+00:00'
+        submitted_at: '2022-11-11T16:58:15.000+00:00',
+        parent_id: nil
       )
     ]
   end

--- a/spec/system/assigning/get_next_application_spec.rb
+++ b/spec/system/assigning/get_next_application_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe 'Assigning an application to myself' do
           resource_id: '696dd4fd-b619-4637-ab42-a5f4565bcf4a',
           reference: 120_398_120,
           status: 'submitted',
-          submitted_at: '2022-10-27T14:09:11.000+00:00'
+          submitted_at: '2022-10-27T14:09:11.000+00:00',
+          parent_id: nil
         )
       ]
     end

--- a/spec/system/assigning/viewing_your_assigned_applications_spec.rb
+++ b/spec/system/assigning/viewing_your_assigned_applications_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe 'Viewing your assigned application' do
           resource_id: '696dd4fd-b619-4637-ab42-a5f4565bcf4a',
           reference: 120_398_120,
           status: 'submitted',
-          submitted_at: '2022-10-27T14:09:11.000+00:00'
+          submitted_at: '2022-10-27T14:09:11.000+00:00',
+          parent_id: nil
         )
       ]
     end

--- a/spec/system/closed_applications_dashboard_spec.rb
+++ b/spec/system/closed_applications_dashboard_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe 'Closed Applications Dashboard' do
         reference: 6_000_002,
         status: 'returned',
         submitted_at: '2022-09-27T14:10:00.000+00:00',
-        reviewed_at: '2022-12-15T16:58:15.000+00:00'
+        reviewed_at: '2022-12-15T16:58:15.000+00:00',
+        parent_id: nil
       )
     ]
   end

--- a/spec/system/viewing_an_application/history_when_a_resubmission_spec.rb
+++ b/spec/system/viewing_an_application/history_when_a_resubmission_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Viewing a resubmitted application's history" do
 
     Reviewing::ReceiveApplication.new(
       application_id: parent_id,
+      parent_id: nil,
       submitted_at: Time.zone.now.to_s
     ).call
 

--- a/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -4,7 +4,11 @@ RSpec.describe 'Viewing an application unassigned, open application' do
   let(:application_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
 
   before do
-    Reviewing::ReceiveApplication.call(application_id: application_id, submitted_at: '2022-10-24T09:50:04.000+00:00')
+    Reviewing::ReceiveApplication.call(
+      application_id: application_id,
+      submitted_at: '2022-10-24T09:50:04.000+00:00',
+      parent_id: nil
+    )
 
     visit '/'
     visit crime_application_path(application_id)


### PR DESCRIPTION
## Description of change

Store the parent_id when an application is received via SNS, search_result, or application find.

## Link to relevant ticket

https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/87

## Notes for reviewer
Latest designs require us to be able to link to the latest version of an application. 

This builds on https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/87 to import the parent_id to store the parent_id when an application is received.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
