### PR TITLE
CRIMRE-306 create review read model

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,0 +1,9 @@
+class Review < ApplicationRecord
+  #
+  # Review is a CQRS read model. It is configured by the
+  # Reviews::Configuration class
+  #
+  def readonly?
+    true
+  end
+end

--- a/app/read_models/reviews/configuration.rb
+++ b/app/read_models/reviews/configuration.rb
@@ -1,0 +1,20 @@
+module Reviews
+  # Review read model event store configuration
+  #
+  # Subscribe the Review read model's UpdateFromAggregate handler to
+  # the required Reviewing event.
+  #
+  class Configuration
+    READ_MODEL_CHANGING_EVENTS = [
+      Reviewing::ApplicationReceived,
+      Reviewing::SentBack,
+      Reviewing::Completed
+    ].freeze
+
+    def call(event_store)
+      event_store.subscribe(
+        Reviews::UpdateFromAggregate, to: READ_MODEL_CHANGING_EVENTS
+      )
+    end
+  end
+end

--- a/app/read_models/reviews/update_from_aggregate.rb
+++ b/app/read_models/reviews/update_from_aggregate.rb
@@ -1,0 +1,32 @@
+module Reviews
+  class UpdateFromAggregate
+    #
+    # Handle Reviewing events by updating the Review read model.
+    #
+    # When passed an event, update the Review read model attributes
+    # with those from the corresponding event sourced Reviewing::Review
+    # aggregate.
+    #
+    def call(event)
+      application_id = event.data.fetch(:application_id, nil)
+      return unless application_id
+
+      update_from_aggregate(Reviewing::LoadReview.call(application_id:))
+    end
+
+    private
+
+    def update_from_aggregate(review)
+      Review.upsert(
+        {
+          application_id: review.id,
+          state: review.state,
+          submitted_at: review.submitted_at,
+          reviewer_id: review.reviewer_id,
+          parent_id: review.parent_id,
+        },
+        unique_by: :application_id
+      )
+    end
+  end
+end

--- a/app/read_models/reviews/update_from_aggregate.rb
+++ b/app/read_models/reviews/update_from_aggregate.rb
@@ -4,26 +4,27 @@ module Reviews
     # Handle Reviewing events by updating the Review read model.
     #
     # When passed an event, update the Review read model attributes
-    # with those from the corresponding event sourced Reviewing::Review
-    # aggregate.
+    # with those from the corresponding event sourced aggregate.
     #
     def call(event)
       application_id = event.data.fetch(:application_id, nil)
       return unless application_id
 
-      update_from_aggregate(Reviewing::LoadReview.call(application_id:))
+      review_aggregate = Reviewing::LoadReview.call(application_id:)
+
+      update_from_aggregate(review_aggregate)
     end
 
     private
 
-    def update_from_aggregate(review)
+    def update_from_aggregate(review_aggregate)
       Review.upsert(
         {
-          application_id: review.id,
-          state: review.state,
-          submitted_at: review.submitted_at,
-          reviewer_id: review.reviewer_id,
-          parent_id: review.parent_id,
+          application_id: review_aggregate.id,
+          state: review_aggregate.state,
+          submitted_at: review_aggregate.submitted_at,
+          reviewer_id: review_aggregate.reviewer_id,
+          parent_id: review_aggregate.parent_id,
         },
         unique_by: :application_id
       )

--- a/config/initializers/event_store.rb
+++ b/config/initializers/event_store.rb
@@ -7,4 +7,5 @@ Rails.configuration.to_prepare do
   #Read Models
   CurrentAssignments::Configuration.new.call(event_store)
   ReceivedOnReports::Configuration.new.call(event_store)
+  Reviews::Configuration.new.call(event_store)
 end

--- a/db/migrate/20230425145156_create_reviews.rb
+++ b/db/migrate/20230425145156_create_reviews.rb
@@ -1,0 +1,17 @@
+class CreateReviews < ActiveRecord::Migration[7.0]
+  # Create the Review read model.
+  def change
+    create_table :reviews, id: false do |t|
+      t.uuid :application_id, null: false
+      t.string :state
+      t.uuid :reviewer_id
+      t.uuid :parent_id
+      t.timestamp :submitted_at
+    end
+
+    add_index :reviews, :application_id, unique: true
+    add_index :reviews, :reviewer_id
+    add_index :reviews, :parent_id
+    add_index :reviews, :state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_10_162458) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_25_145156) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -51,6 +51,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_10_162458) do
     t.integer "total_closed", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "reviews", id: false, force: :cascade do |t|
+    t.uuid "application_id", null: false
+    t.string "state"
+    t.uuid "reviewer_id"
+    t.uuid "parent_id"
+    t.datetime "submitted_at", precision: nil
+    t.index ["application_id"], name: "index_reviews_on_application_id", unique: true
+    t.index ["parent_id"], name: "index_reviews_on_parent_id"
+    t.index ["reviewer_id"], name: "index_reviews_on_reviewer_id"
+    t.index ["state"], name: "index_reviews_on_state"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Review do
+  it 'is a read only model' do
+    expect(described_class.new).to be_readonly
+  end
+end

--- a/spec/read_models/reviews/update_from_aggreate_spec.rb
+++ b/spec/read_models/reviews/update_from_aggreate_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Reviews::UpdateFromAggregate' do
   describe '#call' do
     let(:application_id) { SecureRandom.uuid }
-    let(:submitted_at) { Time.zone.now }
+    let(:submitted_at) { '2023-04-25' }
     let(:state) { 'received' }
     let(:parent_id) { SecureRandom.uuid }
     let(:reviewer_id) { SecureRandom.uuid }

--- a/spec/read_models/reviews/update_from_aggreate_spec.rb
+++ b/spec/read_models/reviews/update_from_aggreate_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'Reviews::UpdateFromAggregate' do
+  describe '#call' do
+    let(:application_id) { SecureRandom.uuid }
+    let(:submitted_at) { Time.zone.now }
+    let(:state) { 'received' }
+    let(:parent_id) { SecureRandom.uuid }
+    let(:reviewer_id) { SecureRandom.uuid }
+
+    before do
+      id = application_id
+
+      aggregate = instance_double(
+        Reviewing::Review,
+        id:, state:, submitted_at:, reviewer_id:, parent_id:
+      )
+
+      allow(Reviewing::LoadReview).to receive(:call).with(application_id:) {
+        aggregate
+      }
+
+      event = Reviewing::ApplicationReceived.new(data: { application_id: })
+
+      Reviews::UpdateFromAggregate.new.call(event)
+    end
+
+    describe 'the read model' do
+      subject(:read_model) { Review.find_by(application_id:) }
+
+      %i[application_id state submitted_at reviewer_id parent_id].each do |attribute|
+        it "sets the #{attribute}" do
+          expect(read_model.public_send(attribute)).to eq(send(attribute))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Create Review read model.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMRE-306

## Notes for reviewer

The Review read model is being introduced to facilitate two new querying requirements on Crime Review:

- Produce a list of all applications reviewed by a given caseworker [CRIMRE-302](https://dsdmoj.atlassian.net/browse/CRIMRE-302)
- Establish the latest version of a given application [CRIMRE-293](https://dsdmoj.atlassian.net/browse/CRIMRE-293)

The Review read model will be a standalone read model for the Review aggregate. Whenever a Review READ_MODEL_CHANGING_EVENT occurs, the corresponding handler will load the Review aggregate from the event stream and store the necessary attributes into the read model.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-302]: https://dsdmoj.atlassian.net/browse/CRIMRE-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMRE-293]: https://dsdmoj.atlassian.net/browse/CRIMRE-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ