### PR TITLE
CRIMAP-172 Add staging subdomain to ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Read [how to connect the cluster](https://user-guide.cloud-platform.service.just
 
 **Namespaces for this service:**
 * [staging namespace](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging)
+* [production namespace](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production)
 
 ### Encode secrets in Base64
 

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -16,8 +16,21 @@ spec:
   tls:
   - hosts:
     - laa-review-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk
+  - hosts:
+    - staging.review-criminal-legal-aid.service.justice.gov.uk
+    secretName: domain-tls-certificate-staging
   rules:
   - host: laa-review-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: service-staging
+            port:
+              number: 80
+  - host: staging.review-criminal-legal-aid.service.justice.gov.uk
     http:
       paths:
       - path: /


### PR DESCRIPTION
## Description of change
This is a subdomain of our production domain.

Internal cloud platform URLs are still available and functional, but this is now an easier to remember domain.

Azure config might require changes to work with this subdomain.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-172

