### PR TITLE
Redirect cloud urls to new domains

### DIFF
--- a/config/kubernetes/production/config_map.yml
+++ b/config/kubernetes/production/config_map.yml
@@ -12,4 +12,4 @@ data:
   DATASTORE_API_ROOT: http://service-production.laa-criminal-applications-datastore-production.svc.cluster.local
   OMNIAUTH_AZURE_CLIENT_ID: 7dfb0abc-3b2e-41cf-a2ae-639c5f6b54ba
   OMNIAUTH_AZURE_TENANT_ID: c6874728-71e6-41fe-a9e1-2e8c36776ad8
-  OMNIAUTH_AZURE_REDIRECT_URI: https://laa-review-criminal-legal-aid-production.apps.live.cloud-platform.service.justice.gov.uk/users/auth/azure_ad/callback
+  OMNIAUTH_AZURE_REDIRECT_URI: https://review-criminal-legal-aid.service.justice.gov.uk/users/auth/azure_ad/callback

--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -7,6 +7,9 @@ metadata:
     external-dns.alpha.kubernetes.io/set-identifier: ingress-production-laa-review-criminal-legal-aid-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/server-snippet: |
+      if ($host = 'laa-review-criminal-legal-aid-production.apps.live.cloud-platform.service.justice.gov.uk') {
+        return 301 https://review-criminal-legal-aid.service.justice.gov.uk;
+      }
       location = /.well-known/security.txt {
         auth_basic off;
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -11,4 +11,4 @@ data:
   DATASTORE_API_ROOT: http://service-staging.laa-criminal-applications-datastore-staging.svc.cluster.local
   OMNIAUTH_AZURE_CLIENT_ID: 5d1ba28b-234a-44e1-9464-f5bec5228bfc
   OMNIAUTH_AZURE_TENANT_ID: c6874728-71e6-41fe-a9e1-2e8c36776ad8
-  OMNIAUTH_AZURE_REDIRECT_URI: https://laa-review-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk/users/auth/azure_ad/callback
+  OMNIAUTH_AZURE_REDIRECT_URI: https://staging.review-criminal-legal-aid.service.justice.gov.uk/users/auth/azure_ad/callback

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -7,6 +7,9 @@ metadata:
     external-dns.alpha.kubernetes.io/set-identifier: ingress-staging-laa-review-criminal-legal-aid-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/server-snippet: |
+      if ($host = 'laa-review-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk') {
+        return 301 https://staging.review-criminal-legal-aid.service.justice.gov.uk;
+      }
       location = /.well-known/security.txt {
         auth_basic off;
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;


### PR DESCRIPTION
## Description of change
The old cloud URLs will keep working (so we don't break bookmarks etc.) but they will redirect to the corresponding new domain/subdomain.

NOTE: Azure might require configuring this new callback. Only merge once that's done.

Follow-up to PRs #244 and #246.
