### PR TITLE
CRIMRE-203 include reviewed applications in caseworker filter

### DIFF
--- a/app/models/current_assignment.rb
+++ b/app/models/current_assignment.rb
@@ -8,4 +8,11 @@ class CurrentAssignment < ApplicationRecord
   def readonly?
     true
   end
+
+  class << self
+    # returns an array of crime application ids currently assigned to the user_id.
+    def assigned_to_ids(user_id:)
+      where(user_id:).pluck(:assignment_id)
+    end
+  end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -6,4 +6,11 @@ class Review < ApplicationRecord
   def readonly?
     true
   end
+
+  class << self
+    # returns an array of crime application ids reviewed by the user id.
+    def reviewed_by_ids(user_id:)
+      where(reviewer_id: user_id).pluck(:application_id)
+    end
+  end
 end

--- a/spec/shared_contexts/with_stubbed_assignments_and_reviews.rb
+++ b/spec/shared_contexts/with_stubbed_assignments_and_reviews.rb
@@ -1,0 +1,51 @@
+RSpec.shared_context 'with stubbed assignments and reviews', shared_context: :metadata do
+  let(:david) do
+    User.create!(
+      auth_oid: '35d581ba-b1f5-4d96-8b1d-233bfe67dfe5',
+      first_name: 'David',
+      last_name: 'Brown',
+      email: 'David.Browneg@justice.gov.uk'
+    )
+  end
+
+  let(:john) do
+    User.create!(
+      auth_oid: '992c1667-745f-4eda-848b-eec7cd92d7fa',
+      first_name: 'John',
+      last_name: 'Deere',
+      email: 'John.Deereeg@justice.gov.uk'
+    )
+  end
+
+  let(:johns_applications) { [SecureRandom.uuid, SecureRandom.uuid] }
+  let(:davids_applications) { [SecureRandom.uuid, SecureRandom.uuid] }
+
+  let(:current_assignment_ids) do
+    [
+      johns_applications.first, johns_applications.last,
+      davids_applications.first, davids_applications.last,
+    ]
+  end
+
+  before do
+    allow(CurrentAssignment).to receive(:assigned_to_ids).with(user_id: john.id) {
+      [johns_applications.first]
+    }
+
+    allow(CurrentAssignment).to receive(:assigned_to_ids).with(user_id: david.id) {
+      [davids_applications.first]
+    }
+
+    allow(Review).to receive(:reviewed_by_ids).with(user_id: john.id) {
+      [johns_applications.last]
+    }
+
+    allow(Review).to receive(:reviewed_by_ids).with(user_id: david.id) {
+      [davids_applications.last]
+    }
+
+    allow(CurrentAssignment).to receive(:pluck).with(:assignment_id) {
+      current_assignment_ids
+    }
+  end
+end


### PR DESCRIPTION
## Description of change
Show both currently assigned and previously reviewed applications in the results when filtering by caseworker.

## Link to relevant ticket

[CRIMRE-302](https://dsdmoj.atlassian.net/browse/CRIMRE-302)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
