### PR TITLE
CRIMRE-293 Add resubmission to a superseded applications history

### DIFF
--- a/app/aggregates/reviewing/commands/receive_application.rb
+++ b/app/aggregates/reviewing/commands/receive_application.rb
@@ -10,6 +10,15 @@ module Reviewing
       with_review do |review|
         review.receive_application(submitted_at:, parent_id:)
       end
+
+      return unless parent_id
+
+      # Supersede parent application if one exists
+      Reviewing::Supersede.call(
+        application_id: parent_id,
+        superseded_at: submitted_at,
+        superseded_by: application_id
+      )
     end
   end
 end

--- a/app/aggregates/reviewing/commands/supersede.rb
+++ b/app/aggregates/reviewing/commands/supersede.rb
@@ -1,0 +1,13 @@
+module Reviewing
+  class Supersede < Command
+    attribute :application_id, Types::Uuid
+    attribute :superseded_at, Types::DateTime
+    attribute :superseded_by, Types::Uuid
+
+    def call
+      with_review do |review|
+        review.supersede(superseded_at:, superseded_by:)
+      end
+    end
+  end
+end

--- a/app/aggregates/reviewing/events/superseded.rb
+++ b/app/aggregates/reviewing/events/superseded.rb
@@ -1,0 +1,4 @@
+module Reviewing
+  class Superseded < Event
+  end
+end

--- a/app/aggregates/reviewing/review.rb
+++ b/app/aggregates/reviewing/review.rb
@@ -10,10 +10,13 @@ module Reviewing
       @reviewed_at = nil
       @received_at = nil
       @submitted_at = nil
+      @superseded_at = nil
+      @superseded_by = nil
       @parent_id = nil
     end
 
-    attr_reader :id, :state, :return_reason, :reviewed_at, :reviewer_id, :submitted_at, :parent_id
+    attr_reader :id, :state, :return_reason, :reviewed_at, :reviewer_id,
+                :submitted_at, :superseded_by, :superseded_at, :parent_id
 
     alias application_id id
 
@@ -32,6 +35,12 @@ module Reviewing
 
       apply SentBack.new(
         data: { application_id:, user_id:, reason: }
+      )
+    end
+
+    def supersede(superseded_at:, superseded_by:)
+      apply Superseded.new(
+        data: { application_id:, superseded_at:, superseded_by: }
       )
     end
 
@@ -68,6 +77,11 @@ module Reviewing
       @return_reason = event.data.fetch(:reason, nil)
       @reviewer_id = event.data.fetch(:user_id)
       @reviewed_at = event.timestamp
+    end
+
+    on Superseded do |event|
+      @superseded_at = event.data.fetch(:superseded_at)
+      @superseded_by = event.data.fetch(:superseded_by)
     end
 
     on Completed do |event|

--- a/app/models/application_history.rb
+++ b/app/models/application_history.rb
@@ -17,10 +17,6 @@ class ApplicationHistory < ApplicationStruct
 
   private
 
-  #
-  # TODO: Refactor as part of CRIMRE-180
-  # Assignment and Review will be combined into a single stream / aggregate.
-  #
   def load_from_events
     RailsEventStore::Projection
       .from_stream(streams)

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -48,6 +48,47 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
     !reviewed? && assigned_to?(user_id)
   end
 
+  # NOTE: This code is intended for temporary use during user research on the
+  # staging environment from 3-4 May. The code is not part of the final
+  # implementation and should not be used in production.
+  #
+  # In production, the events stream will provide up-to-date events. However,
+  # as the supserseding events are not available on the staging data user for
+  # user testing, we are artificially generating the events for testing purposes only.
+
+  # TODO: remove after 4 May
+  def superseding_history_item
+    return nil unless superseded_by
+
+    ApplicationHistoryItem.new(
+      user_name: legal_rep_name,
+      event_type: 'Reviewing::Superseded',
+      timestamp: superseded_at,
+      event_data: { superseded_by: }
+    )
+  end
+
+  # TODO: remove after 4 May
+  def superseded?
+    superseded_by.present?
+  end
+
+  # TODO: remove after 4 May
+  def superseding_review
+    @superseding_review ||= Review.find_by(parent_id: id)
+  end
+
+  # TODO: remove after 4 May
+  def superseded_by
+    superseding_review&.application_id
+  end
+
+  # TODO: remove after 4 May
+  def superseded_at
+    superseding_review&.submitted_at
+  end
+  # END user research temporary code
+
   class << self
     def find(id)
       application = new(

--- a/app/views/application_history_items/_reviewing_application_received.html.erb
+++ b/app/views/application_history_items/_reviewing_application_received.html.erb
@@ -1,17 +1,13 @@
-
-  <% if event_is_for_current_version %>
-    <strong>
-      <%= t("reviewing.#{submission_type}", scope: 'event.description') %>
-    </strong>
+<strong>
+  <% if application.parent_id.nil? %>
+    <%= t('reviewing.application_received', scope: 'event.description') %> <br>
   <% else %>
-    <strong>
-      <% if event_is_for_initial_submission %>
-        <%= t('reviewing.application_received', scope: 'event.description') %> <br>
-      <% else %>
-        <%= t('reviewing.application_resubmitted', scope: 'event.description') %> <br>
-      <% end %>
-    </strong>
-    <%= link_to t('reviewing.selected_application', scope: 'event.description'),
-                crime_application_path(application.id),
-                class: 'govuk-link--no-visited-state' %>
+    <%= t('reviewing.application_resubmitted', scope: 'event.description') %> <br>
   <% end %>
+</strong>
+
+<% unless event_is_for_current_version %>
+  <%= link_to t('reviewing.selected_application', scope: 'event.description'),
+              crime_application_path(application.id),
+              class: 'govuk-link--no-visited-state' %>
+<% end %>

--- a/app/views/application_history_items/_reviewing_superseded.html.erb
+++ b/app/views/application_history_items/_reviewing_superseded.html.erb
@@ -1,0 +1,7 @@
+<strong>
+  <%= t('reviewing.application_resubmitted', scope: 'event.description') %> <br>
+</strong>
+
+<%= link_to t('reviewing.selected_application', scope: 'event.description'),
+            crime_application_path(item.event_data.fetch(:superseded_by)),
+            class: 'govuk-link--no-visited-state' %>

--- a/app/views/crime_applications/history.html.erb
+++ b/app/views/crime_applications/history.html.erb
@@ -25,18 +25,18 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
+      <% if @crime_application.superseded? %>
+        <%= render partial: @crime_application.superseding_history_item, as: :item, layout: 'history_item' %>
+      <% end %>
+
       <% @crime_application.all_histories.each do |history| %>
         <% history.items.each do |item| %>
           <%= render partial: item,
                      layout: 'history_item',
                      as: :item,
                      locals: {
-                       submission_type: @crime_application.parent_id.present? ? 'application_resubmitted' : 'application_received',
                        event_is_for_current_version: (
                          @crime_application.id == history.application.id
-                       ),
-                       event_is_for_initial_submission: (
-                         history.application.id == @crime_application.all_histories.last.application.id
                        ),
                        application: history.application
                      } %>

--- a/spec/system/viewing_an_application/history_when_a_resubmission_spec.rb
+++ b/spec/system/viewing_an_application/history_when_a_resubmission_spec.rb
@@ -61,4 +61,21 @@ RSpec.describe "Viewing a resubmitted application's history" do
         .to(crime_application_path(parent_id))
     end
   end
+
+  context 'when viewing the superseded application\'s history' do
+    before do
+      visit(history_crime_application_path(parent_id))
+    end
+
+    it 'shows the resubmission event at the top of the application history' do
+      first_row = page.first('.app-dashboard-table tbody tr').text
+      expect(first_row).to match('Application resubmitted Go to this version')
+    end
+
+    it 'the resubmission item includes a link to the resubmitted application' do
+      expect { click_on('Go to this version') }.to change { page.current_path }
+        .from(history_crime_application_path(parent_id))
+        .to(crime_application_path(application_id))
+    end
+  end
 end


### PR DESCRIPTION
## Description of change

Create a "Superseded" event in the event stream of an application when a new version is submitted.
Provide a link to the superseding application on the superseded application's history.
 
## Link to relevant ticket
[CRIMRE-293](https://dsdmoj.atlassian.net/browse/CRIMRE-293)

## Notes for reviewer
The code in the CrimeApplication model is intended for temporary use during user research on the staging environment from 3-4 May. This code is not part of the final implementation and should not be used in production.

In production, the events stream will provide up-to-date events. However, as the supserseding events are not available on the staging data user for user testing, we are artificially generating the events for testing purposes only.

## Screenshots of changes (if applicable)

### Before changes:
<img width="664" alt="Screenshot 2023-05-03 at 16 13 10" src="https://user-images.githubusercontent.com/34935/235959655-db740bc8-d50b-40fe-b1d2-650c5507c66d.png">

### After changes:
![image](https://user-images.githubusercontent.com/34935/235960251-8cfd4a56-42f8-41a8-b3ad-64ded07f1b06.png)

## How to manually test the feature


[CRIMRE-293]: https://dsdmoj.atlassian.net/browse/CRIMRE-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ