### PR TITLE
CRIMRE-210 user invitations expire in 48 hours

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   include Reauthable
 
   before_create do
-    self.invitation_expires_at = Rails.configuration.x.auth.reauthenticate_in.from_now
+    self.invitation_expires_at = Rails.configuration.x.auth.invitation_ttl.from_now
   end
 
   scope :pending_activation, lambda {
@@ -27,10 +27,6 @@ class User < ApplicationRecord
 
   def deactivate!
     update!(deactivated_at: Time.zone.now)
-  end
-
-  def activated?
-    !auth_subject_id.nil?
   end
 
   def pending_activation?

--- a/app/models/user_authenticate.rb
+++ b/app/models/user_authenticate.rb
@@ -1,44 +1,43 @@
 class UserAuthenticate
   def initialize(auth_hash)
     @auth_subject_id = auth_hash.uid
-    @auth_expires_at = Time.zone.now + auth_hash.credentials.expires_in
     @last_auth_at = Time.zone.now
     @auth_info = auth_hash.info
   end
 
   def authenticate!
     return nil unless user
-    return nil if user.deactivated?
 
-    user.update!(auth_details)
+    activate_user if user.pending_activation?
+
+    user.update(
+      first_name:, last_name:, email:, last_auth_at:
+    )
 
     user
   end
 
   def user
-    @user ||= User.find_by(auth_subject_id:) || User.find_by(email:)
+    @user ||= find_active_user || find_invited_user
   end
 
   private
 
-  attr_reader :auth_expires_at, :auth_info, :auth_subject_id, :last_auth_at
+  attr_reader :auth_info, :auth_subject_id, :last_auth_at
+
+  alias first_auth_at last_auth_at
 
   delegate :email, :first_name, :last_name, to: :@auth_info
 
-  def auth_details
-    details = {
-      first_name:,
-      last_name:,
-      email:,
-      last_auth_at:,
-      auth_expires_at:
-    }
+  def activate_user
+    user.assign_attributes(first_auth_at:, auth_subject_id:)
+  end
 
-    return details unless user.pending_authentication?
+  def find_active_user
+    User.active.find_by(auth_subject_id:)
+  end
 
-    details[:auth_subject_id] = auth_subject_id
-    details[:first_auth_at] = last_auth_at
-
-    details
+  def find_invited_user
+    User.pending_activation.find_by(email:)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,9 @@ module LaaReviewCriminalLegalAid
 
     # Authentication, authorization, and session configuration
 
+    # Length of time before a user account invitation expires
+    config.x.auth.invitation_ttl = 48.hours 
+
     # The maximum time since a users was last authenticated on DOM1 before
     # they are automatically signed out.
     config.x.auth.reauthenticate_in = 12.hours

--- a/db/migrate/20230504142944_rename_users_auth_expires_at_invitation_expires_at.rb
+++ b/db/migrate/20230504142944_rename_users_auth_expires_at_invitation_expires_at.rb
@@ -1,0 +1,5 @@
+class RenameUsersAuthExpiresAtInvitationExpiresAt < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :users, :auth_expires_at, :invitation_expires_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_25_145156) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_04_142944) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -77,7 +77,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_25_145156) do
     t.string "auth_subject_id"
     t.boolean "can_manage_others", default: false, null: false
     t.datetime "deactivated_at", precision: nil
-    t.datetime "auth_expires_at"
+    t.datetime "invitation_expires_at"
     t.index ["auth_subject_id"], name: "index_users_on_auth_subject_id", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
   end

--- a/spec/models/user_authenticate_spec.rb
+++ b/spec/models/user_authenticate_spec.rb
@@ -4,9 +4,6 @@ RSpec.describe UserAuthenticate do
   describe '.authenticate!' do
     subject(:authenticate!) { described_class.new(auth_hash).authenticate! }
 
-    let(:auth_expires_at) { expires_in.from_now }
-    let(:expires_in) { 1.minute }
-
     let(:auth_hash) do
       OmniAuth::AuthHash.new(
         {
@@ -15,12 +12,13 @@ RSpec.describe UserAuthenticate do
           email: 'test@example.com',
           first_name: 'Jo',
           last_name: 'TEST'
-        },
-        credentials: {
-          expires_in:
         }
         }
       )
+    end
+
+    before do
+      auth_hash
     end
 
     context 'when user does not exist in database' do
@@ -29,42 +27,49 @@ RSpec.describe UserAuthenticate do
 
     context 'when an active user is found' do
       let(:user) do
-        instance_double(
-          User,
-          update!: true,
-          pending_authentication?: false,
-          deactivated?: false
+        User.create!(
+          auth_subject_id: auth_hash.uid,
+          email: 'test1@example.com',
+          last_auth_at: '2023-05-04'
         )
       end
 
-      let(:expected_attributes) do
-        {
-          first_name: 'Jo',
-          last_name: 'TEST',
-          email: 'test@example.com',
-          last_auth_at: Time.zone.now,
-          auth_expires_at: auth_expires_at
-        }
-      end
-
       before do
-        freeze_time
-        allow(User).to receive(:find_by).with(
-          { auth_subject_id: auth_hash.uid }
-        ).and_return user
+        user
       end
 
       it 'returns the active user' do
-        expect(authenticate!).to be user
+        expect(authenticate!).to eq user
       end
 
-      it "sets the user's name, email and last_auth_at" do
-        authenticate!
-        expect(user).to have_received(:update!).with expected_attributes
+      it "updates the user's name" do
+        expect { authenticate! }.to(
+          change { user.reload.name }.from('').to('Jo TEST')
+        )
+      end
+
+      it "updates the user's email" do
+        expect { authenticate! }.to(
+          change { user.reload.email }.from('test1@example.com').to('test@example.com')
+        )
+      end
+
+      it "sets the user's last_auth_at" do
+        expect { authenticate! }.to(
+          change { user.reload.last_auth_at }
+        )
+      end
+
+      it "does not change the user's first_auth_at" do
+        expect { authenticate! }.not_to(
+          change { user.reload.first_auth_at }
+        )
       end
 
       context 'when the user is deactivated' do
-        let(:user) { instance_double(User, deactivated?: true) }
+        before do
+          user.deactivate!
+        end
 
         it 'returns nil' do
           expect(authenticate!).to be_nil
@@ -72,53 +77,75 @@ RSpec.describe UserAuthenticate do
       end
     end
 
-    context 'when a user pending_activation is found' do
+    context 'when an invided user is found' do
       let(:user) do
-        instance_double(
-          User,
-          update!: true,
-          pending_authentication?: true,
-          deactivated?: false
-        )
-      end
-
-      let(:expected_attributes) do
-        {
-          first_name: 'Jo',
-          last_name: 'TEST',
-          auth_subject_id: auth_hash.uid,
-          auth_expires_at: auth_expires_at,
-          email: auth_hash.info.email,
-          first_auth_at: Time.zone.now,
-          last_auth_at: Time.zone.now
-        }
+        User.create!(email: 'test@example.com')
       end
 
       before do
-        freeze_time
+        user
+      end
 
-        allow(User).to receive(:find_by).with(auth_subject_id: auth_hash.uid).and_return(nil)
-
-        allow(User).to receive(:find_by).with(email: auth_hash.info.email) { user }
+      it 'activates the user' do
+        expect { authenticate! }.to(
+          change { user.reload.activated? }.from(false).to(true)
+        )
       end
 
       it 'returns the active user' do
-        expect(authenticate!).to be user
+        expect(authenticate!).to eq user
       end
 
-      it "sets the user's name, auth_oid, first_auth_at and last_auth_at" do
-        authenticate!
-        expect(user).to have_received(:update!).with(expected_attributes)
+      it "updates the user's name" do
+        expect { authenticate! }.to(
+          change { user.reload.name }.from('').to('Jo TEST')
+        )
       end
 
-      context 'when the user is deactivated' do
+      it "sets the user's last_auth_at" do
+        expect { authenticate! }.to(
+          change { user.reload.last_auth_at }
+        )
+      end
+
+      it "sets the user's auth_subject_id" do
+        expect { authenticate! }.to(
+          change { user.reload.auth_subject_id }.from(nil).to(auth_hash.uid)
+        )
+      end
+
+      it "sets the user's first_auth_at" do
+        expect { authenticate! }.to(
+          change { user.reload.first_auth_at }
+        )
+      end
+
+      context 'when the user\'s invitation has expired' do
         before do
-          allow(user).to receive(:deactivated?).and_return true
+          user.update(invitation_expires_at: Time.zone.now)
         end
 
         it 'returns nil' do
           expect(authenticate!).to be_nil
         end
+
+        it 'does not activate the user' do
+          expect { authenticate! }.not_to change { user.reload.auth_subject_id }.from(nil)
+        end
+      end
+    end
+
+    context 'with an activated user with the same email but different auth subject id' do
+      let(:user) do
+        User.create(auth_subject_id: SecureRandom.uuid, email: 'test@example.com')
+      end
+
+      before do
+        user
+      end
+
+      it 'returns nil' do
+        expect(authenticate!).to be_nil
       end
     end
   end

--- a/spec/models/user_authenticate_spec.rb
+++ b/spec/models/user_authenticate_spec.rb
@@ -86,12 +86,6 @@ RSpec.describe UserAuthenticate do
         user
       end
 
-      it 'activates the user' do
-        expect { authenticate! }.to(
-          change { user.reload.activated? }.from(false).to(true)
-        )
-      end
-
       it 'returns the active user' do
         expect(authenticate!).to eq user
       end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'Authentication Session Initialisation' do
 
       it 'sets the current user name' do
         expect { auth_callback }.to(
-          change { user.reload.name }.from(' ').to('Ben EXAMPLE')
+          change { user.reload.name }.from('').to('Ben EXAMPLE')
         )
       end
     end
@@ -131,7 +131,7 @@ RSpec.describe 'Authentication Session Initialisation' do
 
       it 'sets the current user name' do
         expect { auth_callback }.to(
-          change { user.reload.name }.from(' ').to('Ben EXAMPLE')
+          change { user.reload.name }.from('').to('Ben EXAMPLE')
         )
       end
     end


### PR DESCRIPTION
## Description of change

User account invitations only last 48 hours from creation.

## Link to relevant ticket
[CRIMRE-210](https://dsdmoj.atlassian.net/browse/CRIMRE-210)

## Notes for reviewer

Note this PR only adds a time limit to invitations and prevents authentication if more than 48 hours have expired since the invitation was created.
 
How a user manager deals with expired invitations will be part of another ticket. As will the text for the invitation email.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-210]: https://dsdmoj.atlassian.net/browse/CRIMRE-210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ