### PR TITLE
Fix lograge payload current user method

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
 
   config.lograge.custom_payload do |controller|
     {
-      user_id: controller.current_user_id.to_param,
+      user_id: controller.current_user.to_param,
     }
   end
 end


### PR DESCRIPTION
## Description of change
Follow up to PR #253.

`current_user` is defined by Devise automagically. `current_user_id` is a private method in `ApplicationController` but the health controller is a `BareApplicationController` thus don't inherit this and other methods.

Fix pods going into `CrashLoopBackOff` as the probe fails to assert the readiness of the pod.
