### PR TITLE
Fix typo filtered_params --> filtered_parameters

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
       host: request.host,
       request_id: request.request_id,
       user_agent: request.user_agent,
-      params: request.filtered_params.except(
+      params: request.filtered_parameters.except(
         *%w[controller action format id]
       ),
     }.compact_blank


### PR DESCRIPTION
Was stopping logs being captured due to method missing.