### PR TITLE
Add return_reason to return email

### DIFF
--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -16,7 +16,17 @@ RSpec.describe NotifyMailer do
 
   describe '#application_returned_email' do
     let(:mail) do
-      described_class.application_returned_email(crime_application.id)
+      described_class.application_returned_email(
+        crime_application.id, :clarification_required
+      )
+    end
+
+    let(:personalisation) do
+      {
+        applicant_name: 'Kit Pound',
+        application_reference: '6000001',
+        return_reason: 'Clarification required'
+      }
     end
 
     it_behaves_like 'a Notify mailer', template_id: 'application_returned_email_template_id'
@@ -24,12 +34,7 @@ RSpec.describe NotifyMailer do
     it { expect(mail.to).to eq(['provider@example.com']) }
 
     it 'has the right personalisation' do
-      expect(mail.govuk_notify_personalisation).to eq(
-        {
-          applicant_name: 'Kit Pound',
-          application_reference: '6000001'
-        }
-      )
+      expect(mail.govuk_notify_personalisation).to eq(personalisation)
     end
   end
 end

--- a/spec/system/reviewing/send_back_to_provider_spec.rb
+++ b/spec/system/reviewing/send_back_to_provider_spec.rb
@@ -88,7 +88,9 @@ RSpec.describe 'Send an application back to the provider' do
 
         it 'calls the NotifyMailer which would send an email to a provider' do
           click_button(send_back_cta)
-          expect(NotifyMailer).to have_received(:application_returned_email).with(crime_application_id)
+          expect(NotifyMailer).to have_received(:application_returned_email).with(
+            crime_application_id, 'duplicate_application'
+          )
           expect(mailer_double).to have_received(:deliver_now)
         end
       end


### PR DESCRIPTION
## Description of change
Adds return reason to email.

## Link to relevant ticket
[CRIMRE-316](https://dsdmoj.atlassian.net/browse/CRIMRE-316)

## Notes for reviewer
Notify Templates also updated to include this.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-316]: https://dsdmoj.atlassian.net/browse/CRIMRE-316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ