### PR TITLE
[CRIMRE-233] Add modsecurity

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -14,8 +14,16 @@ metadata:
         auth_basic off;
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
       }
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
+    nginx.ingress.kubernetes.io/modsecurity-transaction-id: "$request_id"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecRequestBodyLimit 1048576
+      SecRequestBodyNoFilesLimit 1048576
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
 spec:
-  ingressClassName: default
+  ingressClassName: modsec
   tls:
   - hosts:
     - laa-review-criminal-legal-aid-production.apps.live.cloud-platform.service.justice.gov.uk

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -14,8 +14,16 @@ metadata:
         auth_basic off;
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
       }
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
+    nginx.ingress.kubernetes.io/modsecurity-transaction-id: "$request_id"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecRequestBodyLimit 1048576
+      SecRequestBodyNoFilesLimit 1048576
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
 spec:
-  ingressClassName: default
+  ingressClassName: modsec
   tls:
   - hosts:
     - laa-review-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
## Description of change
Adds modsecurity directive to Staging/Production installations, fulfils basic layer 7 security requirements

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-216 (investigation)
https://dsdmoj.atlassian.net/browse/CRIMRE-223 (implementation - this PR)

## Notes for reviewer
- Deliberately restricted file upload and data upload to 1MiB - is this far too small?
- Deliberately enabled OWASP rules as well as standard WAF rules - too restrictive?

## Screenshots of changes (if applicable)

N/A

## How to manually test the feature

Full smoke test of all functionality required.
Is there any Report Download functionality anywhere? 
Is there any File Upload functionality anywhere?