### PR TITLE
Add class not determined badge for unlisted offences

### DIFF
--- a/app/views/crime_applications/_offences.html.erb
+++ b/app/views/crime_applications/_offences.html.erb
@@ -5,11 +5,13 @@
 <table class="govuk-table app-dashboard-table govuk-!-margin-bottom-9">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-two-thirds">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-half">
         <%= t('crime_applications.labels.offence') %>
       </th>
-      <th scope="col" class="govuk-table__header">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">
         <%= t('crime_applications.labels.offence_date') %>
+      </th>
+      <th scope="col" class="govuk-table__header">
       </th>
     </tr>
   </thead>
@@ -32,6 +34,13 @@
               <%= t('crime_applications.values.to') %>
               <%= l date.date_to, format: :compact %>
               <% end %>
+          </td>
+          <td class="govuk-table__cell govuk-!-text-align-right">
+            <% if offence.offence_class.blank? %>
+              <span class="moj-badge moj-badge--red">
+                <%= t('crime_applications.values.class_not_determined') %>
+              </span>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/app/views/crime_applications/show.html.erb
+++ b/app/views/crime_applications/show.html.erb
@@ -2,7 +2,7 @@
 <%= render partial: 'review_overview', locals: { crime_application: @crime_application } %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-9">
+  <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-9">
     <%= render partial: 'shared/subnavigation', locals: { crime_application: @crime_application } %>
     <%= render partial: 'overview', object: @crime_application %>
     <%= render partial: 'client_details',
@@ -20,7 +20,7 @@
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-three-quarters">
     <% if @crime_application.reviewable_by?(current_user_id) %>
       <div class="govuk-button-group govuk-!-margin-bottom-6">
         <% if @crime_application.status?(:marked_as_ready) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,9 +153,10 @@ en:
     appeal_to_crown_court: Appeal to crown court
     appeal_to_crown_court_with_changes: Appeal to crown court with changes in financial circumstances
     class: Class
+    class_not_determined: "Class\xA0not\xA0determined"
     to: to
     conflict_of_interest:
-      "yes": CONFLICT
+      "yes": Conflict
       "no": ''
     loss_of_liberty: Loss of liberty
     suspended_sentence: Suspended sentence

--- a/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -74,11 +74,11 @@ RSpec.describe 'Viewing an application unassigned, open application' do
   context 'with offence class not provided' do
     let(:application_id) { '5aa4c689-6fb5-47ff-9567-5efe7f8ac211' }
 
-    it 'does not show the offence class caption' do
+    it 'does shows the class not determined badge' do
       table_body = find(:xpath,
                         "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']//tbody[contains(tr[1], 'Robbery')]")
 
-      expect(table_body).not_to have_content('Class')
+      expect(table_body).to have_content('Class not determined')
     end
   end
 


### PR DESCRIPTION
## Description of change
Added class not determined badge for unlisted (manually input) offences. 
Required some moving of govuk layout to fit 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-99

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="715" alt="image" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/2e6c0f1b-850f-490e-aafb-fcd28687a873">

### After changes:
<img width="800" alt="image" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/61fdc27c-d093-4599-9bf2-d69e277a2313">

## How to manually test the feature
