### PR TITLE
CRIMRE-315 send access granted email.

### DIFF
--- a/app/forms/admin/new_user_form.rb
+++ b/app/forms/admin/new_user_form.rb
@@ -10,23 +10,18 @@ module Admin
     validates :can_manage_others, presence: false, inclusion: [true, nil]
 
     def save
-      return unless valid?
+      return false unless valid?
 
       # TODO: look at getting boolean from form directly
       # seems to be issue with DFE form builder
       boolean_can_manage_others = can_manage_others ? true : false
 
-      begin
-        user = User.new(
-          email: email,
-          can_manage_others: boolean_can_manage_others
-        )
-
-        user.save
-      rescue ActiveRecord::RecordNotUnique
-        errors.add(:email, :uniqueness)
-        false
-      end
+      User.create!(email: email, can_manage_others: boolean_can_manage_others)
+      NotifyMailer.access_granted_email(email).deliver_now
+      true
+    rescue ActiveRecord::RecordNotUnique
+      errors.add(:email, :uniqueness)
+      false
     end
   end
 end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -27,6 +27,12 @@ class NotifyMailer < GovukNotifyRails::Mailer
     mail(to: provider_email)
   end
 
+  def access_granted_email(email)
+    set_template(:access_granted_email)
+
+    mail(to: email)
+  end
+
   protected
 
   # rubocop:disable Naming/AccessorMethodName

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -13,5 +13,7 @@
 #
 production:
   application_returned_email: 'd0d8768b-2122-40a2-ba01-b4550f36805b'
+  access_granted_email: '28ddb4dc-ac53-4298-ad55-ea32bc852ffb'
 non-production:
   application_returned_email: 'cfee931f-6588-4814-a2e2-ad025946922f'
+  access_granted_email: 'f2704460-a16c-46f0-ab6b-d868421c621a'

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -6,15 +6,18 @@ RSpec.describe NotifyMailer do
 
   before do
     allow(Rails.configuration).to receive(:govuk_notify_templates).and_return(
-      application_returned_email: 'application_returned_email_template_id'
+      application_returned_email: 'application_returned_email_template_id',
+      access_granted_email: 'access_granted_email_template_id'
     )
-
-    allow(CrimeApplication).to receive(:find)
-      .with(crime_application.id)
-      .and_return(crime_application)
   end
 
   describe '#application_returned_email' do
+    before do
+      allow(CrimeApplication).to receive(:find)
+        .with(crime_application.id)
+        .and_return(crime_application)
+    end
+
     let(:mail) do
       described_class.application_returned_email(crime_application.id)
     end
@@ -31,5 +34,15 @@ RSpec.describe NotifyMailer do
         }
       )
     end
+  end
+
+  describe '#access_granted_email' do
+    let(:mail) do
+      described_class.access_granted_email('test@example.com')
+    end
+
+    it_behaves_like 'a Notify mailer', template_id: 'access_granted_email_template_id'
+
+    it { expect(mail.to).to eq(['test@example.com']) }
   end
 end

--- a/spec/system/manage_users/add_user_spec.rb
+++ b/spec/system/manage_users/add_user_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe 'Add users from manage users dashboard' do
   include_context 'when logged in user is admin'
 
   before do
+    allow(NotifyMailer).to receive(:access_granted_email) {
+      instance_double(ActionMailer::MessageDelivery, deliver_now: true)
+    }
     visit '/'
     visit '/admin/manage_users'
     click_on 'Add new user'


### PR DESCRIPTION
## Description of change

Send an email to a user when they are granted access to the Crime Review service.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-315

## Notes for reviewer

See ticket for email placeholder text used.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
