### PR TITLE
Populate superseding history item from aggregate

### DIFF
--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -3,7 +3,7 @@ module Reviewable
     @review ||= Reviewing::LoadReview.call(application_id: id)
   end
 
-  delegate :reviewed_at, :reviewer_id, :reviewed?, to: :review
+  delegate :reviewed_at, :reviewer_id, :reviewed?, :superseded_by, :superseded_at, to: :review
 
   def review_status
     review.state
@@ -31,5 +31,9 @@ module Reviewable
 
   def status?(status)
     review_status == status
+  end
+
+  def superseded?
+    !superseded_at.nil?
   end
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -48,15 +48,6 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
     !reviewed? && assigned_to?(user_id)
   end
 
-  # NOTE: This code is intended for temporary use during user research on the
-  # staging environment from 3-4 May. The code is not part of the final
-  # implementation and should not be used in production.
-  #
-  # In production, the events stream will provide up-to-date events. However,
-  # as the supserseding events are not available on the staging data user for
-  # user testing, we are artificially generating the events for testing purposes only.
-
-  # TODO: remove after 4 May
   def superseding_history_item
     return nil unless superseded_by
 
@@ -67,27 +58,6 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
       event_data: { superseded_by: }
     )
   end
-
-  # TODO: remove after 4 May
-  def superseded?
-    superseded_by.present?
-  end
-
-  # TODO: remove after 4 May
-  def superseding_review
-    @superseding_review ||= Review.find_by(parent_id: id)
-  end
-
-  # TODO: remove after 4 May
-  def superseded_by
-    superseding_review&.application_id
-  end
-
-  # TODO: remove after 4 May
-  def superseded_at
-    superseding_review&.submitted_at
-  end
-  # END user research temporary code
 
   class << self
     def find(id)


### PR DESCRIPTION
## Description of change
Populate superseding history item from aggregate.

## Link to relevant ticket

## Notes for reviewer

This refactor removes code to allow superseding history item to work with older data. This was required for testing as part of user testing and now no longer necessary.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
