### PR TITLE
Add element check to JS copy function

### DIFF
--- a/app/javascript/local/copy_reference_number.js
+++ b/app/javascript/local/copy_reference_number.js
@@ -2,13 +2,15 @@ function copyReferenceNumber(){
   let referenceNumber = document.querySelector('#reference-number');
   let copyLink = document.querySelector('#copy-reference-number');
 
-  copyLink.addEventListener('click', (e) => {
-    e.preventDefault();
+  if (referenceNumber && copyLink) {
+    copyLink.addEventListener('click', (e) => {
+      e.preventDefault();
 
-    let text = referenceNumber.textContent.trim();
-    window.navigator.clipboard.writeText(text);
-    copyLink.blur();
-  });
+      let text = referenceNumber.textContent.trim();
+      window.navigator.clipboard.writeText(text);
+      copyLink.blur();
+    });
+  }
 }
 
 export default copyReferenceNumber;


### PR DESCRIPTION
## Description of change
There was a browser console error being raised on pages where the links for this function were not present. Added a check in so that the events are only attached if the links are present.

## How to manually test the feature
- copy ref num fuctionality should be the same
- their should be no error errors raised on the FE console when these links don't exist on the page.