### PR TITLE
Only allow user managers access to service on staging

### DIFF
--- a/app/controllers/admin/manage_users_controller.rb
+++ b/app/controllers/admin/manage_users_controller.rb
@@ -14,9 +14,7 @@ module Admin
     def require_user_manager!
       return if current_user.can_manage_others?
 
-      set_flash(:cannot_access, success: false)
-
-      redirect_to authenticated_root_path
+      redirect_to not_found_path
     end
   end
 end

--- a/app/controllers/application_searches_controller.rb
+++ b/app/controllers/application_searches_controller.rb
@@ -1,4 +1,4 @@
-class ApplicationSearchesController < ApplicationController
+class ApplicationSearchesController < ServiceController
   def new
     @filter = ApplicationSearchFilter.new
   end

--- a/app/controllers/assigned_applications_controller.rb
+++ b/app/controllers/assigned_applications_controller.rb
@@ -1,4 +1,4 @@
-class AssignedApplicationsController < ApplicationController
+class AssignedApplicationsController < ServiceController
   def index
     return unless assignments_count.positive?
 

--- a/app/controllers/crime_applications_controller.rb
+++ b/app/controllers/crime_applications_controller.rb
@@ -1,4 +1,4 @@
-class CrimeApplicationsController < ApplicationController
+class CrimeApplicationsController < ServiceController
   before_action :set_crime_application, only: %i[show history complete ready]
 
   def open

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,5 +1,4 @@
-class ErrorsController < ApplicationController
-  skip_before_action :authenticate_user!, only: :forbidden
+class ErrorsController < BareApplicationController
   layout 'external'
 
   def application_not_found

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,5 +1,6 @@
 class ErrorsController < BareApplicationController
   layout 'external'
+  before_action :authenticate_user!, except: [:forbidden]
 
   def application_not_found
     respond_with_status(:not_found)

--- a/app/controllers/reassigns_controller.rb
+++ b/app/controllers/reassigns_controller.rb
@@ -1,4 +1,4 @@
-class ReassignsController < ApplicationController
+class ReassignsController < ServiceController
   def new
     @current_assignment = current_assignment
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,4 +1,4 @@
-class ReportsController < ApplicationController
+class ReportsController < ServiceController
   def show
     case params[:id]
     when /workload_report/

--- a/app/controllers/returns_controller.rb
+++ b/app/controllers/returns_controller.rb
@@ -1,4 +1,4 @@
-class ReturnsController < ApplicationController
+class ReturnsController < ServiceController
   before_action :set_crime_application
 
   def new

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -6,8 +6,8 @@ class ServiceController < ApplicationController
   # Users that can manage others are only allowed to access the Service on staging.
   # This is configured by the allow_user_managers_service_access feature flag.
   def require_service_user!
+    return if current_user.service_user?
     return if FeatureFlags.allow_user_managers_service_access.enabled?
-    return unless current_user.can_manage_others?
 
     redirect_to admin_manage_users_root_path
   end

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -3,11 +3,12 @@ class ServiceController < ApplicationController
 
   private
 
-  # UserManagers are only allowed to access the Service on staging.
+  # Users that can manage others are only allowed to access the Service on staging.
+  # This is configured by the allow_user_managers_service_access feature flag.
   def require_service_user!
     return if FeatureFlags.allow_user_managers_service_access.enabled?
     return unless current_user.can_manage_others?
 
-    redirect_to admin_manage_users_path
+    redirect_to admin_manage_users_root_path
   end
 end

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -1,0 +1,13 @@
+class ServiceController < ApplicationController
+  before_action :require_service_user!
+
+  private
+
+  # UserManagers are only allowed to access the Service on staging.
+  def require_service_user!
+    return if FeatureFlags.allow_user_managers_service_access.enabled?
+    return unless current_user.can_manage_others?
+
+    redirect_to admin_manage_users_path
+  end
+end

--- a/app/models/concerns/auth_updateable.rb
+++ b/app/models/concerns/auth_updateable.rb
@@ -13,6 +13,8 @@ module AuthUpdateable
 
   def update_from_auth_hash!(request)
     auth_hash = request.env['omniauth.auth']
+    return unless auth_hash
+
     activate_from_auth_hash(auth_hash) if pending_activation?
     update_from_auth_hash(auth_hash)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,6 +58,10 @@ class User < ApplicationRecord
     self.invitation_expires_at = Rails.configuration.x.auth.invitation_ttl.from_now
   end
 
+  def service_user?
+    !can_manage_others?
+  end
+
   def dormant?
     activated? && last_auth_at < Rails.configuration.x.auth.dormant_account_threshold.ago
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,8 +70,9 @@ Rails.application.routes.draw do
   root 'assigned_applications#index'
 
   # catch-all route
-  # :nocov:
+  # which, because errors#not_found is authenticated, results in an
+  # unauthenticated user being redirect to the sign in page.
+
   match '*path', to: 'errors#not_found', via: :all, constraints:
     lambda { |_request| !Rails.application.config.consider_all_requests_local }
-  # :nocov:
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,3 +7,5 @@ feature_flags:
     local: <%= ENV.fetch("DEV_AUTH_ENABLED", false) %>
     staging: false
     production: false
+  allow_user_managers_service_access:
+    staging: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,4 +8,6 @@ feature_flags:
     staging: false
     production: false
   allow_user_managers_service_access:
+    local: false
     staging: true
+    production: false

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -148,9 +148,7 @@ RSpec.describe 'Authentication Session Initialisation' do
     it 'redirects the user to the "Not authorised" page' do
       auth_callback
 
-      follow_redirect!
-
-      expect(response).to have_http_status(:forbidden)
+      expect(response).to redirect_to('/forbidden')
     end
   end
 end

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -1,0 +1,203 @@
+require 'rails_helper'
+RSpec.describe 'Authorisation' do
+  include Devise::Test::IntegrationHelpers
+
+  let(:service_user_routes) do
+    %w[
+      assigned_application
+      assigned_applications
+      closed_crime_applications
+      complete_crime_application
+      crime_application
+      crime_application_reassign
+      crime_application_return
+      crime_applications
+      history_crime_application
+      new_application_searches
+      new_crime_application_reassign
+      new_crime_application_return
+      next_application_assigned_applications
+      open_crime_applications
+      ready_crime_application
+      report
+      search_application_searches
+    ]
+  end
+
+  let(:user_manager_routes) do
+    %w[
+      admin_manage_users_active_user
+      admin_manage_users_active_users
+      admin_manage_users_deactivated_users
+      admin_manage_users_invitation
+      admin_manage_users_invitations
+      admin_manage_users_root
+      confirm_destroy_admin_manage_users_invitation
+      confirm_renew_admin_manage_users_invitation
+      edit_admin_manage_users_active_user
+      new_admin_manage_users_deactivated_user
+      new_admin_manage_users_invitation
+    ]
+  end
+
+  let(:unauthenticated_routes) do
+    %w[
+      authenticated_root
+      dev_auth
+      forbidden
+      health
+      ping
+      preview_view_component
+      preview_view_components
+      root
+      unauthenticated_root
+    ]
+  end
+
+  let(:authenticated_routes) do
+    %w[
+      application_not_found
+      not_found
+      unhandled
+    ]
+  end
+
+  describe 'an unauthenticated user' do
+    it 'can access all unauthenticated routes' do
+      configured_routes.each do |route|
+        next unless unauthenticated_routes.include?(route.name)
+
+        visit_configured_route(route)
+        status = route.name == 'forbidden' ? :forbidden : :ok
+
+        expect(response).to have_http_status(status)
+      end
+    end
+
+    it 'is redirected to "sign in" for all authenticated routes' do
+      configured_routes.select { |r| unauthenticated_routes.exclude?(r.name) }.each do |route|
+        visit_configured_route(route)
+
+        expect(response).to redirect_to(unauthenticated_root_path)
+        follow_redirect!
+        expect(response.body).to include('You are not authorised to view this page')
+      end
+    end
+
+    it 'is redirected to "sign in" for a none existent url' do
+      get '/this_is_not_a/route'
+
+      expect(response).to redirect_to(unauthenticated_root_path)
+      follow_redirect!
+      expect(response.body).to include('You are not authorised to view this page')
+    end
+  end
+
+  describe 'an authenticated service user' do
+    include_context 'with stubbed search'
+    before do
+      user = User.create(email: 'Ben.EXAMPLE@example.com')
+      sign_in user
+    end
+
+    it 'can access the service' do
+      get open_crime_applications_path
+
+      expect(response).to have_http_status :ok
+    end
+
+    it 'is redirected to "Not found" for all user manager routes' do
+      configured_routes.each do |route|
+        next unless user_manager_routes.include?(route.name)
+
+        visit_configured_route(route)
+
+        expect(response).to redirect_to(not_found_path)
+      end
+    end
+  end
+
+  describe 'an authenticated user manager' do
+    include_context 'with stubbed search'
+
+    before do
+      user = User.create(email: 'Ben.EXAMPLE@example.com', can_manage_others: true)
+      sign_in user
+    end
+
+    it 'can access admin manage users' do
+      get admin_manage_users_root_path
+      expect(response).to have_http_status :ok
+    end
+
+    it 'is redirected to "admin manage users root" for all service routes' do
+      configured_routes.each do |route|
+        next unless service_user_routes.include?(route.name)
+
+        visit_configured_route(route)
+
+        expect(response).to redirect_to(admin_manage_users_root_path)
+      end
+    end
+
+    context 'when user managers are allowed service access' do
+      before do
+        # Override allow_user_managers_service_access as per staging
+        allow(FeatureFlags).to receive(:allow_user_managers_service_access) {
+          instance_double(FeatureFlags::EnabledFeature, enabled?: true)
+        }
+      end
+
+      it 'can access admin manage users' do
+        get admin_manage_users_root_path
+        expect(response).to have_http_status :ok
+      end
+
+      it 'can access the service' do
+        get open_crime_applications_path
+        expect(response).to have_http_status :ok
+      end
+    end
+  end
+
+  it 'all configured routes are tested' do
+    configured_routes.each do |route|
+      tested_routes = user_manager_routes + service_user_routes + unauthenticated_routes + authenticated_routes
+
+      expect(tested_routes.include?(route.name)).to be(true), "\"#{route.name}\" is not tested"
+    end
+  end
+
+  def configured_routes
+    Rails.application.routes.routes.dup.select do |r|
+      r.name.present? && outside_the_scope_of_this_test.exclude?(r.name)
+    end
+  end
+
+  def outside_the_scope_of_this_test
+    %w[
+      _system_test_entrypoint
+      api_events
+      destroy_user_session
+      turbo_recede_historical_location
+      turbo_refresh_historical_location
+      turbo_resume_historical_location
+      user_azure_ad_omniauth_authorize
+      user_azure_ad_omniauth_callback
+    ]
+  end
+
+  # processs a request according to the routes path and https method
+  def visit_configured_route(route)
+    url_helper = [route.name, 'path'].join('_')
+    path = send(url_helper.to_sym, dummy_params(route))
+    process(route.verb.downcase.to_sym, path)
+  end
+
+  # Returns the params required to construct a valid path
+  def dummy_params(route)
+    path = '/'
+    id = crime_application_id = '696dd4fd-b619-4637-ab42-a5f4565bcf4a'
+    { id:, crime_application_id:, path: }.slice(*route.required_keys.dup)
+  end
+end

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'Authorisation' do
       end
     end
 
-    it 'is redirected to "sign in" for a none existent url' do
+    it 'is redirected to "sign in" for a non-existent url' do
       get '/this_is_not_a/route'
 
       expect(response).to redirect_to(unauthenticated_root_path)

--- a/spec/system/header_nav_spec.rb
+++ b/spec/system/header_nav_spec.rb
@@ -56,20 +56,30 @@ RSpec.describe 'Header navigation' do
     end
   end
 
-  context 'when user does have access to manage other users is allowed service access' do
+  context 'when a user has access to manage other users' do
     before do
       User.update(current_user_id, can_manage_others: true)
-      # Override allow_user_managers_service_access as per staging
-      allow(FeatureFlags).to receive(:allow_user_managers_service_access) {
-        instance_double(FeatureFlags::EnabledFeature, enabled?: true)
-      }
       visit '/'
     end
 
-    it 'shows the "Manage users" link and can follow it' do
-      expect { click_link('Manage users') }.to change {
-                                                 page.first('.govuk-heading-xl').text
-                                               }.from('Your list').to('Manage users')
+    it 'they are redirected to the admin manage users route by default' do
+      expect { click_link('Manage users') }.not_to change { page.first('.govuk-heading-xl').text }.from('Manage users')
+    end
+
+    context 'when user managers are allowed to access the service' do
+      before do
+        # Override allow_user_managers_service_access as per staging
+        allow(FeatureFlags).to receive(:allow_user_managers_service_access) {
+          instance_double(FeatureFlags::EnabledFeature, enabled?: true)
+        }
+        visit '/'
+      end
+
+      it 'shows the "Manage users" link and can follow it' do
+        expect { click_link('Manage users') }.to change {
+                                                   page.first('.govuk-heading-xl').text
+                                                 }.from('Your list').to('Manage users')
+      end
     end
   end
 end

--- a/spec/system/header_nav_spec.rb
+++ b/spec/system/header_nav_spec.rb
@@ -56,17 +56,20 @@ RSpec.describe 'Header navigation' do
     end
   end
 
-  context 'when user does have access to manage other users' do
+  context 'when user does have access to manage other users is allowed service access' do
     before do
       User.update(current_user_id, can_manage_others: true)
+      # Override allow_user_managers_service_access as per staging
+      allow(FeatureFlags).to receive(:allow_user_managers_service_access) {
+        instance_double(FeatureFlags::EnabledFeature, enabled?: true)
+      }
       visit '/'
     end
 
-    it 'takes you to user management dashboard when you click "Manage users"' do
-      click_link('Manage users')
-
-      heading_text = page.first('.govuk-heading-xl').text
-      expect(heading_text).to eq('Manage users')
+    it 'shows the "Manage users" link and can follow it' do
+      expect { click_link('Manage users') }.to change {
+                                                 page.first('.govuk-heading-xl').text
+                                               }.from('Your list').to('Manage users')
     end
   end
 end

--- a/spec/system/manage_users/viewing_spec.rb
+++ b/spec/system/manage_users/viewing_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Manage Users Dashboard' do
       visit admin_manage_users_root_path
     end
 
-    it 'redirects to Your list page' do
+    it 'redirects to "Page not" found' do
       heading_text = page.first('.govuk-heading-xl').text
       expect(heading_text).to eq('Page not found')
     end

--- a/spec/system/manage_users/viewing_spec.rb
+++ b/spec/system/manage_users/viewing_spec.rb
@@ -10,14 +10,7 @@ RSpec.describe 'Manage Users Dashboard' do
 
     it 'redirects to Your list page' do
       heading_text = page.first('.govuk-heading-xl').text
-      expect(heading_text).to eq('Your list')
-    end
-
-    it 'show access denied flash message' do
-      expect(page).to have_notification_banner(
-        text: 'You do not have access to that page',
-        details: 'Contact laa-crime-apply@digital.justice.gov.uk if you think this is wrong'
-      )
+      expect(heading_text).to eq('Page not found')
     end
   end
 


### PR DESCRIPTION
## Description of change
User managers can only access the service on staging.
On all other environments they are redirect to the manage users interface

## Link to relevant ticket
[CRIMRE-323](https://dsdmoj.atlassian.net/browse/CRIMRE-323)

## Notes for reviewer

I've added the authorisation request spec which is should check all routes.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-323]: https://dsdmoj.atlassian.net/browse/CRIMRE-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ