### PR TITLE
CRIMRE-292 Add differentiators for historical applications

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -18,6 +18,6 @@ form.search {
   }
 }
 
-p.help-text, #superseded  {
+p.help-text, #superseded_style  {
   color: govuk-colour("dark-grey");
 }

--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -18,6 +18,6 @@ form.search {
   }
 }
 
-p.help-text {
+p.help-text, #superseded  {
   color: govuk-colour("dark-grey");
 }

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -88,6 +88,16 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
     @parent ||= CrimeApplication.find(parent_id)
   end
 
+  def latest_application_id
+    crime_application = self
+
+    until crime_application.superseded_by.nil?
+      crime_application = CrimeApplication.find(crime_application.superseded_by)
+    end
+
+    crime_application.id
+  end
+
   def all_histories
     return @all_histories if @all_histories
 

--- a/app/views/crime_applications/_review_overview.html.erb
+++ b/app/views/crime_applications/_review_overview.html.erb
@@ -6,14 +6,20 @@
       </span>
     </div>
 
-    <p class="govuk-body-l govuk-!-margin-bottom-2">
+    <% if crime_application.superseded? %>
+      <% id = "superseded" %>
+    <% end %>
+
+    <p class="govuk-body-l govuk-!-margin-bottom-2" id=<%= id %>>
       <span class="govuk-!-margin-right-2" id="reference-number">
         <%= crime_application.reference %>
       </span>
-      <%=link_to t('calls_to_action.copy'), '', id: 'copy-reference-number', class: 'govuk-link--no-visited-state' %>
+      <% unless crime_application.superseded? %>
+        <%=link_to t('calls_to_action.copy'), '', id: 'copy-reference-number', class: 'govuk-link--no-visited-state' %>
+      <% end %>
     </p>
 
-    <h2 class="govuk-heading-xl govuk-!-margin-bottom-4">
+    <h2 class="govuk-heading-xl govuk-!-margin-bottom-4" id=<%= id %>>
       <%= crime_application.applicant_name %>
     </h2>
 

--- a/app/views/crime_applications/_review_overview.html.erb
+++ b/app/views/crime_applications/_review_overview.html.erb
@@ -7,10 +7,10 @@
     </div>
 
     <% if crime_application.superseded? %>
-      <% id = "superseded" %>
+      <% id = 'superseded_' %>
     <% end %>
 
-    <p class="govuk-body-l govuk-!-margin-bottom-2" id=<%= id %>>
+    <p class="govuk-body-l govuk-!-margin-bottom-2" id="<%= id %>style">
       <span class="govuk-!-margin-right-2" id="reference-number">
         <%= crime_application.reference %>
       </span>
@@ -19,9 +19,22 @@
       <% end %>
     </p>
 
-    <h2 class="govuk-heading-xl govuk-!-margin-bottom-4" id=<%= id %>>
+    <h2 class="govuk-heading-xl govuk-!-margin-bottom-4" id="<%= id %>style">
       <%= crime_application.applicant_name %>
     </h2>
+
+    <% if crime_application.superseded? %>
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive"><%= t('warning_text.title') %></span>
+          <%= t('warning_text.resubmitted') %>
+          <%= link_to t('calls_to_action.go_to_latest'),
+                      crime_application_path(crime_application.latest_application_id),
+                      class: 'govuk-link--no-visited-state' %>
+        </strong>
+      </div>
+    <%end%>
 
     <%= render partial: 'assignment', locals: { crime_application: } %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,9 @@ en:
       staging: staging
       production: alpha
     text: This is an MVP. Some things may not work as expected.
+  warning_text:
+    title: Warning
+    resubmitted: This application has been resubmitted.
   flash:
     success:
       title: Success
@@ -68,6 +71,7 @@ en:
     # flash.notice is only used by Devise and is treated as success.
     notice:
       title: Success
+
     # flash.notice is only used by Devise and is treated as important.
     alert:
       title: Important
@@ -225,6 +229,7 @@ en:
     confirm_reassign_to_self: Yes, reassign
     confirm_deactivation: Yes, deactivate
     copy: Copy reference number
+    go_to_latest: Go to the latest version
     reassign_to_self: Reassign to your list
     search: Search
     unassign_from_self: Remove from your list

--- a/spec/system/viewing_an_application/that_is_superseded_spec.rb
+++ b/spec/system/viewing_an_application/that_is_superseded_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing an application that is superseded' do
+  let(:application_id) { '148df27d-4710-4c5b-938c-bb132eb040ca' }
+  let(:parent_id) { '5aa4c689-6fb5-47ff-9567-5efe7f8ac211' }
+  let(:latest_application_url) { "/applications/#{application_id}" }
+
+  let(:return_details) do
+    ReturnDetails.new(
+      reason: 'evidence_issue',
+      details: 'September bank statement required'
+    )
+  end
+
+  before do
+    Reviewing::ReceiveApplication.call(
+      application_id: parent_id,
+      submitted_at: '2022-10-24T09:50:04.000+00:00',
+      parent_id: nil
+    )
+
+    stub_request(
+      :put,
+      "#{ENV.fetch('DATASTORE_API_ROOT')}/api/v1/applications/#{parent_id}/return"
+    ).to_return(body: LaaCrimeSchemas.fixture(1.0, name: 'application_returned').read, status: 200)
+
+    user = User.create(
+      first_name: 'Fred',
+      last_name: 'Smitheg',
+      auth_oid: '976658f9-f3d5-49ec-b0a9-485ff8b308fa',
+      email: 'Fred.Smitheg@justice.gov.uk'
+    )
+
+    Assigning::AssignToUser.new(
+      user_id: user.id,
+      to_whom_id: user.id,
+      assignment_id: parent_id
+    ).call
+
+    Reviewing::SendBack.new(
+      user_id: user.id,
+      application_id: parent_id,
+      return_details: return_details.attributes
+    ).call
+
+    Reviewing::ReceiveApplication.call(
+      application_id: application_id,
+      submitted_at: '2022-10-24T09:50:04.000+00:00',
+      parent_id: parent_id
+    )
+
+    visit '/'
+    visit crime_application_path(parent_id)
+  end
+
+  it 'shows the sent back status badge' do
+    badge = page.all('.govuk-tag').last.text
+
+    expect(badge).to match('Sent back to provider')
+  end
+
+  it 'includes the page title' do
+    expect(page).to have_content I18n.t('crime_applications.show.page_title')
+  end
+
+  it 'does not show the copy reference link' do
+    expect(page).not_to have_content('Copy reference number')
+  end
+
+  it 'shows the resubmitted warning text' do
+    expect(page).to have_content('This application has been resubmitted.')
+  end
+
+  it 'shows link to the most recent version' do
+    expect(page).to have_link('Go to the latest version', href: latest_application_url)
+  end
+
+  it 'shows who closed the application' do
+    expect(page).to have_content('Closed by: Fred Smitheg')
+  end
+
+  it 'does not show button to assign' do
+    expect(page).not_to have_content('Assign to your list')
+  end
+
+  it 'does not show the CTAs' do
+    expect(page).not_to have_content('Mark as completed')
+  end
+end


### PR DESCRIPTION
## Description of change
For superseded applications show view:
- Grey out ref number and applicant name
- Remove copy ref link
- Add warning text and link to latest application

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-292

## Screenshots of changes (if applicable)

### Before changes:
<img width="1003" alt="image" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/0d6a46a6-ea73-40e1-b447-479d8b915a5c">

### After changes:
<img width="834" alt="image" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/8dbd7f0a-fed0-449e-affe-d63c89c98e9f">

## How to manually test the feature
Return an application and resubmit it
Go to closed applications and view the version that was sent back