### PR TITLE
Use latest version of the schema gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.1.6'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.1.9'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 5f18ff9ac519360826fda2f5373ffb8da2d8336c
-  tag: v0.1.6
+  revision: d9802d263c9a0fb34c6cfdb10473567c592f34a9
+  tag: v0.1.9
   specs:
-    laa-criminal-legal-aid-schemas (0.1.6)
+    laa-criminal-legal-aid-schemas (0.1.9)
       dry-struct
       json-schema (~> 3.0.0)
 


### PR DESCRIPTION
## Description of change

Use the latest version of the laa schema gem which standardises timestamp format and enforces types in the json schema.

## Link to relevant ticket

[CRIMRE-333](https://dsdmoj.atlassian.net/browse/CRIMRE-333)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-333]: https://dsdmoj.atlassian.net/browse/CRIMRE-333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ