### PR TITLE
Create snyk-infrastructure.yml

### DIFF
--- a/.github/workflows/snyk-infrastructure.yml
+++ b/.github/workflows/snyk-infrastructure.yml
@@ -15,9 +15,6 @@ name: Snyk Infrastructure as Code
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
   schedule:
     - cron: '30 21 * * 1' # at 21:30 on Monday evening
 

--- a/.github/workflows/snyk-infrastructure.yml
+++ b/.github/workflows/snyk-infrastructure.yml
@@ -1,0 +1,53 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# A sample workflow which checks out your Infrastructure as Code Configuration files,
+# such as Kubernetes, Helm & Terraform and scans them for any security issues.
+# The results are then uploaded to GitHub Security Code Scanning
+#
+# For more examples, including how to limit scans to only high-severity issues
+# and fail PR checks, see https://github.com/snyk/actions/
+
+name: Snyk Infrastructure as Code
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '30 21 * * 1' # at 21:30 on Monday evening
+
+permissions:
+  contents: read
+
+jobs:
+  snyk:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Snyk to check configuration files for security issues
+        # Snyk can be used to break the build when it detects security issues.
+        # In this case we want to upload the issues to GitHub Code Scanning
+        continue-on-error: true
+        uses: snyk/actions/iac@14818c4695ecc4045f33c9cee9e795a788711ca4
+        env:
+          # In order to use the Snyk Action you will need to have a Snyk API token.
+          # More details in https://github.com/snyk/actions#getting-your-snyk-token
+          # or you can signup for free at https://snyk.io/login
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          # Add the path to the configuration file that you would like to test.
+          # For example `deployment.yaml` for a Kubernetes deployment manifest
+          # or `main.tf` for a Terraform configuration file
+          file: config/kubernetes/production/**
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: snyk.sarif


### PR DESCRIPTION
Adds Snyk infrastructure as code scanning for our production K8s files.

I ran these locally and there were not any issues - open to the idea that this might not be needed but adding PR to start the discussion.

## Description of change
Adds infra as code scanning by snyk, which will report findings to security section of repo.

Will run as a cron-job every Monday evening at 21:30.

Also runs on PRs at the moment though this is very quick I wonder if this is worthwhile, it will invariably run quicker than the specs.

## Link to relevant ticket
[CRIMRE-313](https://dsdmoj.atlassian.net/browse/CRIMRE-313)
## Notes for reviewer


[CRIMRE-313]: https://dsdmoj.atlassian.net/browse/CRIMRE-313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ