### PR TITLE
CRIMRE-336 Update error copy

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,7 @@
 class ErrorsController < BareApplicationController
   layout 'external'
   before_action :authenticate_user!, except: [:forbidden]
+  helper_method :assignments_count
 
   def application_not_found
     respond_with_status(:not_found)
@@ -25,5 +26,11 @@ class ErrorsController < BareApplicationController
       format.html { render status: }
       format.all  { head status }
     end
+  end
+
+  def assignments_count
+    @assignments_count ||= CurrentAssignment.where(
+      user_id: current_user.id
+    ).count
   end
 end

--- a/app/views/errors/application_not_found.html.erb
+++ b/app/views/errors/application_not_found.html.erb
@@ -5,5 +5,7 @@
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
     <p class="govuk-body-l"><%=t '.body_1' %></p>
     <p class="govuk-body-l"><%=t '.body_2' %></p>
+    <% url = link_to t('.link_text'), open_crime_applications_path %>
+    <p class="govuk-body-l"><%= sanitize t('.body_3', url:) %></p>  </div>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -3,7 +3,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t '.heading' %></h1>
-
-    <p class="govuk-body-l"><%=t '.lead_text' %></p>
+    <p class="govuk-body-l"><%=t '.body_1' %></p>
+    <p class="govuk-body-l"><%=t '.body_2' %></p>
+    <% url = mail_to Rails.configuration.x.admin.onboarding_email %>
+    <p class="govuk-body-l"><%= sanitize t('.body_3', url:) %></p>
   </div>
 </div>

--- a/app/views/layouts/external.html.erb
+++ b/app/views/layouts/external.html.erb
@@ -1,11 +1,21 @@
 <% content_for?(:page_title) ? yield(:page_title) : fallback_title %>
 
-<% content_for(:header) do %>
-  <%= govuk_header(service_name: t('service.name'), classes: ["app-banner-#{HostEnv.env_name}"]) %>
+<% if current_user %>
+  <% content_for(:header) do %>
+    <% render partial: 'layouts/header' %>
+  <% end %>
+
+  <% content_for(:primary_navgation) do %>
+    <%= render partial: 'layouts/primary_navigation' %>
+  <% end %>
+<% else %>
+  <% content_for(:header) do %>
+    <%= govuk_header(service_name: t('service.name'), classes: ["app-banner-#{HostEnv.env_name}"]) %>
+  <% end %>
 <% end %>
 
 <% content_for(:content) do %>
-  <%= render partial: 'shared/flash_banner' %>
+  <%= render partial: 'shared/message_interstitial' %>
   <%= yield %>
 <% end %>
 

--- a/app/views/shared/_message_interstitial.erb
+++ b/app/views/shared/_message_interstitial.erb
@@ -14,7 +14,7 @@
   <% text = details.delete_at(0) %>
 
   <h1 class="govuk-heading-xl govuk-!-margin-bottom-3"><%=text%></h1>
- 
+
   <% details.each do |detail| %>
     <p class="govuk-body"><%= sanitize detail%></p>
   <% end %>

--- a/app/views/shared/_message_interstitial.erb
+++ b/app/views/shared/_message_interstitial.erb
@@ -1,0 +1,21 @@
+<% flash.each do |key, message| %>
+  <%# Ignore Devise timedout flash messages %>
+  <% next if key == 'timedout' %>
+
+  <%#
+      If the flash message is an array, display the first item as the heading.
+      Subsequent items are displayed as paragraphs. (See Devise locales
+      'devise.failure.user.reauthenticate' for example.)
+
+      If the message is not an array, display it as the heading.
+  %>
+
+  <% details = Array[*message] %>
+  <% text = details.delete_at(0) %>
+
+  <h1 class="govuk-heading-xl govuk-!-margin-bottom-3"><%=text%></h1>
+ 
+  <% details.each do |detail| %>
+    <p class="govuk-body"><%= sanitize detail%></p>
+  <% end %>
+<% end %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,3 +1,5 @@
 <% title t('landing.page_title') %>
 
-<%= govuk_start_button(text: t('calls_to_action.sign_in'), href: user_azure_ad_omniauth_authorize_path, as_button: true) %>
+<% unless flash.first&.last&.include?("You cannot access this service") %>
+  <%= govuk_start_button(text: t('calls_to_action.sign_in'), href: user_azure_ad_omniauth_authorize_path, as_button: true) %>
+<%end%>

--- a/config/application.rb
+++ b/config/application.rb
@@ -61,5 +61,8 @@ module LaaReviewCriminalLegalAid
 
     # Default page size for paging results
     config.x.admin.pagination_per_page = 50
+
+    #Onboarding email address for user contact
+    config.x.admin.onboarding_email = 'LAAapplyonboarding@justice.gov.uk'
   end
 end

--- a/config/locales/en/devise.yml
+++ b/config/locales/en/devise.yml
@@ -6,21 +6,22 @@ en:
     failure:
       user:
         reauthenticate:
-          - You have been signed out
-          - Your session automatically ends if it has been more than 12 hours since you last signed in.
+          - For your security, we signed you out
+          - This is becasue you were signed in for more than 12 hours.
+          - Sign in again to continue using the service.
         timeout: 
-          - You have been signed out
-          - Your session automatically ends if you do not access the service for more than 15 minutes.
-        unauthenticated:
-          - You are not authorised to view this page
-          - Access to this service is restricted if a user is not signed in
+          - For your security, we signed you out
+          - This is becasue you were inactive for 15 minutes.
+        unauthenticated: Sign in to view this page
         dormant: 
-          - Your access to this service has been restricted
-          - It has been more than 6 months since you last accessed the service. Your account will need to be re-activated before you can sign in.
+          - You cannot access this service
+          - This is because you have not signed in to the service for more than 6 months.
+          - Contact <a mailto=LAAapplyonboarding@justice.gov.uk>LAAapplyonboarding@justice.gov.uk</a> to reactivate your account.
         invitation_expired: 
-          - Your invitation has expired 
-          - Invitations to access this service automatically expire after 48 hours.
+          - You cannot access this service
+          - Your invitation to access this service has expired.
+          - "Contact <a mailto=LAAapplyonboarding@justice.gov.uk>LAAapplyonboarding@justice.gov.uk</a> for a new invitation."
     sessions:
       user:
         signed_in: ""
-        signed_out: You have been signed out
+        signed_out: You have signed out

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -26,7 +26,9 @@ en:
     not_found:
       page_title: Page not found
       heading: Page not found
-      lead_text: If you copied a web address, please check it’s correct.
+      body_1: If you typed the web address, check it is correct.
+      body_2: If you pasted the web address, check you copied the entire address.
+      body_3: If the web address is correct or you selected a link or button, contact %{url} for help
     unhandled:
       page_title: Unexpected error
       heading: Sorry, something went wrong with our service

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -21,8 +21,10 @@ en:
     application_not_found:
       page_title: Page not found
       heading: Page not found
-      body_1: The web address you are trying to access cannot be found.
-      body_2: If you’re looking for a specific application, go to all open applications
+      body_1: If you typed the web address, check it is correct.
+      body_2: If you pasted the web address, check you copied the entire address.
+      body_3: If you're looking for a specific application, %{url}.
+      link_text: go to all open applications
     not_found:
       page_title: Page not found
       heading: Page not found

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'Authorisation' do
 
         expect(response).to redirect_to(unauthenticated_root_path)
         follow_redirect!
-        expect(response.body).to include('You are not authorised to view this page')
+        expect(response.body).to include('Sign in to view this page')
       end
     end
 
@@ -89,7 +89,7 @@ RSpec.describe 'Authorisation' do
 
       expect(response).to redirect_to(unauthenticated_root_path)
       follow_redirect!
-      expect(response.body).to include('You are not authorised to view this page')
+      expect(response.body).to include('Sign in to view this page')
     end
   end
 

--- a/spec/system/authenticating/a_dormant_user_spec.rb
+++ b/spec/system/authenticating/a_dormant_user_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe 'Authenticating a dormant user' do
     expect(page).not_to have_content 'Your list'
   end
 
+  it 'the user cannot see the nav' do
+    expect(page).not_to have_content 'Closed applications'
+  end
+
   it 'shows the correct title' do
     expect(page).to have_css('h1.govuk-heading-xl', text: 'You cannot access this service')
   end

--- a/spec/system/authenticating/a_dormant_user_spec.rb
+++ b/spec/system/authenticating/a_dormant_user_spec.rb
@@ -13,11 +13,18 @@ RSpec.describe 'Authenticating a dormant user' do
     expect(page).not_to have_content 'Your list'
   end
 
-  it 'informs the user that their invitation has expired' do
-    expect(page).to have_notification_banner(
-      text: 'Your access to this service has been restricted',
-      details: 'It has been more than 6 months since you last accessed the service. ' \
-               'Your account will need to be re-activated before you can sign in.'
-    )
+  it 'shows the correct title' do
+    expect(page).to have_css('h1.govuk-heading-xl', text: 'You cannot access this service')
+  end
+
+  it 'shows the correct body' do
+    expect(page).to have_css('p.govuk-body',
+                             text: 'This is because you have not signed in to the service for more than 6 months.')
+    expect(page).to have_css('p.govuk-body',
+                             text: 'Contact LAAapplyonboarding@justice.gov.uk to reactivate your account.')
+  end
+
+  it 'does not show the sign in button' do
+    expect(page).not_to have_button('Sign in')
   end
 end

--- a/spec/system/authenticating/a_signed_out_user_spec.rb
+++ b/spec/system/authenticating/a_signed_out_user_spec.rb
@@ -10,8 +10,12 @@ RSpec.describe 'Authenticating a signed out user' do
       visit '/assigned_applications'
     end
 
-    it 'the cannot access their list' do
-      expect(page).not_to have_content 'Your list'
+    it 'the user cannot see the nav' do
+      expect(page).not_to have_content 'Closed applications'
+    end
+
+    it 'the user cannot access their list' do
+      expect(page).not_to have_css('h1.govuk-heading-xl', text: 'Your list')
     end
 
     it 'informs the user that they need to be signed to access the page requested' do
@@ -23,6 +27,10 @@ RSpec.describe 'Authenticating a signed out user' do
   context 'when trying to access an non-existent path' do
     before do
       visit '/foo'
+    end
+
+    it 'the user cannot see the nav' do
+      expect(page).not_to have_content 'Closed applications'
     end
 
     it 'informs the user that they need to be signed to access the page requested' do

--- a/spec/system/authenticating/a_signed_out_user_spec.rb
+++ b/spec/system/authenticating/a_signed_out_user_spec.rb
@@ -3,17 +3,31 @@ require 'rails_helper'
 RSpec.describe 'Authenticating a signed out user' do
   before do
     click_link 'Sign out'
-    visit '/assigned_applications'
   end
 
-  it 'the cannot access their list' do
-    expect(page).not_to have_content 'Your list'
+  context 'when trying to access an existent path' do
+    before do
+      visit '/assigned_applications'
+    end
+
+    it 'the cannot access their list' do
+      expect(page).not_to have_content 'Your list'
+    end
+
+    it 'informs the user that they need to be signed to access the page requested' do
+      expect(page).to have_css('h1.govuk-heading-xl', text: 'Sign in to view this page')
+      expect(page).to have_button('Sign in')
+    end
   end
 
-  it 'informs the user that they need to be singed to access the page requested' do
-    expect(page).to have_notification_banner(
-      text: 'You are not authorised to view this page',
-      details: 'Access to this service is restricted if a user is not signed in'
-    )
+  context 'when trying to access an non-existent path' do
+    before do
+      visit '/foo'
+    end
+
+    it 'informs the user that they need to be signed to access the page requested' do
+      expect(page).to have_css('h1.govuk-heading-xl', text: 'Sign in to view this page')
+      expect(page).to have_button('Sign in')
+    end
   end
 end

--- a/spec/system/authenticating/an_invited_user_spec.rb
+++ b/spec/system/authenticating/an_invited_user_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe 'Authenticating an invited user' do
         )
       end
 
+      it 'the user cannot see the nav' do
+        expect(page).not_to have_content 'Closed applications'
+      end
+
       it 'the page has the correct title' do
         expect(page).to have_css('h1.govuk-heading-xl', text: 'You cannot access this service')
       end

--- a/spec/system/authenticating/an_invited_user_spec.rb
+++ b/spec/system/authenticating/an_invited_user_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe 'Authenticating an invited user' do
 
   let(:invited_user) { User.create(email: 'Invited.Test@example.com') }
 
-  context 'when an invited users signs in for the first time' do
+  context 'when an invited user signs in for the first time' do
     before do
       invited_user
       click_button 'Sign in'
       select invited_user.email
     end
 
-    it 'the users is signed in' do
+    it 'the user is signed in' do
       click_button 'Sign in'
       expect(page).to have_content 'Your list'
     end
@@ -29,17 +29,25 @@ RSpec.describe 'Authenticating an invited user' do
         click_button 'Sign in'
       end
 
-      it 'informs the user that their invitation has expired' do
-        expect(page).to have_notification_banner(
-          text: 'Your invitation has expired',
-          details: 'Invitations to access this service automatically expire after 48 hours.'
-        )
-      end
-
       it 'the user is not activated' do
+        visit '/'
         expect { click_button 'Sign in' }.not_to(
           change { invited_user.reload.activated? }
         )
+      end
+
+      it 'the page has the correct title' do
+        expect(page).to have_css('h1.govuk-heading-xl', text: 'You cannot access this service')
+      end
+
+      it 'the page has the correct body' do
+        expect(page).to have_css('p.govuk-body', text: 'Your invitation to access this service has expired.')
+        expect(page).to have_css('p.govuk-body',
+                                 text: 'Contact LAAapplyonboarding@justice.gov.uk for a new invitation.')
+      end
+
+      it 'the page does not show the sign in button' do
+        expect(page).not_to have_button('Sign in')
       end
     end
   end

--- a/spec/system/authenticating/dev_auth_spec.rb
+++ b/spec/system/authenticating/dev_auth_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe 'Authenticating with the DevAuth strategy' do
         expect(page).to have_content 'Access to this service is restricted'
         expect(page).to have_current_path '/forbidden'
       end
+
+      it 'the user cannot see the nav' do
+        expect(page).not_to have_content 'Closed applications'
+      end
     end
 
     context 'when an authorised, but not yet authenticated, user is selected' do

--- a/spec/system/authenticating/reauthentication_spec.rb
+++ b/spec/system/authenticating/reauthentication_spec.rb
@@ -26,11 +26,17 @@ RSpec.describe 'Reauthentication' do
       expect(page).not_to have_content 'Your list'
     end
 
-    it 'shows the notification banner' do
-      expect(page).to have_notification_banner(
-        text: 'You have been signed out',
-        details: 'Your session automatically ends if it has been more than 12 hours since you last signed in.'
-      )
+    it 'shows the correct title' do
+      expect(page).to have_css('h1.govuk-heading-xl', text: 'For your security, we signed you out')
+    end
+
+    it 'shows the correct body' do
+      expect(page).to have_css('p.govuk-body', text: 'This is becasue you were signed in for more than 12 hours.')
+      expect(page).to have_css('p.govuk-body', text: 'Sign in again to continue using the service.')
+    end
+
+    it 'shows the sign in button' do
+      expect(page).to have_button('Sign in')
     end
   end
 end

--- a/spec/system/authenticating/sign_out_spec.rb
+++ b/spec/system/authenticating/sign_out_spec.rb
@@ -10,9 +10,8 @@ RSpec.describe 'Sign out' do
     expect(page).not_to have_content 'Your list'
   end
 
-  it 'shows the notification banner' do
-    expect(page).to have_success_notification_banner(
-      text: 'You have been signed out'
-    )
+  it 'shows the sign out confirmation page' do
+    expect(page).to have_css('h1.govuk-heading-xl', text: 'You have signed out')
+    expect(page).to have_button('Sign in')
   end
 end

--- a/spec/system/authenticating/timeout_spec.rb
+++ b/spec/system/authenticating/timeout_spec.rb
@@ -28,11 +28,13 @@ RSpec.describe 'Session timeout' do
       expect(page).not_to have_content 'Your list'
     end
 
-    it 'shows the notification banner' do
-      expect(page).to have_notification_banner(
-        text: 'You have been signed out',
-        details: 'Your session automatically ends if you do not access the service for more than 15 minutes.'
-      )
+    it 'shows the correct notification page' do
+      expect(page).to have_css('h1.govuk-heading-xl', text: 'For your security, we signed you out')
+      expect(page).to have_css('p.govuk-body', text: 'This is becasue you were inactive for 15 minutes.')
+    end
+
+    it 'shows the sign in button' do
+      expect(page).to have_button('Sign in')
     end
   end
 end

--- a/spec/system/errors_spec.rb
+++ b/spec/system/errors_spec.rb
@@ -18,6 +18,6 @@ RSpec.describe 'Error pages' do
 
   it 'shows not found error page' do
     visit '/foo'
-    expect(page).to have_content 'If you copied a web address, please check it’s correct'
+    expect(page).to have_content 'If you typed the web address, check it is correct.'
   end
 end

--- a/spec/system/errors_spec.rb
+++ b/spec/system/errors_spec.rb
@@ -11,13 +11,15 @@ RSpec.describe 'Error pages' do
     expect(page).to have_content 'Sorry, something went wrong with our service'
   end
 
-  it 'shows application not found error page' do
+  it 'shows application not found error page with nav' do
     visit '/applications/123'
-    expect(page).to have_content 'If you’re looking for a specific application, go to all open applications'
+    expect(page).to have_content "If you're looking for a specific application, go to all open applications."
+    expect(page).to have_content 'Closed applications'
   end
 
-  it 'shows not found error page' do
+  it 'shows not found error page with nav' do
     visit '/foo'
     expect(page).to have_content 'If you typed the web address, check it is correct.'
+    expect(page).to have_content 'Closed applications'
   end
 end


### PR DESCRIPTION
## Description of change
Update error copy
Render errors directly on page, not as flash notifications

Update routing and nav rendering to be conditional on logged in status to show more helpful messaging to logged in users but not leak and info of which pages exist to external users

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-336

## Notes for reviewer
DO NOT MERGE - conversations ongoing as to whether we want to stop using flash notifications for these errors

## Screenshots of changes (if applicable)

### Before changes:
<img width="1093" alt="image" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/c30414a6-aeaf-4eed-970d-79306e06e02d">

### After changes:
<img width="1091" alt="image" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/2b6e03e2-d828-489b-91be-31974af7db90">

etc per error
## How to manually test the feature
To see service errors (not get redirected to user admin) set feature flag in config/settings.yml:
```
allow_user_managers_service_access:
    local: true
```
 - Doing so will make authorisation_spec and header_nav_spec fail
 
To see all error pages, remove from routes.rb:
```
, constraints:
    lambda { |_request| !Rails.application.config.consider_all_requests_local }
    ``` 