### PR TITLE
Skip modsec xss rule

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -22,6 +22,7 @@ metadata:
       SecRequestBodyLimit 1048576
       SecRequestBodyNoFilesLimit 1048576
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
+      SecRuleUpdateTargetById 941100 !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
 spec:
   ingressClassName: modsec
   tls:

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -22,6 +22,7 @@ metadata:
       SecRequestBodyLimit 1048576
       SecRequestBodyNoFilesLimit 1048576
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
+      SecRuleUpdateTargetById 941100 !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
 spec:
   ingressClassName: modsec
   tls:


### PR DESCRIPTION
## Description of change
Replica of [ PR on Apply ](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/367) to prevent 403 forbidden on modsec xss suspicion

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
