### PR TITLE
Bump schema gem from 0.2.1 to 0.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.2.1'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.3.0'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 0a80f2d03dd5fdffafbfcfababa518c186d33a00
-  tag: v0.2.1
+  revision: 183785d967669e94009623978e094de03e910b12
+  tag: v0.3.0
   specs:
-    laa-criminal-legal-aid-schemas (0.2.1)
+    laa-criminal-legal-aid-schemas (0.3.0)
       dry-struct
       json-schema (~> 3.0.0)
 


### PR DESCRIPTION
## Description of change
Bump schema gem from 0.2.1 to 0.3.0
## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
