### PR TITLE
Amend logging filters, post audit

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -6,33 +6,27 @@
 Rails.application.config.filter_parameters += [
   :_key, :certificate, :client_id, :client_secret,
   :oid, :otp, :passw, :pkce, :salt, :secret, :ssn,
-  :tenant_id, :token,
+  :tenant_id, :token, :crypt,
 
   # Attributes relating to an application
   # It does partial matching (i.e. `telephone_number` is covered by `phone`)
-  :address,
-  :address_line_one,
-  :address_line_two,
-  :application_start_date,
+  :address_line,
   :city,
   :code,
   :country,
-  :crypt,
   :date_of_birth,
-  :details,
   :description,
+  :details,
   :email,
   :first_name,
   :hearing_court_name,
   :hearing_date,
   :last_name,
   :lookup_id,
-  :name,
   :nino,
   :other_names,
   :phone,
   :postcode,
   :reason,
-  :submission_date,
   :urn
 ]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,39 +3,36 @@
 # Configure parameters to be filtered from the log file. Use this to limit dissemination of
 # sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
 # notations and behaviors.
-Rails.application.config.filter_parameters += %i[
-  _key
-  address
-  address_line_one
-  address_line_two
-  application_start_date
-  certificate
-  client_id
-  client_secret
-  code
-  country
-  crypt
-  date_of_birth
-  email
-  first_name
-  hearing_court_name
-  hearing_date
-  last_name
-  name
-  nino
-  oid
-  other_names
-  otp
-  passw
-  pkce
-  postcode
-  reason
-  salt
-  secret
-  ssn
-  submission_date
-  telephone_number
-  tenant_id
-  token
-  urn
+Rails.application.config.filter_parameters += [
+  :_key, :certificate, :client_id, :client_secret,
+  :oid, :otp, :passw, :pkce, :salt, :secret, :ssn,
+  :tenant_id, :token,
+
+  # Attributes relating to an application
+  # It does partial matching (i.e. `telephone_number` is covered by `phone`)
+  :address,
+  :address_line_one,
+  :address_line_two,
+  :application_start_date,
+  :city,
+  :code,
+  :country,
+  :crypt,
+  :date_of_birth,
+  :details,
+  :description,
+  :email,
+  :first_name,
+  :hearing_court_name,
+  :hearing_date,
+  :last_name,
+  :lookup_id,
+  :name,
+  :nino,
+  :other_names,
+  :phone,
+  :postcode,
+  :reason,
+  :submission_date,
+  :urn
 ]


### PR DESCRIPTION
## Description of change
PR does a little rationalisation and adds some missed filters to the filter logger. Also separates the "application" domain filters from the the more technical ones (e.g. salt, passw).

I also moved these to symbols to be consistent with apply and enable comments to be added to the filter.

Analysis of what is logged across systems is linked in the comment of the ticket as a google sheet. 

## Link to relevant ticket
[CRIMRE-227](https://dsdmoj.atlassian.net/browse/CRIMRE-227)


[CRIMRE-227]: https://dsdmoj.atlassian.net/browse/CRIMRE-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ