### PR TITLE
Update fixtures for stricter structs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.3.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.4.0'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,12 +8,12 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 183785d967669e94009623978e094de03e910b12
-  tag: v0.3.0
+  revision: 39186b9ebf3d71c00e3b53b506c936aed52429ef
+  tag: v0.4.0
   specs:
-    laa-criminal-legal-aid-schemas (0.3.0)
-      dry-struct
-      json-schema (~> 3.0.0)
+    laa-criminal-legal-aid-schemas (0.4.0)
+      dry-struct (~> 1.6.0)
+      json-schema (~> 4.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -247,7 +247,7 @@ GEM
       bindata
       faraday (~> 2.0)
       faraday-follow_redirects
-    json-schema (3.0.0)
+    json-schema (4.0.0)
       addressable (>= 2.8)
     jwt (2.7.0)
     kaminari (1.2.2)

--- a/spec/fixtures/files/crime_apply_data/applications/148df27d-4710-4c5b-938c-bb132eb040ca.json
+++ b/spec/fixtures/files/crime_apply_data/applications/148df27d-4710-4c5b-938c-bb132eb040ca.json
@@ -8,10 +8,11 @@
   "date_stamp": "2022-11-21T16:19:00.000+00:00",
   "submitted_at": "2023-01-14T16:58:15.000+00:00",
   "provider_details": {
-    "office_code": "1",
-    "legal_rep_first_name": "Jack",
-    "legal_rep_last_name": "Wagyu",
-    "legal_rep_telephone": "07098765602"
+    "office_code": "1A123B",
+    "provider_email": "provider@example.com",
+    "legal_rep_first_name": "John",
+    "legal_rep_last_name": "Doe",
+    "legal_rep_telephone": "123456789"
   },
   "client_details": {
     "applicant": {
@@ -46,11 +47,15 @@
     }
   ],
   "case_details": {
+    "appeal_maat_id": null,
+    "appeal_with_changes_maat_id": null,
+    "appeal_with_changes_details": null,
     "case_type": "summary_only",
     "codefendants": [],
     "offences": [
       {
         "offence_class": "C",
+        "passportable": true,
         "dates": [
           {
             "date_from": "2020-12-12",

--- a/spec/fixtures/files/crime_apply_data/applications/1aa4c689-6fb5-47ff-9567-5eee7f8ac2cc.json
+++ b/spec/fixtures/files/crime_apply_data/applications/1aa4c689-6fb5-47ff-9567-5eee7f8ac2cc.json
@@ -1,5 +1,6 @@
 {
   "id": "1aa4c689-6fb5-47ff-9567-5eee7f8ac2cc",
+  "parent_id": null,
   "reference": "22340980",
   "schema_version": "1.0",
   "status": "submitted",
@@ -9,10 +10,11 @@
   "submitted_at": "2022-11-14T16:58:15.000+00:00",
   "reviewed_at": "2022-11-16T11:58:15.000+00:00",
   "provider_details": {
-    "office_code": "1",
-    "legal_rep_first_name": "Jack",
-    "legal_rep_last_name": "Wagyu",
-    "legal_rep_telephone": "07098765602"
+    "office_code": "1A123B",
+    "provider_email": "provider@example.com",
+    "legal_rep_first_name": "John",
+    "legal_rep_last_name": "Doe",
+    "legal_rep_telephone": "123456789"
   },
   "client_details": {
     "applicant": {
@@ -23,7 +25,8 @@
       "nino": "NC123458A",
       "date_of_birth": "1980-06-01",
       "telephone_number": null,
-      "correspondence_address_type": "home_address"
+      "correspondence_address_type": "providers_office_address",
+      "correspondence_address": null
     }
   },
   "ioj_passport": [],
@@ -34,11 +37,15 @@
     }
   ],
   "case_details": {
+    "appeal_maat_id": null,
+    "appeal_with_changes_maat_id": null,
+    "appeal_with_changes_details": null,
     "case_type": "summary_only",
     "codefendants": [],
     "offences": [
       {
-        "offence_class": "Class C or B",
+        "offence_class": "C",
+        "passportable": true,
         "dates": [
           {
             "date_from": "2020-12-12",

--- a/spec/fixtures/files/crime_apply_data/applications/5aa4c689-6fb5-47ff-9567-5efe7f8ac211.json
+++ b/spec/fixtures/files/crime_apply_data/applications/5aa4c689-6fb5-47ff-9567-5efe7f8ac211.json
@@ -1,5 +1,6 @@
 {
   "id": "5aa4c689-6fb5-47ff-9567-5efe7f8ac211",
+  "parent_id": null,
   "reference": "5230234344",
   "schema_version": "1.0",
   "status": "returned",
@@ -7,10 +8,11 @@
   "date_stamp": "2022-11-21T16:19:00.000+00:00",
   "submitted_at": "2022-12-14T16:58:15.000+00:00",
   "provider_details": {
-    "office_code": "1",
-    "legal_rep_first_name": "Jack",
-    "legal_rep_last_name": "Wagyu",
-    "legal_rep_telephone": "07098765602"
+    "office_code": "1A123B",
+    "provider_email": "provider@example.com",
+    "legal_rep_first_name": "John",
+    "legal_rep_last_name": "Doe",
+    "legal_rep_telephone": "123456789"
   },
   "client_details": {
     "applicant": {
@@ -40,18 +42,22 @@
   "ioj_passport": ["on_age_under18"],
   "interests_of_justice": [],
   "case_details": {
+    "appeal_maat_id": null,
+    "appeal_with_changes_maat_id": null,
+    "appeal_with_changes_details": null,
     "case_type": "summary_only",
     "codefendants": [],
     "offences": [
       {
         "offence_class": null,
+        "passportable": false,
         "dates": [
           {
             "date_from": "2020-12-12",
             "date_to": null
           }
         ],
-        "name": "Robbery"
+        "name": "Robbery of some form"
       }
     ],
     "hearing_court_name": "Caernarfon Crown Court",


### PR DESCRIPTION
## Description of change
Update to use 0.4.0 of the schema gem.
Update fixtures to work with the stricter structs.

## Link to relevant ticket

## Notes for reviewer

The structs now have stricter definitions -- which are, in some cases, more strict than the json schema itself. 

This PR updates the fixtures we have on review so that they work with the latest structs/schema.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
