### PR TITLE
Disable sidescrolling to help with usability

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -21,3 +21,9 @@ form.search {
 p.help-text, #superseded_style  {
   color: govuk-colour("dark-grey");
 }
+
+// On Edge browser, the app will side scroll left and right and make it more difficult to scroll down the page.
+// Side scrolling has been disabled to help with usability
+html {
+  overflow-x: hidden;
+}


### PR DESCRIPTION
## Description of change
On Edge browser, the app will side scroll making it more difficult to scroll down the page. The experimental feature `elastic-overscroll` is enabled by default on edge browsers (on windows) and is responsible for this. This can be disabled by the user by navigating to `edge://flags` and manually disabling the feature. However, this cannot be disabled programatically. Therefore, side scrolling is disabled using css and the page is 'locked' to help with usability. This is will impact usability across all browsers but as the user base primarily use edge and are unlikely to use other browsers, this is not a concern.

## Link to relevant ticket
[CRIMRE-331](https://dsdmoj.atlassian.net/browse/CRIMRE-331)

## Notes for reviewer
This recordings below are in chrome but this applies across all browsers

## Screenshots of changes (if applicable)

### Before changes:
https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/e59610df-f5af-4829-804e-d2ae0dd0b9f5

### After changes:
https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/ea5afd0d-8c71-435d-9620-713c3c4758f9

## How to manually test the feature


[CRIMRE-331]: https://dsdmoj.atlassian.net/browse/CRIMRE-331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ