### PR TITLE
[CRIMRE-361] Prevent current_user from reactivating

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,4 +56,12 @@ module ApplicationHelper
 
     render headers, base_params:, sort_form_method:
   end
+
+  # Rails link_to_if and variants still render the link text hence custom implementation
+  # https://govuk-components.netlify.app/helpers/link/#input-erb-class-helpers
+  def gov_link_to_unless_current_user(user:, **options)
+    return '' if current_user == user
+
+    govuk_link_to options[:text], options[:path], options[:html_options]
+  end
 end

--- a/app/views/admin/manage_users/deactivated_users/_actions.html.erb
+++ b/app/views/admin/manage_users/deactivated_users/_actions.html.erb
@@ -1,5 +1,10 @@
 <ul class="govuk-summary-list__actions-list">
   <li class="govuk-summary-list__actions-list-item">
-    <%= govuk_link_to action_text(:reactivate), confirm_reactivate_admin_manage_users_deactivated_user_path(user), { no_visited_state: true } %>
+    <%= gov_link_to_unless_current_user(
+          user: user,
+          text: action_text(:reactivate),
+          path: confirm_reactivate_admin_manage_users_deactivated_user_path(user),
+          html_options: { no_visited_state: true }
+        )%>
   </li>
 </li>

--- a/config/locales/en/manage_users.yml
+++ b/config/locales/en/manage_users.yml
@@ -34,6 +34,7 @@ en:
         cannot_access:
           - You do not have access to that page
           - Contact laa-crime-apply@digital.justice.gov.uk if you think this is wrong
+        reactivation_denied: You cannot reactivate yourself
 
     confirmations:
       deactivate_user: Are you sure you want to deactivate %{user_name}?


### PR DESCRIPTION
## Description of change
Does not allow the current logged in user from reactivating themselves by:

- Hiding the 'Reactivate' link
- Showing an error message if current_user attempts to Reactivate by entering an appropriate URL into their browser

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-361

## Notes for reviewer
This behaviour is only applicable when current_user is deactivated by somebody else but their browser session is still open.
Introduced a new helper method `gov_link_to_unless_current_user` because `link_to_if` still outputs the link just without the anchor tag.
Not sure if premature to move the reactivation methods into a dedicated controller - perhaps overkill?

## Screenshots of changes (if applicable)
#### No reactivate link for logged in user if they are deactivated but still logged in
![Screenshot 2023-06-14 at 10 11 18](https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/47113046/750e90f1-9a23-4cdc-a3a8-84ecb01e2eb1)


#### If current_user manually tries to reactivate themselves they are bounced back to the deactivated users page
![Screenshot 2023-06-14 at 10 26 42](https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/47113046/724a2eb2-b3f6-425a-b7d0-928a61769322)






### Before changes:

### After changes:

## How to manually test the feature
1. Log in to 2 different browsers with 2 different users, both with 'can manage others' permission set to true. 
2. Deactivate one of the users.
3. Then in the browser with the deactivated user still logged-in, browse to manage users -> deactivated users