### PR TITLE
Ensure all times are TZ London before formatting

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,13 @@
 module ApplicationHelper
+  # Convert to the London time zone before localizing.
+  def tz_l(timestamp, options = {})
+    time_zone = options.fetch(:time_zone, 'London')
+
+    I18n.l(timestamp.in_time_zone(time_zone), **options)
+  end
+
+  alias l tz_l
+
   def service_name
     t('service.name')
   end

--- a/app/models/application_search_filter.rb
+++ b/app/models/application_search_filter.rb
@@ -43,13 +43,13 @@ class ApplicationSearchFilter < ApplicationStruct
   #
   def datastore_params
     {
-      applicant_date_of_birth:,
-      application_id_in:,
-      application_id_not_in:,
-      review_status:,
-      submitted_after:,
-      submitted_before:,
-      search_text:
+      applicant_date_of_birth: applicant_date_of_birth,
+      application_id_in: application_id_in,
+      application_id_not_in: application_id_not_in,
+      review_status: review_status,
+      submitted_after: submitted_after&.in_time_zone('London'),
+      submitted_before: submitted_before&.in_time_zone('London'),
+      search_text: search_text
     }
   end
 

--- a/app/models/application_search_result.rb
+++ b/app/models/application_search_result.rb
@@ -12,7 +12,10 @@ class ApplicationSearchResult < ApplicationStruct
   alias id resource_id
 
   def days_passed
-    Calendar.new.business_days_between(submitted_at, Time.zone.now.to_date)
+    @days_passed ||= Calendar.new.business_days_between(
+      submitted_at.in_time_zone('London').to_date,
+      Time.current.in_time_zone('London').to_date
+    )
   end
 
   def caseworker_name

--- a/app/models/business_day.rb
+++ b/app/models/business_day.rb
@@ -1,5 +1,5 @@
 class BusinessDay
-  def initialize(age_in_business_days: 0, day_zero: Time.zone.now.to_date, calendar: Calendar.new)
+  def initialize(day_zero:, age_in_business_days: 0, calendar: Calendar.new)
     @age_in_business_days = age_in_business_days
     @day_zero = day_zero
     @calendar = calendar
@@ -8,7 +8,7 @@ class BusinessDay
   attr_reader :age_in_business_days
 
   def date
-    return calendar.roll_forward(day_zero).to_date if age_in_business_days.zero?
+    return calendar.roll_forward(day_zero) if age_in_business_days.zero?
 
     calendar.subtract_business_days(day_zero, age_in_business_days)
   end

--- a/app/models/reporting/processed_report.rb
+++ b/app/models/reporting/processed_report.rb
@@ -2,8 +2,8 @@ module Reporting
   class ProcessedReport
     include Reportable
 
-    def initialize(day_zero: Time.zone.now.to_date)
-      @day_zero = day_zero
+    def initialize(day_zero: Time.current)
+      @day_zero = day_zero.in_time_zone('London').to_date
     end
 
     def table

--- a/app/models/reporting/workload_report.rb
+++ b/app/models/reporting/workload_report.rb
@@ -2,9 +2,9 @@ module Reporting
   class WorkloadReport
     include Reportable
 
-    def initialize(number_of_days: 4, day_zero: Time.zone.now.to_date, last_row_limit_in_days: 10)
+    def initialize(number_of_days: 4, day_zero: Time.current, last_row_limit_in_days: 10)
       @number_of_days = number_of_days
-      @day_zero = day_zero
+      @day_zero = day_zero.in_time_zone('London').to_date
       @last_row_limit_in_days = last_row_limit_in_days
     end
 

--- a/app/views/application_searches/_search_results_table_body.html.erb
+++ b/app/views/application_searches/_search_results_table_body.html.erb
@@ -11,7 +11,7 @@
     <%= l(result.submitted_at) %>
   </td>
   <td class="govuk-table__cell">
-    <%= result.reviewed_at.present? ? l(result.reviewed_at) : nil %>
+    <%= l(result.reviewed_at) if result.reviewed_at %>
   </td>
   <td class="govuk-table__cell">
     <%= result.caseworker_name %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,12 @@ module LaaReviewCriminalLegalAid
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    config.time_zone = "London"
+    # UTC is used as the application time_zone across Crime apply services. This
+    # means that all times must be converted to TZ London before formatting or 
+    # converting to dates.
+    #
+    config.time_zone = "UTC"
+
     # config.eager_load_paths << Rails.root.join("extras")
     config.force_ssl = true
     config.ssl_options = { redirect: { exclude: ->(request) { request.path =~ /health|ping/ } } }

--- a/spec/models/application_search_filter_spec.rb
+++ b/spec/models/application_search_filter_spec.rb
@@ -65,6 +65,22 @@ RSpec.describe ApplicationSearchFilter do
     end
   end
 
+  describe 'datastore date params' do
+    it 'BST dates can be correctly converted to UCT' do
+      date = Date.parse('2023-07-01')
+      report = described_class.new(submitted_after: date, submitted_before: date)
+      expect(report.datastore_params.fetch(:submitted_after)).to eq Time.iso8601('2023-06-30T23:00:00Z')
+      expect(report.datastore_params.fetch(:submitted_before)).to eq Time.iso8601('2023-06-30T23:00:00Z')
+    end
+
+    it 'GMT dates can be correctly converted to UCT' do
+      date = Date.parse('2023-01-01')
+      report = described_class.new(submitted_after: date, submitted_before: date)
+      expect(report.datastore_params.fetch(:submitted_after)).to eq Time.iso8601('2023-01-01T00:00:00Z')
+      expect(report.datastore_params.fetch(:submitted_before)).to eq Time.iso8601('2023-01-01T00:00:00Z')
+    end
+  end
+
   describe 'translating the assigned_status into search params' do
     let(:application_id_in) { new.datastore_params.fetch(:application_id_in) }
     let(:application_id_not_in) { new.datastore_params.fetch(:application_id_not_in) }

--- a/spec/system/closed_applications_dashboard_spec.rb
+++ b/spec/system/closed_applications_dashboard_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe 'Closed Applications Dashboard' do
         reference: 6_000_002,
         status: 'returned',
         submitted_at: '2022-09-27T14:10:00.000+00:00',
-        reviewed_at: '2022-12-15T16:58:15.000+00:00',
-        parent_id: nil
+        reviewed_at: '2022-12-15T16:58:15.000+00:00'
       )
     ]
   end
@@ -57,7 +56,7 @@ RSpec.describe 'Closed Applications Dashboard' do
 
   it 'shows the correct information' do
     first_row_text = page.first('.app-dashboard-table tbody tr').text
-    reviewed_at = I18n.l(Time.zone.now.to_date)
+    reviewed_at = I18n.l(Time.current.in_time_zone('London'))
     expect(first_row_text).to eq("John Potter 6000002 27 Sep 2022 #{reviewed_at} Joe EXAMPLE Sent back to provider")
   end
 

--- a/spec/system/manage_users/viewing_spec.rb
+++ b/spec/system/manage_users/viewing_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Manage Users Dashboard' do
     it 'shows the correct table content' do
       first_data_row = page.first('.govuk-table tbody tr').text
       expect(first_data_row).to eq([current_user.name, current_user.email, 'Yes',
-                                    I18n.l(last_auth_at, format: :timestamp)].join(' '))
+                                    I18n.l(last_auth_at.in_time_zone('London'), format: :timestamp)].join(' '))
     end
 
     describe 'ordering of users in the list' do

--- a/spec/system/open_applications_dashboard_spec.rb
+++ b/spec/system/open_applications_dashboard_spec.rb
@@ -24,8 +24,7 @@ RSpec.describe 'Open Applications Dashboard' do
     first_row_text = page.first('.app-dashboard-table tbody tr').text
 
     days_ago = Calendar.new.business_days_between(
-      DateTime.parse('2022-10-27T14:09:11.000+00:00'),
-      Time.zone.now.to_date
+      Date.parse('2022-10-27'), Time.current.in_time_zone('London')
     )
 
     expect(first_row_text).to eq("Kit Pound 120398120 27 Oct 2022 #{days_ago} days")

--- a/spec/system/searching/filter_by_date_range_spec.rb
+++ b/spec/system/searching/filter_by_date_range_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Search by submitted date' do
   include_context 'when search results are returned'
 
-  let(:after_date) { Date.parse('2011-06-08') }
-  let(:before_date) { Date.parse('2011-06-09') }
+  let(:after_date) { Date.parse('2023-06-08') }
+  let(:before_date) { Date.parse('2023-01-09') }
 
   before do
     visit '/'

--- a/spec/system/viewing_an_application/history_spec.rb
+++ b/spec/system/viewing_an_application/history_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Viewing application history' do
 
     it 'includes the submission event' do
       first_row = page.first('.app-dashboard-table tbody tr').text
-      expect(first_row).to match('Monday 24 Oct 09:50 John Doe Application submitted')
+      expect(first_row).to match('Monday 24 Oct 10:50 John Doe Application submitted')
     end
   end
 


### PR DESCRIPTION
## Description of change

Convert all timestamps to London TZ before formatting or converting to dates.

## Link to relevant ticket

## Notes for reviewer

UTC is used for the application and database timezones across the crime review/apply services.

Because the timestamps we get from the datastore etc are in UTC, before formatting them, or converting to dates, they must be converted to the London TZ.

This is especially important for Review where we need to know specific day in the London time zone for MI.

## Screenshots of changes (if applicable)

### Before changes:

<img width="778" alt="Screenshot 2023-06-15 at 14 04 21" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/a172d215-6fee-4213-b12b-e0bd047a5874">

### After changes:

<img width="698" alt="Screenshot 2023-06-15 at 14 11 23" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/deaee236-5c1f-4f77-9971-385d351b0e66">


## How to manually test the feature
