### PR TITLE
Allow links in flash notifications

### DIFF
--- a/app/models/flash_notice.rb
+++ b/app/models/flash_notice.rb
@@ -1,0 +1,46 @@
+# FlashNotice view object
+#
+# Takes a flash item and converts it into a view object with attributes
+# matching those used by the govuk_notification_banner helper
+
+class FlashNotice
+  include ActionView::Helpers::SanitizeHelper
+  include ActionView::Helpers::UrlHelper
+
+  def initialize(key, message)
+    content = Array[*message]
+
+    @text = content.delete_at(0)
+    @key = key
+    @raw_details = content
+  end
+
+  attr_reader :text
+
+  def details
+    @details ||= @raw_details.map do |raw_detail|
+      # Remove all tags and replace placeholder with link
+      strip_tags(raw_detail).sub('ONBOARDING_EMAIL_LINK', onboarding_email_link)
+    end
+  end
+
+  def success?
+    %i[success notice].include? key.to_sym
+  end
+
+  def title_text
+    I18n.t(:title, scope: "flash.#{key}")
+  end
+
+  def to_partial_path
+    'flash_notice'
+  end
+
+  private
+
+  attr_reader :key
+
+  def onboarding_email_link
+    mail_to(Rails.application.config.x.admin.onboarding_email)
+  end
+end

--- a/app/views/application/_flash_notice.html.erb
+++ b/app/views/application/_flash_notice.html.erb
@@ -1,0 +1,6 @@
+<%= govuk_notification_banner(title_text: flash_notice.title_text, success: flash_notice.success?) do |banner| %>
+  <% banner.with_heading(text: flash_notice.text) %>
+  <% flash_notice.details.each do |detail| %>
+    <p><%= sanitize(detail, tags: %w[a]) %></p>
+  <% end %>
+<% end %>

--- a/app/views/shared/_flash_banner.html.erb
+++ b/app/views/shared/_flash_banner.html.erb
@@ -2,23 +2,5 @@
   <%# Ignore Devise timedout flash messages %>
   <% next if key == 'timedout' %>
 
-  <%#
-      If the flash message is an array, display the first item as the heading.
-      Subsiquent items are displayed as paragraphs. (See Devise locales
-      'devise.failure.user.reauthenticate' for example.)
-
-      If the message is not an array, display it as the heading.
-  %>
-
-  <% details = Array[*message] %>
-  <% text = details.delete_at(0) %>
-  <% success = %i[success notice].include? key.to_sym %>
-  <% title_text = t(:title, scope: "flash.#{key}") %>
-
-  <%= govuk_notification_banner(title_text:, success:) do |banner| %>
-    <% banner.with_heading(text:) %>
-    <% details.each do |detail| %>
-      <p><%= sanitize(detail, tags: %w[a], attributes: %w[href]) %></p>
-    <% end %>
-  <% end %>
+  <%= render FlashNotice.new(key, message) %>
 <% end %>

--- a/app/views/shared/_flash_banner.html.erb
+++ b/app/views/shared/_flash_banner.html.erb
@@ -18,7 +18,7 @@
   <%= govuk_notification_banner(title_text:, success:) do |banner| %>
     <% banner.with_heading(text:) %>
     <% details.each do |detail| %>
-      <p><%= detail %></p>
+      <p><%= sanitize(detail, tags: %w[a], attributes: %w[href]) %></p>
     <% end %>
   <% end %>
 <% end %>

--- a/config/locales/en/devise.yml
+++ b/config/locales/en/devise.yml
@@ -18,11 +18,11 @@ en:
         dormant: 
           - You cannot access this service
           - This is because you have not signed in to the service for more than 6 months.
-          - Contact <a mailto=LAAapplyonboarding@justice.gov.uk>LAAapplyonboarding@justice.gov.uk</a> to reactivate your account.
+          - Contact ONBOARDING_EMAIL_LINK to reactivate your account.
         invitation_expired: 
           - You cannot access this service
           - Your invitation to access this service has expired.
-          - "Contact <a mailto=LAAapplyonboarding@justice.gov.uk>LAAapplyonboarding@justice.gov.uk</a> for a new invitation."
+          - Contact ONBOARDING_EMAIL_LINK for a new invitation.
     sessions:
       user:
         signed_in: ""

--- a/spec/models/flash_notice_spec.rb
+++ b/spec/models/flash_notice_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe FlashNotice do
+  subject(:new) { described_class.new(key, message) }
+
+  let(:key) { :success }
+  let(:message) { 'Simple message' }
+
+  describe '#text' do
+    subject(:text) { new.text }
+
+    context 'when the message is a string' do
+      it { is_expected.to eq 'Simple message' }
+    end
+
+    context 'when the message is an array of one' do
+      let(:message) { ['Simple message'] }
+
+      it { is_expected.to eq 'Simple message' }
+    end
+
+    context 'when the message is an array of several' do
+      let(:message) { ['Message with details', 'First detail.', 'Second detail.'] }
+
+      it { is_expected.to eq 'Message with details' }
+    end
+  end
+
+  describe '#details' do
+    subject(:details) { new.details }
+
+    context 'when the message is a string' do
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the message is an array of one' do
+      let(:message) { ['Simple message'] }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the message is an array of several' do
+      let(:message) { ['Message with details', 'First detail.', 'Second detail.'] }
+
+      it 'sets all but the first items in message as the details' do
+        expect(details).to contain_exactly('First detail.', 'Second detail.')
+      end
+    end
+
+    context 'when the message includes "ONBOARDING_EMAIL_LINK" placeholder in the details' do
+      let(:message) { ['Message with mail link placeholder', 'Contact ONBOARDING_EMAIL_LINK for help.'] }
+
+      it 'replaces the placeholder with the onboarding link' do
+        expected_detail = "Contact <a href=\"mailto:#{Rails.application.config.x.admin.onboarding_email}\">" \
+                          "#{Rails.application.config.x.admin.onboarding_email}</a> for help."
+
+        expect(details.first).to eq expected_detail
+      end
+    end
+
+    context 'when the message details include html tags' do
+      let(:message) { ['Message with a link', 'Detail <em>with</em> html <a href="https://example.com">link</a> for help.'] }
+
+      it 'tags are stripped from the details' do
+        expect(details.first).to eq 'Detail with html link for help.'
+      end
+    end
+  end
+
+  describe '#success?' do
+    subject(:success) { new.success? }
+
+    context 'when key is "success"' do
+      it { is_expected.to be true }
+    end
+
+    context 'when key is "alert"' do
+      let(:key) { 'alert' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when key is "notice"' do
+      let(:key) { 'notice' }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#title_text' do
+    subject(:title_text) { new.title_text }
+
+    context 'when key is "success"' do
+      it { is_expected.to eq 'Success' }
+    end
+
+    context 'when key is "alert"' do
+      let(:key) { 'alert' }
+
+      it { is_expected.to eq 'Important' }
+    end
+
+    context 'when key is "notice"' do
+      let(:key) { 'notice' }
+
+      it { is_expected.to eq 'Success' }
+    end
+  end
+
+  describe '#to_partial_path' do
+    it 'is expected to equal "flash_message"' do
+      expect(new.to_partial_path).to eq 'flash_notice'
+    end
+  end
+end

--- a/spec/support/gds_helper.rb
+++ b/spec/support/gds_helper.rb
@@ -6,11 +6,11 @@ module GdsHelper
       assertion = have_selector('h2', text: title_text)
                   .and(have_selector('div', text:))
 
-      if details
-        assertion.and(have_selector('p', text: details))
-      else
-        assertion
+      [details].flatten.each do |detail|
+        assertion = assertion.and(have_selector('p', text: detail))
       end
+
+      assertion
     end
   end
 

--- a/spec/system/authenticating/a_dormant_user_spec.rb
+++ b/spec/system/authenticating/a_dormant_user_spec.rb
@@ -16,7 +16,10 @@ RSpec.describe 'Authenticating a dormant user' do
   it 'informs the user that their invitation has expired' do
     expect(page).to have_notification_banner(
       text: 'You cannot access this service',
-      details: 'This is because you have not signed in to the service for more than 6 months.'
+      details: [
+        'This is because you have not signed in to the service for more than 6 months.',
+        "Contact #{Rails.application.config.x.admin.onboarding_email} to reactivate your account."
+      ]
     )
   end
 end

--- a/spec/system/authenticating/an_invited_user_spec.rb
+++ b/spec/system/authenticating/an_invited_user_spec.rb
@@ -32,7 +32,10 @@ RSpec.describe 'Authenticating an invited user' do
       it 'informs the user that their invitation has expired' do
         expect(page).to have_notification_banner(
           text: 'You cannot access this service',
-          details: 'Your invitation to access this service has expired.'
+          details: [
+            'Your invitation to access this service has expired.',
+            "Contact #{Rails.application.config.x.admin.onboarding_email} for a new invitation."
+          ]
         )
       end
 


### PR DESCRIPTION
## Description of change
Allow links to appear in flash messages

## Link to relevant ticket
[CRIMRE-369](https://dsdmoj.atlassian.net/browse/CRIMRE-369)

## Notes for reviewer
This issue arose after the content for some devise flash messages was updated to include a mail link.  One alternative to this change might be to include the email as a text rather than a link.

## Screenshots of changes (if applicable)

### Before changes:
<img width="1005" alt="Screenshot 2023-06-21 at 08 47 10" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/a4407c12-1d5e-4638-8951-51b882800d8c">


### After changes:
<img width="1018" alt="Screenshot 2023-06-21 at 08 46 28" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/3b333a83-6854-4dbb-b6bc-e01377bbcb69">

## How to manually test the feature



[CRIMRE-369]: https://dsdmoj.atlassian.net/browse/CRIMRE-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ