### PR TITLE
Ugrade schema to 0.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.4.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.5.0'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 39186b9ebf3d71c00e3b53b506c936aed52429ef
-  tag: v0.4.0
+  revision: 86ed15ee153a473c77e9683e3f0e51895d9e935f
+  tag: v0.5.0
   specs:
-    laa-criminal-legal-aid-schemas (0.4.0)
+    laa-criminal-legal-aid-schemas (0.5.0)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 


### PR DESCRIPTION
Ugrade schema to 0.5.0

## Description of change

0.4.0 used to require the passported attr. This has been renamed and no longer required by 0.5.0

## Link to relevant ticket
https://ministryofjustice.sentry.io/issues/4278395203/?query=is%3Aunresolved&referrer=issue-stream&stream_index=0

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
