### PR TITLE
Reorder if statements for logic to display ioj passport vs ioj reason

### DIFF
--- a/app/views/crime_applications/_interests_of_justice.html.erb
+++ b/app/views/crime_applications/_interests_of_justice.html.erb
@@ -14,18 +14,7 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% if crime_application.ioj_passport.present? %>
-      <% crime_application.ioj_passport.each do |passport| %>
-        <tr class="govuk-table__row">
-          <td scope="row" class="govuk-table__cell">
-            <%= t(passport, scope: 'crime_applications.values') %>
-          </td>
-          <td class="govuk-table__cell">
-            <span class="moj-badge moj-badge--blue"><%= t(:passported, scope: 'crime_applications.values') %></span>
-          </td>
-        </tr>
-      <% end %>
-    <% else %>
+    <% if crime_application.interests_of_justice.present? %>
       <% crime_application.interests_of_justice.each do |interest_of_justice| %>
         <tr class="govuk-table__row">
           <td scope="row" class="govuk-table__cell">
@@ -36,7 +25,17 @@
           </td>
         </tr>
       <% end %>
+    <% else %>
+      <% crime_application.ioj_passport.each do |passport| %>
+        <tr class="govuk-table__row">
+          <td scope="row" class="govuk-table__cell">
+            <%= t(passport, scope: 'crime_applications.values') %>
+          </td>
+          <td class="govuk-table__cell">
+            <span class="moj-badge moj-badge--blue"><%= t(:passported, scope: 'crime_applications.values') %></span>
+          </td>
+        </tr>
+      <% end %>
     <% end %>
-
   </tbody>
 </table>

--- a/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -59,11 +59,26 @@ RSpec.describe 'Viewing an application unassigned, open application' do
     end
   end
 
-  context 'with ioj passport' do
-    let(:application_data) { super().deep_merge('ioj_passport' => ['on_age_under18']) }
+  context 'with ioj passport and no ioj reason' do
+    let(:application_data) do
+      super().deep_merge(
+        'ioj_passport' => ['on_age_under18'],
+        'interests_of_justice' => nil
+      )
+    end
 
     it 'shows passport reason' do
       expect(page).to have_content('Client is under 18')
+    end
+  end
+
+  context 'when a passported application is a split case and resubmitted with ioj passport' do
+    let(:application_data) do
+      super().deep_merge('ioj_passport' => ['on_age_under18'])
+    end
+
+    it 'shows passport reason' do
+      expect(page).to have_content('More details about loss of liberty.')
     end
   end
 


### PR DESCRIPTION
## Description of change
If an application that when first submitted has IoJ not needed (no reason input), if it is found to be a split case on the courts systems then it may require returning and having an IoJ reason added. Crime Apply allows for this and overrides the 'IoJ not needed' attribute locally, but it remains in place in the data on resubmission, so a resubmitted application can have both an IoJ not needed flag AND an IoJ reason attribute. 

This PR reorders the conditional statements to check first if there is an IoJ reason and render that regardless of if the not needed flag is present (from the original submission) 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-355
## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
