### PR TITLE
Consider sent back as closed in workload report

### DIFF
--- a/app/models/flash_notice.rb
+++ b/app/models/flash_notice.rb
@@ -8,7 +8,7 @@ class FlashNotice
   include ActionView::Helpers::UrlHelper
 
   def initialize(key, message)
-    content = Array[*message]
+    content = [*message]
 
     @text = content.delete_at(0)
     @key = key

--- a/app/read_models/received_on_reports/configuration.rb
+++ b/app/read_models/received_on_reports/configuration.rb
@@ -5,7 +5,7 @@ module ReceivedOnReports
     ].freeze
 
     CLOSING_EVENTS = [
-      Reviewing::SendBack, Reviewing::Completed
+      Reviewing::SentBack, Reviewing::Completed
     ].freeze
 
     def call(event_store)

--- a/spec/models/reporting/received_on_report_spec.rb
+++ b/spec/models/reporting/received_on_report_spec.rb
@@ -20,4 +20,56 @@ RSpec.describe Reporting::ReceivedOnReport do
   it 'is a read only model' do
     expect(described_class.new).to be_readonly
   end
+
+  describe 'updating with review events' do
+    let(:application_id) { SecureRandom.uuid }
+    let(:submitted_at) { 1.week.ago.to_s }
+    let(:report) { described_class.find(BusinessDay.new(day_zero: submitted_at).date) }
+
+    let(:command) { Reviewing::ReceiveApplication.new(application_id: SecureRandom.uuid, submitted_at: submitted_at) }
+
+    context 'when a report does not exist for the given business day' do
+      it 'a new report is created' do
+        business_day = BusinessDay.new(day_zero: submitted_at).date
+        expect { command.call }.to change { described_class.where(business_day:).count }.by(1)
+      end
+    end
+
+    context 'when a report for the given business day exists' do
+      before do
+        stub_request(:get, "https://datastore-api-stub.test/api/v1/applications/#{application_id}")
+        allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
+          .and_return(instance_double(DatastoreApi::Requests::UpdateApplication, call: {}))
+
+        Reviewing::ReceiveApplication.call(application_id:, submitted_at:)
+      end
+
+      let(:user_id) { SecureRandom.uuid }
+
+      describe 'a receive command' do
+        it 'increments the total received' do
+          expect { command.call }.to change { report.reload.total_received }.from(1).to(2)
+        end
+      end
+
+      describe 'a mark as complete command' do
+        let(:command) { Reviewing::Complete.new(application_id:, submitted_at:, user_id:) }
+
+        it 'increments the total closed' do
+          expect { command.call }.to change { report.reload.total_closed }.from(0).to(1)
+        end
+      end
+
+      describe 'a send back command' do
+        let(:command) do
+          Reviewing::SendBack.new(application_id: application_id, submitted_at: submitted_at, user_id: user_id,
+                                  return_details: { reason: 'evidence_issue', details: 'a' })
+        end
+
+        it 'increments the total closed' do
+          expect { command.call }.to change { report.reload.total_closed }.from(0).to(1)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
Consider sent back as closed in workload report

## Link to relevant ticket

[CRIMRE-385](https://dsdmoj.atlassian.net/browse/CRIMRE-385)

## Notes for reviewer

A typo, was causing sent back applications not be counted as closed in the workload report.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-385]: https://dsdmoj.atlassian.net/browse/CRIMRE-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ