### PR TITLE
Render summary list for IoJ when IoJ passported

### DIFF
--- a/app/views/crime_applications/_interests_of_justice.html.erb
+++ b/app/views/crime_applications/_interests_of_justice.html.erb
@@ -2,19 +2,19 @@
   <%= t(:interests_of_justice, scope: 'crime_applications.section.headings') %>
 </h2>
 
-<table class="govuk-table app-dashboard-table govuk-!-margin-bottom-9">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">
-        <%= t('crime_applications.labels.interests_of_justice_type') %>
-      </th>
-      <th scope="col" class="govuk-table__header">
-        <%= t('crime_applications.labels.justification') %>
-      </th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% if crime_application.interests_of_justice.present? %>
+<% if crime_application.interests_of_justice.present? %>
+  <table class="govuk-table app-dashboard-table govuk-!-margin-bottom-9">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">
+          <%= t('crime_applications.labels.interests_of_justice_type') %>
+        </th>
+        <th scope="col" class="govuk-table__header">
+          <%= t('crime_applications.labels.justification') %>
+        </th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
       <% crime_application.interests_of_justice.each do |interest_of_justice| %>
         <tr class="govuk-table__row">
           <td scope="row" class="govuk-table__cell">
@@ -25,17 +25,19 @@
           </td>
         </tr>
       <% end %>
-    <% else %>
-      <% crime_application.ioj_passport.each do |passport| %>
-        <tr class="govuk-table__row">
-          <td scope="row" class="govuk-table__cell">
-            <%= t(passport, scope: 'crime_applications.values') %>
-          </td>
-          <td class="govuk-table__cell">
-            <span class="moj-badge moj-badge--blue"><%= t(:passported, scope: 'crime_applications.values') %></span>
-          </td>
-        </tr>
-      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <% crime_application.ioj_passport.each do |passport| %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= t(:justification, scope: 'crime_applications.labels') %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(passport, scope: 'crime_applications.values') %>
+        </dd>
+      </div>
     <% end %>
-  </tbody>
-</table>
+  </dl>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -186,8 +186,8 @@ en:
     interest_of_another: Interest of another person
     other: Other
     passported: Passported
-    on_age_under18: Client is under 18
-    on_offence: On offence
+    on_age_under18: Not needed because the client is under 18 years old
+    on_offence: Not needed based on offence
     today: Today
     yesterday: Yesterday
     day_before_yesterday: Day before yesterday

--- a/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -53,9 +53,13 @@ RSpec.describe 'Viewing an application unassigned, open application' do
     expect(page).not_to have_content('Mark as completed')
   end
 
-  context 'with interest of justice reason' do
-    it 'shows reason' do
-      expect(page).to have_content('Loss of liberty')
+  context 'with interest of justice reason only' do
+    it 'shows a table with ioj reason' do
+      ioj_table = find(:xpath,
+                       "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
+                       //tr[contains(td[1], 'Loss of liberty')]")
+
+      expect(ioj_table).to have_content('More details about loss of liberty.')
     end
   end
 
@@ -67,8 +71,12 @@ RSpec.describe 'Viewing an application unassigned, open application' do
       )
     end
 
-    it 'shows passport reason' do
-      expect(page).to have_content('Client is under 18')
+    it 'shows a summary list with passport reason' do
+      summary_list = find(:xpath,
+                          "//dl[@class='govuk-summary-list govuk-!-margin-bottom-9']
+                          //div[contains(dt[1], 'Justification')]")
+
+      expect(summary_list).to have_content('Not needed because the client is under 18 years old')
     end
   end
 
@@ -77,16 +85,20 @@ RSpec.describe 'Viewing an application unassigned, open application' do
       super().deep_merge('ioj_passport' => ['on_age_under18'])
     end
 
-    it 'shows passport reason' do
-      expect(page).to have_content('More details about loss of liberty.')
+    it 'shows a table with ioj reason' do
+      ioj_table = find(:xpath,
+                       "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
+                       //tr[contains(td[1], 'Loss of liberty')]")
+
+      expect(ioj_table).to have_content('More details about loss of liberty.')
     end
   end
 
-  # rubocop:disable Layout/LineLength
   context 'with offence class not provided' do
     it 'does shows the class not determined badge' do
       table_body = find(:xpath,
-                        "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']//tr[contains(td[1], 'Non-listed offence, manually entered')]")
+                        "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
+                        //tr[contains(td[1], 'Non-listed offence, manually entered')]")
 
       expect(table_body).to have_content('Class not determined')
     end
@@ -110,7 +122,8 @@ RSpec.describe 'Viewing an application unassigned, open application' do
 
     it 'does show the offence class' do
       row = first(:xpath,
-                  "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']//tr[contains(td[1], 'Robbery')]")
+                  "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
+                  //tr[contains(td[1], 'Robbery')]")
 
       expect(row).to have_content('Class C')
     end
@@ -119,7 +132,6 @@ RSpec.describe 'Viewing an application unassigned, open application' do
       expect(page).to have_content('Overall offence class Class C')
     end
   end
-  # rubocop:enable Layout/LineLength
 
   context 'with optional fields not provided' do
     let(:application_data) do


### PR DESCRIPTION
## Description of change
When ioj not needed flag is set (with no ioj reason) render a summary list under the IoJ section of application details.
Remove use of badges
When Ioj reason set, render as usual in govuk table

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-390
## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="855" alt="image" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/b4b88018-2395-4d48-ad1d-a2c5ebd08b2e">

### After changes:
<img width="818" alt="image" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/813ea5f4-7625-4d19-bd2d-7ca871a8d3b8">

## How to manually test the feature
