### PR TITLE
Link 'Choose a reason' error message to radio button

### DIFF
--- a/app/views/returns/new.html.erb
+++ b/app/views/returns/new.html.erb
@@ -13,8 +13,8 @@
     <%= form_with model: @return_details, url: crime_application_return_path(@crime_application.id), scope: :return_details, method: :post do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_radio_buttons_fieldset(:reason, legend: { text: t(:select_return_reason, scope: 'labels') }) do %>
-        <% ReturnDetails::RETURN_REASONS.each do |reason| %>
-          <%= f.govuk_radio_button :reason, reason, label: { text: t(reason, scope: 'values.return_reason') } %>
+        <% ReturnDetails::RETURN_REASONS.each_with_index do |reason, index| %>
+          <%= f.govuk_radio_button :reason, reason, label: { text: t(reason, scope: 'values.return_reason') }, link_errors: index.zero? %>
         <% end %>
       <% end %>
 


### PR DESCRIPTION
## Description of change
On the send back to provider page, the choose a reason error link did not link to the first radio button option when clicked. This has been amended.

## Link to relevant ticket

[CRIMRE-386](https://dsdmoj.atlassian.net/browse/CRIMRE-386)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

<img width="917" alt="Screenshot 2023-07-03 at 09 10 29" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/a6838de0-6dc3-4729-a48f-4be96cca8cf6">

### After changes:
<img width="917" alt="Screenshot 2023-07-03 at 09 10 39" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/88f177b5-7f39-4fb3-b59b-f484225f012f">


## How to manually test the feature


[CRIMRE-386]: https://dsdmoj.atlassian.net/browse/CRIMRE-386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ