### PR TITLE
Workload report limited to 9 days and younger

### DIFF
--- a/app/models/reporting/workload_report.rb
+++ b/app/models/reporting/workload_report.rb
@@ -2,8 +2,12 @@ module Reporting
   class WorkloadReport
     include Reportable
 
-    def initialize(number_of_days: 4, day_zero: Time.current, last_row_limit_in_days: 10)
-      @number_of_days = number_of_days
+    # Builds a Workload Report table with 'n' number of rows. The first row corresponds
+    # to applications that were received zero business days ago. The second row
+    # applications received one business day ago, and so on, until the last row, which
+    # includes a count up to the specified 'last_row_limit_in_days'.
+    def initialize(number_of_rows: 4, day_zero: Time.current, last_row_limit_in_days: 9)
+      @number_of_rows = number_of_rows
       @day_zero = day_zero.in_time_zone('London').to_date
       @last_row_limit_in_days = last_row_limit_in_days
     end
@@ -20,7 +24,7 @@ module Reporting
 
     private
 
-    attr_reader :number_of_days, :day_zero, :last_row_limit_in_days
+    attr_reader :number_of_rows, :day_zero, :last_row_limit_in_days
 
     def open_applications_by_age
       reports.map { |report| Cell.new(report.total_open, numeric: true) }
@@ -37,23 +41,23 @@ module Reporting
     # 0 days
     # 1 day
     # 2 days
-    # between 3(#number_of_days) and (#last_row_limit_in_days)
+    # between 3(#number_of_rows) and (#last_row_limit_in_days)
     #
     #
     def days_passed
-      # All bar last header
-      row_headers = Array.new(number_of_days - 1) do |day|
+      # All bar last row header
+      row_headers = Array.new(number_of_rows - 1) do |day|
         I18n.t('values.days_passed', count: day)
       end
 
-      # Add the last header.
-      row_headers << I18n.t('values.days_passed.last', count: number_of_days - 1)
+      # Add the last row header.
+      row_headers << last_row_header_text
 
       row_headers.map { |text| Cell.new(text, header: true, numeric: false) }
     end
 
     def business_days
-      @business_days ||= Array.new(number_of_days) do |age_in_business_days|
+      @business_days ||= Array.new(number_of_rows) do |age_in_business_days|
         BusinessDay.new(
           age_in_business_days:,
           day_zero:
@@ -74,7 +78,8 @@ module Reporting
     end
 
     # The date of the youngest business day not included in the last
-    # row counts.
+    # row counts -- all applications in the last row must have a business
+    # date younger than this date.
     def last_row_cut_off_date
       @last_row_cut_off_date ||= BusinessDay.new(
         age_in_business_days: last_row_limit_in_days + 1,
@@ -82,10 +87,18 @@ module Reporting
       ).date
     end
 
+    def last_row_header_text
+      I18n.t(
+        'values.days_passed.last',
+        count: number_of_rows - 1,
+        limit: last_row_limit_in_days
+      )
+    end
+
     #
     # The last row of the report differs from the preceding rows in that it
     # includes the counts for the previous business days up to and including the
-    # #number_of_days_limit business day period.
+    # #last_row_limit_in_days business day period.
     #
     def last_day_or_more_report
       scope = Reporting::ReceivedOnReport.where(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,7 +195,7 @@ en:
     days_passed:
       one: 1 day
       other: "%{count} days"
-      last: "Between %{count} and 9 days"
+      last: "Between %{count} and %{limit} days"
     review_status:
       submitted: Open
       open: Open

--- a/spec/models/reporting/workload_report_spec.rb
+++ b/spec/models/reporting/workload_report_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Reporting::WorkloadReport do
       ['2023-01-03', 8, 8],
       ['2022-12-30', 5, 1],
       ['2022-12-29', 4, 3],
-      ['2022-12-17', 50, 49],
-      ['2022-12-16', 1000, 999],
-      ['2022-12-15', 10_000, 1]
+      ['2022-12-18', 50, 49],
+      ['2022-12-17', 1000, 999],
+      ['2022-12-16', 10_000, 1]
     ].map do |business_day, total_received, total_closed|
       { business_day:, total_received:, total_closed: }
     end
@@ -69,7 +69,7 @@ RSpec.describe Reporting::WorkloadReport do
   end
 
   describe 'number of rows can be configured using :number_of_days' do
-    subject(:report) { described_class.new(number_of_days: 7) }
+    subject(:report) { described_class.new(number_of_rows: 7) }
 
     it 'returns the counts for the four working days up to and including day_zero' do
       expect(report.table.rows.size).to be 7


### PR DESCRIPTION
## Description of change
Reduce workload report last row limit from 10 to 9 business days.

## Link to relevant ticket
[CRIMRE-392](https://dsdmoj.atlassian.net/browse/CRIMRE-392)

## Notes for reviewer

This PR fixes a bug where the label for the last row was different to the limit set on the report. This change reduces the limit to 9 Business Days and also removes the hard coded value in the label text, to hopefully prevent such a mismatch happening again.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
