### PR TITLE
Fix conditional to stop rendering of empty conflict badge. Add tests

### DIFF
--- a/app/views/crime_applications/_codefendants.html.erb
+++ b/app/views/crime_applications/_codefendants.html.erb
@@ -13,7 +13,7 @@
           <%= codefendant.first_name %>
           <%= codefendant.last_name %>
         </dd>
-        <% if codefendant.conflict_of_interest %>
+        <% if codefendant.conflict_of_interest == 'yes' %>
           <dd class="govuk-summary-list__value govuk-!-text-align-right">
             <span class="moj-badge moj-badge--red">
               <%= t("crime_applications.values.conflict_of_interest.#{codefendant.conflict_of_interest}") %>

--- a/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -133,6 +133,38 @@ RSpec.describe 'Viewing an application unassigned, open application' do
     end
   end
 
+  context 'with correct codefendant information' do
+    context 'when there is no codefendant' do
+      let(:application_data) do
+        super().deep_merge('case_details' => { 'codefendants' => [] })
+      end
+
+      it 'says there is no codefendant' do
+        expect(page).to have_content('Co-defendants No')
+      end
+    end
+
+    context 'when there is a codefendant' do
+      context 'with a conflict' do
+        it 'shows the conflict badge' do
+          expect(page).to have_content('Co-defendant 1 Zoe Blogs Conflict')
+        end
+      end
+
+      context 'with no conflict' do
+        let(:application_data) do
+          super().deep_merge('case_details' => { 'codefendants' => [{ 'first_name' => 'Billy',
+                                                                  'last_name' => 'Bates',
+                                                                  'conflict_of_interest' => 'no', }] })
+        end
+
+        it 'has no badge' do
+          expect(page).not_to have_content('Conflict')
+        end
+      end
+    end
+  end
+
   context 'with optional fields not provided' do
     let(:application_data) do
       super().deep_merge('client_details' => { 'applicant' => { 'home_address' => nil, 'telephone_number' => nil } })


### PR DESCRIPTION
## Description of change
Co-defendant conflict conditional was not checking conflict value, just presence, so rendering of empty conflict badge for no-conflict co-defendants.

Added tests for codefendant options, to guard against this error.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-391

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
![image](https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/9a111ba2-f1fa-4a22-9c16-c51a7d45774d)

### After changes:
![image](https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/87399966-64c1-4059-9fe3-0e89b70dd20c)

## How to manually test the feature
