### PR TITLE
CRIMAP-427 Bump schemas gem (appeal_lodged_date)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ministryofjustice/laa-crime-apply-reviewers

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.5.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.6.0'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 86ed15ee153a473c77e9683e3f0e51895d9e935f
-  tag: v0.5.0
+  revision: bf2bbf156ff4d89c815bea9dba1b3a1f0cbe96c0
+  tag: v0.6.0
   specs:
-    laa-criminal-legal-aid-schemas (0.5.0)
+    laa-criminal-legal-aid-schemas (0.6.0)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 


### PR DESCRIPTION
## Description of change
Bump the schemas gem, which contains the refactor of the appeal attributes, incorporating the new appeal_lodged_date.

NOTE: even if Review wasn't using these appeal attributes before, once Apply start submitting new applications without the old `appeal_with_changes_maat_id` attribute, if Review remains in an old version of the schemas gem, the structs will not be able to map these new applications, as that attribute was marked as "mandatory presence" and no longer is returned by the datastore.

This is the same issue we had recently with the `passportable` attribute.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-427

## Notes for reviewer
Review is not showing to the case worker these appeal attributes, I think there is a separate ticket to add those to the view.

## How to manually test the feature
Everything should keep working with no additional changes other than this gem bump.