### PR TITLE
Redirect user managers to manage users' admin on sign in

### DIFF
--- a/app/controllers/admin/manage_users_controller.rb
+++ b/app/controllers/admin/manage_users_controller.rb
@@ -1,13 +1,14 @@
 module Admin
   class ManageUsersController < ApplicationController
+    before_action :authenticate_user!
+    before_action :require_user_manager!
+
     layout 'manage_users'
 
     # Scope for I18n locale, used by _text helpers.
     def text_namespace
       :manage_users
     end
-
-    before_action :require_user_manager!
 
     private
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,25 +11,17 @@ class ApplicationController < ActionController::Base
     current_user&.id
   end
 
+  # Redirect user managers to manage users' admin on sign in
+  def after_sign_in_path_for(user)
+    return admin_manage_users_root_path if user.can_manage_others?
+
+    super
+  end
+
   def assignments_count
     @assignments_count ||= CurrentAssignment.where(
       user_id: current_user_id
     ).count
-  end
-
-  def set_search(filter: ApplicationSearchFilter.new, sorting: {})
-    sorting = Sorting.new(
-      permitted_params[:sorting] || sorting.to_h
-    )
-
-    pagination = Pagination.new(
-      current_page: permitted_params[:page],
-      limit_value: permitted_params[:per_page]
-    )
-
-    @search = ApplicationSearch.new(
-      filter:, sorting:, pagination:
-    )
   end
 
   # Sets the full flash message based on the message key.

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -1,14 +1,32 @@
 class ServiceController < ApplicationController
+  before_action :authenticate_user!
   before_action :require_service_user!
 
   private
 
+  #
   # Users that can manage others are only allowed to access the Service on staging.
   # This is configured by the allow_user_managers_service_access feature flag.
+  #
   def require_service_user!
     return if current_user.service_user?
     return if FeatureFlags.allow_user_managers_service_access.enabled?
 
     redirect_to admin_manage_users_root_path
+  end
+
+  def set_search(filter: ApplicationSearchFilter.new, sorting: {})
+    sorting = Sorting.new(
+      permitted_params[:sorting] || sorting.to_h
+    )
+
+    pagination = Pagination.new(
+      current_page: permitted_params[:page],
+      limit_value: permitted_params[:per_page]
+    )
+
+    @search = ApplicationSearch.new(
+      filter:, sorting:, pagination:
+    )
   end
 end


### PR DESCRIPTION
## Description of change
Redirect user managers to manage users' admin on sign in
Move service specific methods from Application to Service controller

## Link to relevant ticket
[CRIMRE-374](https://dsdmoj.atlassian.net/browse/CRIMRE-374)

## Notes for reviewer
This is part of a series of changes to simplify error handling in the application. 

User managers will be shown a 404 for all service routes rather than redirecting them to admin as currently. This is being done to prevent information leakage to user managers via the redirect urls. This PR supports that change by explicitly redirecting user managers to admin on sign in rather than relying on the #require_service_user! method which will soon 404 with user managers.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-374]: https://dsdmoj.atlassian.net/browse/CRIMRE-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ