### PR TITLE
CRIMRE-389 Surface appeal lodged date, change details and maat id in appeal cases

### DIFF
--- a/app/views/crime_applications/_case_details.html.erb
+++ b/app/views/crime_applications/_case_details.html.erb
@@ -11,6 +11,34 @@
       <%= t(case_details.case_type, scope: 'crime_applications.values') %>
     </dd>
   </div>
+  <% if case_details.case_type.include? 'appeal' %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= t(:date_appeal_lodged, scope: 'crime_applications.labels') %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= l case_details.appeal_lodged_date, format: :compact %>
+      </dd>
+    </div>
+    <% if case_details.case_type == 'appeal_to_crown_court_with_changes' %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= t(:financial_change_details, scope: 'crime_applications.labels') %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= case_details.appeal_with_changes_details %>
+        </dd>
+      </div>
+    <% end %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= t(:previous_maat_id, scope: 'crime_applications.labels') %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= case_details.appeal_maat_id.presence || t(:not_provided, scope: 'crime_applications.values') %>
+      </dd>
+    </div>
+  <% end%>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
       <%= t(:hearing_court_name, scope: 'crime_applications.labels') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,6 +110,9 @@ en:
     last_name: Last name
     other_names: Other names
     case_type: Case type
+    date_appeal_lodged: Date the appeal was lodged
+    financial_change_details: Details of changes in financial circumstances
+    previous_maat_id: Previous MAAT ID
     national_insurance_number: National Insurance number
     date_of_birth: Date of birth
     application_type: Application type

--- a/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -7,18 +7,26 @@ RSpec.describe 'Viewing an application unassigned, open application' do
     visit crime_application_path(application_id)
   end
 
+  it 'includes the page title' do
+    expect(page).to have_content I18n.t('crime_applications.show.page_title')
+  end
+
   it 'shows the open status badge' do
     badge = page.all('.govuk-tag').last.text
 
     expect(badge).to match('Open')
   end
 
-  it 'includes the page title' do
-    expect(page).to have_content I18n.t('crime_applications.show.page_title')
-  end
-
   it 'includes the copy reference link' do
     expect(page).to have_content('Copy reference number')
+  end
+
+  it 'shows that the application is unassigned' do
+    expect(page).to have_content('Assigned to: no one')
+  end
+
+  it 'includes button to assign' do
+    expect(page).to have_content('Assign to your list')
   end
 
   it 'includes the date received' do
@@ -41,95 +49,118 @@ RSpec.describe 'Viewing an application unassigned, open application' do
     expect(page).to have_content('AJ 12 34 56 C')
   end
 
-  it 'shows that the application is unassigned' do
-    expect(page).to have_content('Assigned to: no one')
-  end
+  context 'with case details' do
+    context 'when case type is not an appeal type' do
+      let(:application_data) do
+        super().deep_merge('case_details' => { 'case_type' => 'either_way' })
+      end
 
-  it 'includes button to assign' do
-    expect(page).to have_content('Assign to your list')
-  end
+      it 'does not show appeal lodged date section' do
+        expect(page).not_to have_content('Appeal lodged')
+      end
 
-  it 'does not show the CTAs' do
-    expect(page).not_to have_content('Mark as completed')
-  end
+      it 'does not show change details section' do
+        expect(page).not_to have_content('Change of financial circumstances details')
+      end
 
-  context 'with interest of justice reason only' do
-    it 'shows a table with ioj reason' do
-      ioj_table = find(:xpath,
-                       "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
-                       //tr[contains(td[1], 'Loss of liberty')]")
+      it 'does not show previous maat id section' do
+        expect(page).not_to have_content('Previous MAAT ID')
+      end
+    end
 
-      expect(ioj_table).to have_content('More details about loss of liberty.')
+    context 'when case type is an appeal' do
+      context 'when previous MAAT ID is not provided' do
+        it 'shows appeal lodged date' do
+          expect(page).to have_content('Date the appeal was lodged 25/10/2021')
+          expect(page).to have_content('Previous MAAT ID Not provided')
+        end
+      end
+
+      context 'when previous MAAT ID is provided' do
+        let(:application_data) do
+          super().deep_merge('case_details' => { 'appeal_maat_id' => '123456' })
+        end
+
+        it 'shows previous maat id' do
+          expect(page).to have_content('Previous MAAT ID 123456')
+        end
+      end
+    end
+
+    context 'when case type is an appeal with changes to financial circumstances' do
+      let(:application_data) do
+        super().deep_merge('case_details' => { 'case_type' => 'appeal_to_crown_court_with_changes',
+                                               'appeal_with_changes_details' => 'Some details' })
+      end
+
+      context 'when previous MAAT ID is not provided' do
+        it 'shows appeal lodged date' do
+          expect(page).to have_content('Date the appeal was lodged 25/10/2021')
+        end
+
+        it 'shows changes to details' do
+          expect(page).to have_content('Details of changes in financial circumstances Some details')
+        end
+
+        it 'shows that previous maat id was not provided' do
+          expect(page).to have_content('Previous MAAT ID Not provided')
+        end
+      end
+
+      context 'when previous MAAT ID is provided' do
+        let(:application_data) do
+          super().deep_merge('case_details' => { 'appeal_maat_id' => '123456' })
+        end
+
+        it 'shows changes to details' do
+          expect(page).to have_content('Details of changes in financial circumstances Some details')
+        end
+
+        it 'shows previous maat id' do
+          expect(page).to have_content('Previous MAAT ID 123456')
+        end
+      end
     end
   end
 
-  context 'with ioj passport and no ioj reason' do
-    let(:application_data) do
-      super().deep_merge(
-        'ioj_passport' => ['on_age_under18'],
-        'interests_of_justice' => nil
-      )
+  context 'with offence class' do
+    context 'when at least one of the offences is manually input' do
+      it 'does shows the class not determined badge' do
+        table_body = find(:xpath,
+                          "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
+                          //tr[contains(td[1], 'Non-listed offence, manually entered')]")
+
+        expect(table_body).to have_content('Class not determined')
+      end
+
+      it 'displays undetermined overall offence class badge' do
+        expect(page).to have_content('Overall offence class Undetermined')
+      end
     end
 
-    it 'shows a summary list with passport reason' do
-      summary_list = find(:xpath,
-                          "//dl[@class='govuk-summary-list govuk-!-margin-bottom-9']
-                          //div[contains(dt[1], 'Justification')]")
+    context 'with offence class provided' do
+      let(:application_data) do
+        super().deep_merge('case_details' => { 'offence_class' => 'C',
+                                                'offences' => [{ 'name' => 'Robbery',
+                                                                'offence_class' => 'C',
+                                                                'passportable' => true,
+                                                                'dates' => [{
+                                                                  'date_from' => '2020-12-12',
+                                                                        'date_to' => nil
+                                                                }] }] })
+      end
 
-      expect(summary_list).to have_content('Not needed because the client is under 18 years old')
-    end
-  end
+      it 'does show the offence class' do
+        row = first(:xpath,
+                    "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
+                    //tr[contains(td[1], 'Robbery')]")
 
-  context 'when a passported application is a split case and resubmitted with ioj passport' do
-    let(:application_data) do
-      super().deep_merge('ioj_passport' => ['on_age_under18'])
-    end
+        expect(row).to have_content('Class C')
+      end
 
-    it 'shows a table with ioj reason' do
-      ioj_table = find(:xpath,
-                       "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
-                       //tr[contains(td[1], 'Loss of liberty')]")
-
-      expect(ioj_table).to have_content('More details about loss of liberty.')
-    end
-  end
-
-  context 'with offence class not provided' do
-    it 'does shows the class not determined badge' do
-      table_body = find(:xpath,
-                        "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
-                        //tr[contains(td[1], 'Non-listed offence, manually entered')]")
-
-      expect(table_body).to have_content('Class not determined')
-    end
-
-    it 'displays undetermined overall offence class' do
-      expect(page).to have_content('Overall offence class Undetermined')
-    end
-  end
-
-  context 'with offence class provided' do
-    let(:application_data) do
-      super().deep_merge('case_details' => { 'offence_class' => 'C',
-                                              'offences' => [{ 'name' => 'Robbery',
-                                                              'offence_class' => 'C',
-                                                              'passportable' => true,
-                                                              'dates' => [{
-                                                                'date_from' => '2020-12-12',
-                                                                      'date_to' => nil
-                                                              }] }] })
-    end
-
-    it 'does show the offence class' do
-      row = first(:xpath,
-                  "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
-                  //tr[contains(td[1], 'Robbery')]")
-
-      expect(row).to have_content('Class C')
-    end
-
-    it 'displays calculated overall offence class' do
-      expect(page).to have_content('Overall offence class Class C')
+      it 'displays calculated overall offence class badgee' do
+        expect(page).to have_content('Overall offence class Class C')
+      end
     end
   end
 
@@ -163,6 +194,53 @@ RSpec.describe 'Viewing an application unassigned, open application' do
         end
       end
     end
+  end
+
+  context 'with ioj reasons' do
+    context 'with ioj reason only' do
+      it 'shows a table with ioj reason' do
+        ioj_table = find(:xpath,
+                         "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
+                        //tr[contains(td[1], 'Loss of liberty')]")
+
+        expect(ioj_table).to have_content('More details about loss of liberty.')
+      end
+    end
+
+    context 'with ioj passport and no ioj reason' do
+      let(:application_data) do
+        super().deep_merge(
+          'ioj_passport' => ['on_age_under18'],
+          'interests_of_justice' => nil
+        )
+      end
+
+      it 'shows a summary list with passport reason' do
+        summary_list = find(:xpath,
+                            "//dl[@class='govuk-summary-list govuk-!-margin-bottom-9']
+                            //div[contains(dt[1], 'Justification')]")
+
+        expect(summary_list).to have_content('Not needed because the client is under 18 years old')
+      end
+    end
+
+    context 'when a passported application is a split case and resubmitted with ioj passport' do
+      let(:application_data) do
+        super().deep_merge('ioj_passport' => ['on_age_under18'])
+      end
+
+      it 'shows a table with ioj reason' do
+        ioj_table = find(:xpath,
+                         "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
+                        //tr[contains(td[1], 'Loss of liberty')]")
+
+        expect(ioj_table).to have_content('More details about loss of liberty.')
+      end
+    end
+  end
+
+  it 'does not show the CTAs' do
+    expect(page).not_to have_content('Mark as completed')
   end
 
   context 'with optional fields not provided' do


### PR DESCRIPTION
## Description of change

In appeal cases surface appeal attributes:
- lodged date
- financial change details 
- previous maat id

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-389

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="868" alt="image" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/f578fe04-ec98-4cfd-b8b6-da5a8b4d430a">

### After changes:
<img width="797" alt="image" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/e5944b0c-2c3e-4d9d-91d8-e9981898a4f6">

## How to manually test the feature
Put an appeal / appeal with changes case type through Apply, view Case Details section on Review