### PR TITLE
Render forbidden for Omniauth/Devise errors

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -6,14 +6,12 @@ module Users
       if @user
         sign_in_and_redirect @user, event: :authentication
       else
-        redirect_to forbidden_path
+        throw(:warden, recall: 'Errors#forbidden', message: :forbidden)
       end
     end
 
-    private
-
-    def after_omniauth_failure_path_for(_scope)
-      forbidden_path
+    def failure
+      throw(:warden, recall: 'Errors#forbidden', message: :forbidden)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
     }
   )
 
+  get "users/auth/failure", to: "errors#forbidden"
+
   devise_scope :user do
     unauthenticated :user do
       root 'users/sessions#new', as: :unauthenticated_root

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -42,9 +42,10 @@ RSpec.describe 'Authentication Session Initialisation' do
     end
 
     describe 'when the user does not exist in the review database' do
-      it 'redirects the user to the "Not authorised" page' do
+      it 'responds with "Access to this service is restricted' do
         auth_callback
-        expect(response).to redirect_to('/forbidden')
+
+        expect(response.body).to include 'Access to this service is restricted'
       end
     end
 
@@ -145,10 +146,10 @@ RSpec.describe 'Authentication Session Initialisation' do
       OmniAuth.config.mock_auth[:azure_ad] = :access_denied
     end
 
-    it 'redirects the user to the "Not authorised" page' do
+    it 'redirects to the omniauth failure endpoint' do
       auth_callback
 
-      expect(response).to redirect_to('/forbidden')
+      expect(response.body).to include 'Access to this service is restricted'
     end
   end
 end

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe 'Authorisation' do
       preview_view_components
       root
       unauthenticated_root
+      users_auth_failure
     ]
   end
 
@@ -65,15 +66,27 @@ RSpec.describe 'Authorisation' do
     ]
   end
 
+  def expected_status(route_name)
+    case route_name
+    when 'users_auth_failure', 'forbidden'
+      :forbidden
+    when 'unhandled'
+      :internal_server_error
+    when 'not_found', 'application_not_found'
+      :not_found
+    else
+      :ok
+    end
+  end
+
   describe 'an unauthenticated user' do
     it 'can access all unauthenticated routes' do
       configured_routes.each do |route|
         next unless unauthenticated_routes.include?(route.name)
 
         visit_configured_route(route)
-        status = route.name == 'forbidden' ? :forbidden : :ok
 
-        expect(response).to have_http_status(status)
+        expect(response).to have_http_status(expected_status(route.name))
       end
     end
 


### PR DESCRIPTION
## Description of change
Render rather than redirect for Omniauth/Devise errors.

## Link to relevant ticket
[CRIMRE-374](https://dsdmoj.atlassian.net/browse/CRIMRE-374)

## Notes for reviewer
This is part of a series of changes to simplify error handling in the application.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-374]: https://dsdmoj.atlassian.net/browse/CRIMRE-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ