### PR TITLE
Remove spaces from nino

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -11,10 +11,7 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
   def formatted_applicant_nino
     return if applicant.nino.nil?
 
-    # Remove all spaces
-    formatted_nino = applicant.nino.gsub(/\s+/, '').upcase
-    [2, 5, 8, 11].each { |i| formatted_nino.insert i, ' ' } if formatted_nino.length == 9
-    formatted_nino
+    applicant.nino
   end
 
   def formatted_applicant_telephone_number

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CrimeApplication do
   describe '#formatted_applicant_nino' do
     subject(:formatted_applicant_nino) { application.formatted_applicant_nino }
 
-    it { is_expected.to eq 'AJ 12 34 56 C' }
+    it { is_expected.to eq 'AJ123456C' }
   end
 
   describe '#formatted_applicant_telephone_number' do

--- a/spec/system/reviewing/send_back_to_provider_spec.rb
+++ b/spec/system/reviewing/send_back_to_provider_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe 'Send an application back to the provider' do
       end
 
       it 'includes the applicant details' do
-        expect(page).to have_content('AJ 12 34 56 C')
+        expect(page).to have_content('AJ123456C')
       end
 
       it 'does not show the CTAs' do

--- a/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Viewing an application unassigned, open application' do
   end
 
   it 'includes the applicant details' do
-    expect(page).to have_content('AJ 12 34 56 C')
+    expect(page).to have_content('AJ123456C')
   end
 
   context 'with case details' do


### PR DESCRIPTION
## Description of change
Removes the NINO spaces from review so that the are easier to copy for CWs etc.

## Link to relevant ticket
[CRIMRE-388](https://dsdmoj.atlassian.net/browse/CRIMRE-388)

## Notes for reviewer
I have left the formatting methof in as it:
1. removes some of the dot chain that the crime application has to go through to get to the nino
2. has some logic in it to check the nil-ness of the nino for the view.

Happy to discuss removing this if you think its not needed 👍 

## Screenshots of changes (if applicable)

### Before changes:
<img width="928" alt="Screenshot 2023-07-06 at 15 30 49" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/13377553/0397e98c-05ac-4915-b850-be07733a353b">

### After changes:
<img width="901" alt="Screenshot 2023-07-06 at 15 30 12" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/13377553/17637c63-7791-49eb-a344-961ff406a586">

## How to manually test the feature
Look at an applications Client details section, make sure the NINO has no spaces in it.