### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,16 +4,16 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby File.read('.ruby-version').chomp
 gem 'pg', '~> 1.4'
 gem 'puma'
-gem 'rails', '~> 7.0.3'
+gem 'rails'
 
 gem 'business'
 gem 'faraday'
-gem 'govuk-components', '~> 4.0.0'
-gem 'govuk_design_system_formbuilder', '~> 4.0.0'
+gem 'govuk-components'
+gem 'govuk_design_system_formbuilder'
 
 gem 'govuk_notify_rails'
 
-gem 'kaminari', '~> 1.2'
+gem 'kaminari'
 
 gem 'lograge'
 gem 'logstash-event'
@@ -22,7 +22,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.6.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.6.1'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
-  revision: 5827572079190de784d36761d39cbcbc6f8a95ea
+  revision: 867f6dbcc8c646b08c19994cfbf19bf672acbec8
   specs:
-    laa-criminal-applications-datastore-api-client (0.0.1)
+    laa-criminal-applications-datastore-api-client (0.1.0)
       faraday (~> 2.6)
-      moj-simple-jwt-auth (= 0.0.1)
+      moj-simple-jwt-auth (~> 0.1.0)
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: bf2bbf156ff4d89c815bea9dba1b3a1f0cbe96c0
-  tag: v0.6.0
+  revision: dc0dce7fddf899a920fb419f67a936ead184b34f
+  tag: v0.6.1
   specs:
-    laa-criminal-legal-aid-schemas (0.6.0)
+    laa-criminal-legal-aid-schemas (0.6.1)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 
@@ -93,21 +93,21 @@ GEM
     ast (2.4.2)
     attr_required (1.0.1)
     aws-eventstream (1.2.0)
-    aws-partitions (1.739.0)
-    aws-sdk-core (3.171.0)
+    aws-partitions (1.784.0)
+    aws-sdk-core (3.177.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-sns (1.60.0)
-      aws-sdk-core (~> 3, >= 3.165.0)
+    aws-sdk-sns (1.64.0)
+      aws-sdk-core (~> 3, >= 3.177.0)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.5.2)
+    aws-sigv4 (1.6.0)
       aws-eventstream (~> 1, >= 1.0.2)
-    axe-core-api (4.6.0)
+    axe-core-api (4.7.0)
       dumb_delegator
       virtus
-    axe-core-rspec (4.6.0)
+    axe-core-rspec (4.7.0)
       axe-core-api
       dumb_delegator
       virtus
@@ -115,8 +115,8 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    bcrypt (3.1.18)
-    better_html (2.0.1)
+    bcrypt (3.1.19)
+    better_html (2.0.2)
       actionview (>= 6.0)
       activesupport (>= 6.0)
       ast (~> 2.0)
@@ -127,10 +127,10 @@ GEM
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
-    brakeman (5.4.1)
+    brakeman (6.0.0)
     builder (3.2.4)
     business (2.3.0)
-    capybara (3.38.0)
+    capybara (3.39.2)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -149,12 +149,12 @@ GEM
     dartsass-rails (0.4.1)
       railties (>= 6.0.0)
     date (3.3.3)
-    debug (1.7.2)
+    debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (4.9.1)
+    devise (4.9.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -178,12 +178,12 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0, < 2)
       zeitwerk (~> 2.6)
-    dry-schema (1.13.0)
+    dry-schema (1.13.2)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 1.0, >= 1.0.1)
       dry-core (~> 1.0, < 2)
       dry-initializer (~> 3.0)
-      dry-logic (>= 1.5, < 2)
+      dry-logic (>= 1.4, < 2)
       dry-types (>= 1.7, < 2)
       zeitwerk (~> 2.6)
     dry-struct (1.6.0)
@@ -206,7 +206,7 @@ GEM
       rubocop
       smart_properties
     erubi (1.12.0)
-    faraday (2.7.4)
+    faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-follow_redirects (0.3.0)
@@ -237,7 +237,7 @@ GEM
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.6.0)
-    irb (1.6.3)
+    irb (1.7.1)
       reline (>= 0.3.0)
     jmespath (1.6.2)
     json (2.6.3)
@@ -249,7 +249,7 @@ GEM
       faraday-follow_redirects
     json-schema (4.0.0)
       addressable (>= 2.8)
-    jwt (2.7.0)
+    jwt (2.7.1)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -262,6 +262,7 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    language_server-protocol (3.17.0.3)
     lograge (0.12.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -282,10 +283,10 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
     minitest (5.18.1)
-    moj-simple-jwt-auth (0.0.1)
+    moj-simple-jwt-auth (0.1.0)
       json
       jwt
-    msgpack (1.7.0)
+    msgpack (1.7.1)
     net-imap (0.3.6)
       date
       net-protocol
@@ -296,7 +297,7 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.2)
+    nokogiri (1.15.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)
@@ -327,16 +328,17 @@ GEM
     orm_adapter (0.5.0)
     pagy (6.0.4)
     parallel (1.23.0)
-    parser (3.2.2.1)
+    parser (3.2.2.3)
       ast (~> 2.4.1)
-    pg (1.4.6)
+      racc
+    pg (1.5.3)
     prometheus_exporter (2.0.8)
       webrick
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (5.0.1)
-    puma (6.2.1)
+    puma (6.3.0)
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.7)
@@ -347,7 +349,7 @@ GEM
       faraday-follow_redirects
       json-jwt (>= 1.11.0)
       rack (>= 2.1.0)
-    rack-protection (3.0.5)
+    rack-protection (3.0.6)
       rack
     rack-test (2.1.0)
       rack (>= 1.3)
@@ -392,8 +394,8 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.8.0)
-    reline (0.3.3)
+    regexp_parser (2.8.1)
+    reline (0.3.5)
       io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -401,47 +403,51 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.5)
-    rspec-core (3.12.1)
+    rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.2)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-rails (6.0.1)
+    rspec-rails (6.0.3)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       railties (>= 6.1)
-      rspec-core (~> 3.11)
-      rspec-expectations (~> 3.11)
-      rspec-mocks (~> 3.11)
-      rspec-support (~> 3.11)
-    rspec-support (3.12.0)
-    rubocop (1.51.0)
+      rspec-core (~> 3.12)
+      rspec-expectations (~> 3.12)
+      rspec-mocks (~> 3.12)
+      rspec-support (~> 3.12)
+    rspec-support (3.12.1)
+    rubocop (1.54.1)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.0.0)
+      parser (>= 3.2.2.3)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
       rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.28.1)
+    rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
-    rubocop-capybara (2.17.1)
+    rubocop-capybara (2.18.0)
       rubocop (~> 1.41)
-    rubocop-performance (1.16.0)
+    rubocop-factory_bot (2.23.1)
+      rubocop (~> 1.33)
+    rubocop-performance (1.18.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rails (2.18.0)
+    rubocop-rails (2.20.2)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
-    rubocop-rspec (2.19.0)
+    rubocop-rspec (2.22.0)
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
+      rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     ruby_event_store (2.9.1)
@@ -453,14 +459,14 @@ GEM
       rack
       ruby_event_store (= 2.9.1)
     rubyzip (2.3.2)
-    selenium-webdriver (4.8.6)
+    selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-rails (5.9.0)
+    sentry-rails (5.10.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.9.0)
-    sentry-ruby (5.9.0)
+      sentry-ruby (~> 5.10.0)
+    sentry-ruby (5.10.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -552,11 +558,11 @@ DEPENDENCIES
   dry-struct
   erb_lint
   faraday
-  govuk-components (~> 4.0.0)
-  govuk_design_system_formbuilder (~> 4.0.0)
+  govuk-components
+  govuk_design_system_formbuilder
   govuk_notify_rails
   importmap-rails
-  kaminari (~> 1.2)
+  kaminari
   laa-criminal-applications-datastore-api-client!
   laa-criminal-legal-aid-schemas!
   lograge
@@ -567,7 +573,7 @@ DEPENDENCIES
   prometheus_exporter
   pry
   puma
-  rails (~> 7.0.3)
+  rails
   rails_event_store
   rspec-rails
   rubocop


### PR DESCRIPTION
## Description of change

Updates dependencies.

## Link to relevant ticket

## Notes for reviewer

Mainly minor/patch updates that seem benign.

Major update to brakeman 6.0 which include several improvements and no braking changes that should effect us.

laa-criminal-applications-datastore-api-client and moj-simple-jwt-auth were both quite out of date.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
