### PR TITLE
Convert times to dates before business day calculations

### DIFF
--- a/app/models/business_day.rb
+++ b/app/models/business_day.rb
@@ -1,7 +1,7 @@
 class BusinessDay
   def initialize(day_zero:, age_in_business_days: 0, calendar: Calendar.new)
     @age_in_business_days = age_in_business_days
-    @day_zero = day_zero
+    @day_zero = day_zero.in_time_zone('London').to_date
     @calendar = calendar
   end
 
@@ -13,23 +13,7 @@ class BusinessDay
     calendar.subtract_business_days(day_zero, age_in_business_days)
   end
 
-  #
-  # The start of the date period whithin which an event's age in business days
-  # should be counted as #age_in_business_days.
-  #
-  def period_starts_on
-    previous_business_day.tomorrow
-  end
-
-  def period_ends_before
-    date.tomorrow
-  end
-
   private
 
   attr_reader :calendar, :day_zero
-
-  def previous_business_day
-    calendar.subtract_business_days(day_zero, age_in_business_days + 1)
-  end
 end

--- a/spec/models/business_day_spec.rb
+++ b/spec/models/business_day_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe BusinessDay do
       expect(business_day.date).to eq(Date.parse('2022-12-30'))
     end
 
+    context 'when date_zero is given as a time' do
+      let(:day_zero) { '2023-07-07T23:04:35.351Z' }
+      let(:age_in_business_days) { 0 }
+
+      it 'converts the time to the corresponding date in TZ London' do
+        expect(described_class.new(day_zero: '2023-07-07T23:04:35.351Z').date).to eq(Date.parse('2023-07-10'))
+        expect(described_class.new(day_zero: '2023-07-07T22:59:35.351Z').date).to eq(Date.parse('2023-07-07'))
+      end
+    end
+
     describe '#date' do
       context 'when "age_in_business_days" is twenty' do
         let(:age_in_business_days) { 20 }
@@ -47,31 +57,6 @@ RSpec.describe BusinessDay do
           expect(business_day.date).not_to eq(day_zero)
           expect(business_day.date).to eq(Date.parse('2023-01-03'))
         end
-      end
-    end
-
-    describe '#period_starts_on' do
-      context 'when the previous day is a business day' do
-        let(:age_in_business_days) { 2 }
-
-        it 'returns the date' do
-          expect(business_day.period_starts_on).to eq(business_day.date)
-        end
-      end
-
-      context 'when the previous day is a non-business day' do
-        let(:age_in_business_days) { 1 }
-
-        it 'returns the date of the first non-business day after the prevous business day' do
-          expect(business_day.period_starts_on).not_to eq(business_day.date)
-          expect(business_day.period_starts_on).to eq(Date.parse('2022-12-31'))
-        end
-      end
-    end
-
-    describe '#period_ends_before' do
-      it 'the first date after the last day in the period' do
-        expect(business_day.period_ends_before).to eq(business_day.date.tomorrow)
       end
     end
   end


### PR DESCRIPTION
## Description of change
Convert times to dates in TZ London before Business Day calculations
Code previously used to calculate the date range for database queries has been removed.

## Link to relevant ticket
[CRIMRE-400](https://dsdmoj.atlassian.net/browse/CRIMRE-400)

## Notes for reviewer
Applications submitted after midnight but before 01:00 BST are counted as being received on the previous day in the workload report.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
