### PR TITLE
Changes the reply to address for access granted emails

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -31,6 +31,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
 
   def access_granted_email(email)
     set_template(:access_granted_email)
+    set_email_reply_to(:onboarding_reply_to_address)
 
     mail(to: email)
   end
@@ -39,6 +40,10 @@ class NotifyMailer < GovukNotifyRails::Mailer
 
   # rubocop:disable Naming/AccessorMethodName
   def set_template(name)
+    super(@template_ids.fetch(name))
+  end
+
+  def set_email_reply_to(name)
     super(@template_ids.fetch(name))
   end
   # rubocop:enable Naming/AccessorMethodName

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -14,6 +14,9 @@
 production:
   application_returned_email: 'd0d8768b-2122-40a2-ba01-b4550f36805b'
   access_granted_email: '28ddb4dc-ac53-4298-ad55-ea32bc852ffb'
+  onboarding_reply_to_address: 'ab9aa707-25c5-43ea-b079-be65e4aa5765'
+
 non-production:
   application_returned_email: 'cfee931f-6588-4814-a2e2-ad025946922f'
   access_granted_email: 'f2704460-a16c-46f0-ab6b-d868421c621a'
+  onboarding_reply_to_address: '37a1aa3d-214a-40db-a44a-57a4631536a3'

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe NotifyMailer do
   before do
     allow(Rails.configuration).to receive(:govuk_notify_templates).and_return(
       application_returned_email: 'application_returned_email_template_id',
-      access_granted_email: 'access_granted_email_template_id'
+      access_granted_email: 'access_granted_email_template_id',
+      onboarding_reply_to_address: 'onboarding_reply_to_address'
     )
   end
 
@@ -49,5 +50,6 @@ RSpec.describe NotifyMailer do
     it_behaves_like 'a Notify mailer', template_id: 'access_granted_email_template_id'
 
     it { expect(mail.to).to eq(['test@example.com']) }
+    it { expect(mail.govuk_notify_email_reply_to).to eq('onboarding_reply_to_address') }
   end
 end


### PR DESCRIPTION
## Description of change
Changes the reply to email address for access granted emails.

These have been added to notify for staging / prod - they are referenced like templates via UUID in:

`config/govuk_notify_templates.yml`

Note this only changes reply to for onboarding as the return email will use the default address - see ticket for more detail.

## Link to relevant ticket

[CRIMRE-376](https://dsdmoj.atlassian.net/browse/CRIMRE-376)

## Notes for reviewer
- please double check that the UUIDs are correct to your understanding. i.e. they match the UUID for the return to for each environment.



[CRIMRE-376]: https://dsdmoj.atlassian.net/browse/CRIMRE-376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ