### PR TITLE
CRIMAP-433 Bump schemas gem (return_details refactor)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.6.1'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.7.0'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: dc0dce7fddf899a920fb419f67a936ead184b34f
-  tag: v0.6.1
+  revision: 5dae17e1af44335493dae6932b9257e8a9ba6b08
+  tag: v0.7.0
   specs:
-    laa-criminal-legal-aid-schemas (0.6.1)
+    laa-criminal-legal-aid-schemas (0.7.0)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 


### PR DESCRIPTION
## Description of change
Bump schemas gem to accommodate the datastore return_details refactor.
## Link to relevant ticket

## Notes for reviewer
Link to  @zheileman 's Apply ticket to which this belongs https://dsdmoj.atlassian.net/browse/CRIMAP-433

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
