### PR TITLE
CRIMRE-401 handle datastore errors better

### DIFF
--- a/app/controllers/admin/manage_users_controller.rb
+++ b/app/controllers/admin/manage_users_controller.rb
@@ -15,7 +15,8 @@ module Admin
     def require_user_manager!
       return if current_user.can_manage_others?
 
-      render_not_found
+      render status: :not_found, template: 'errors/not_found', layout: 'errors'
+      false
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,11 +14,6 @@ class ApplicationController < ActionController::Base
     super
   end
 
-  def render_not_found
-    render status: :not_found, template: 'errors/not_found', layout: 'errors'
-    false
-  end
-
   # Sets the full flash message based on the message key.
   #
   # Like the AppTextHelper#named_text, it will scope locales according

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -4,6 +4,12 @@ class ServiceController < ApplicationController
 
   helper_method :assignments_count
 
+  rescue_from DatastoreApi::Errors::ApiError do |e|
+    Rails.error.report(e, handled: true, severity: :error)
+
+    render status: :internal_server_error, template: 'errors/datastore_error'
+  end
+
   rescue_from DatastoreApi::Errors::NotFoundError do
     render status: :not_found, template: 'errors/application_not_found'
   end

--- a/app/models/application_search.rb
+++ b/app/models/application_search.rb
@@ -51,8 +51,6 @@ class ApplicationSearch
   end
 
   def datastore_response
-    Rails.error.handle(DatastoreApi::Errors::BadRequest, fallback: -> { { records: [], pagination: {} } }) do
-      http_client.post('/searches', datastore_params)
-    end
+    http_client.post('/searches', datastore_params)
   end
 end

--- a/app/views/errors/datastore_error.html.erb
+++ b/app/views/errors/datastore_error.html.erb
@@ -1,0 +1,8 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+    <p class="govuk-body-l"><%=t '.body_1' %></p>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -37,3 +37,7 @@ en:
     forbidden:
       page_title: Not authorised
       heading: Access to this service is restricted
+    datastore_error:
+      page_title: Unexpected error
+      heading: Sorry, something went wrong with our service
+      body_1: We cannot connect to our database. This means you cannot view, search, or review applications.

--- a/spec/init/api_data.rb
+++ b/spec/init/api_data.rb
@@ -25,16 +25,6 @@ RSpec.configure do |config|
     ).to_return(body: LaaCrimeSchemas.fixture(1.0, name: 'application_returned').read, status: 200)
 
     #
-    # All DatastoreApi search requests are stubbed to return empty result sets by default.
-    # To return anything other than that include the shared_context "with stubbed search".
-    #
-    stub_request(:post, "#{ENV.fetch('DATASTORE_API_ROOT')}/api/v1/searches")
-      .to_return(
-        body: { pagination: {}, records: [], sort: {} }.to_json,
-        status: 201
-      )
-
-    #
     # For an application not found on the datastore
     #
     stub_request(:get, "#{ENV.fetch('DATASTORE_API_ROOT')}/api/v1/applications/123")

--- a/spec/system/assigning/get_next_application_spec.rb
+++ b/spec/system/assigning/get_next_application_spec.rb
@@ -22,26 +22,4 @@ RSpec.describe 'Assigning an application to myself' do
       expect(page).to have_content('There are no new applications to be reviewed')
     end
   end
-
-  context 'when multiple caseworkers attempt to request the same next application to review' do
-    let(:stubbed_search_results) do
-      [
-        ApplicationSearchResult.new(
-          applicant_name: 'Kit Pound',
-          resource_id: '696dd4fd-b619-4637-ab42-a5f4565bcf4a',
-          reference: 120_398_120,
-          status: 'submitted',
-          submitted_at: '2022-10-27T14:09:11.000+00:00',
-          parent_id: nil
-        )
-      ]
-    end
-
-    it 'shows an error when there is no next application' do
-      visit '/'
-      click_on 'Review next application'
-      expect(page).to have_content('Your list')
-      expect(page).to have_content('There are no new applications to be reviewed')
-    end
-  end
 end

--- a/spec/system/searching/filter_by_status_spec.rb
+++ b/spec/system/searching/filter_by_status_spec.rb
@@ -25,28 +25,6 @@ RSpec.describe 'Search applications status filter' do
       end
     end
 
-    describe 'Completed' do
-      #
-      # Completed is expected to raise an error because the completed
-      # state is not yet supported.
-      #
-      # Here we catch the error and return an empty collection.
-      #
-      let(:datastore_response) do
-        raise DatastoreApi::Errors::BadRequest
-      end
-
-      before do
-        select 'Completed', from: filter_field
-        click_button 'Search'
-      end
-
-      it 'filters by status "completed"' do
-        expect(page).to have_select(filter_field, selected: 'Completed')
-        expect(page).to have_content('There are no results that match the search criteria')
-      end
-    end
-
     describe 'Sent back to provider' do
       before do
         select 'Sent back to provider', from: filter_field


### PR DESCRIPTION
## Description of change

Caseworkers see an error message explaining that we cannot connect to the datastore. 
The page shown contains the service navigation for a signed in user.

## Link to relevant ticket
[CRIMRE-401](https://dsdmoj.atlassian.net/browse/CRIMRE-401)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="813" alt="Screenshot 2023-07-12 at 15 17 54" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/651de894-eb96-4f35-8395-7a6b59ed5fb6">

### After changes:
<img width="673" alt="Screenshot 2023-07-12 at 15 16 25" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/fa0550b0-06fe-404f-9b7f-a12aec5625ef">


## How to manually test the feature


[CRIMRE-401]: https://dsdmoj.atlassian.net/browse/CRIMRE-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ