### PR TITLE
CRIMRE-402 ensure dev_auth cannot be used outside local env

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -36,6 +36,10 @@ Devise.setup do |config|
   #
   # Uses the DevAuth strategy if local and ENV["DEV_AUTH_ENABLED"] is true
 
+  if !HostEnv.local? && FeatureFlags.dev_auth.enabled?
+    raise "The DevAuth strategy must not be used in this environment"
+  end
+
   strategy_class = FeatureFlags.dev_auth.enabled? ? OmniAuth::Strategies::DevAuth : OmniAuth::Strategies::OpenIDConnect
 
   config.omniauth(

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,12 +1,8 @@
 feature_flags:
-  developer_tools:
-    local: true
-    staging: true
-    production: false
   dev_auth:
     local: <%= ENV.fetch("DEV_AUTH_ENABLED", false) %>
     staging: false
-    production: false
+    production: false # must never be enabled in the live service
   allow_user_managers_service_access:
     local: false
     staging: true


### PR DESCRIPTION
## Description of change
Prevent the DevAuth strategy from being configured outside the local env

## Link to relevant ticket
[CRIMRE-402](https://dsdmoj.atlassian.net/browse/CRIMRE-402)

## Notes for reviewer
Adds an additional check to prevent the application being initialised with the DevAuth feature enabled in a non Local environment.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-402]: https://dsdmoj.atlassian.net/browse/CRIMRE-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ