### PR TITLE
CRIMRE-411 only show users with reviews or assignments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,7 +74,7 @@ RSpec/MultipleExpectations:
 Rails/SkipsModelValidations:
   Exclude:
     - '**/app/read_models/**/*'
-    - '**/lib/warden/**/*'
+    - 'spec'
 
 # Prefer block over method call.
 RSpec/ExpectChange:

--- a/app/models/application_search_filter.rb
+++ b/app/models/application_search_filter.rb
@@ -56,9 +56,11 @@ class ApplicationSearchFilter < ApplicationStruct
   private
 
   def assigned_to_user_options
-    User.order(:first_name, :last_name).pluck(:id).map do |id|
-      [User.name_for(id), id]
-    end
+    user_ids = (
+      CurrentAssignment.distinct.pluck(:user_id) + Review.distinct.pluck(:reviewer_id)
+    ).uniq
+
+    user_ids.map { |id| [User.name_for(id), id] }.sort
   end
 
   # Returns the value of the DatastoreApi Search "application_id_in" constraint

--- a/spec/models/application_search_filter_spec.rb
+++ b/spec/models/application_search_filter_spec.rb
@@ -8,12 +8,14 @@ RSpec.describe ApplicationSearchFilter do
   include_context 'with stubbed assignments and reviews'
 
   describe '#assigned_status_options' do
-    subject(:assigned_status_options) { new.assigned_status_options }
+    subject(:assigned_status_options) { new.assigned_status_options.map(&:first) }
 
-    it 'list of unassigned, all_assigned, then all assignees sorted by name' do
-      expect(assigned_status_options.map(&:first)).to eq(
-        ['Unassigned', 'All assigned', 'David Brown', 'John Deere']
-      )
+    before do
+      User.create!(email: 'Not.Started@example.com', first_name: 'Not', last_name: 'Started')
+    end
+
+    it 'list of unassigned, all_assigned, then all caseworkers with assignments or reviews sorted by name' do
+      expect(assigned_status_options).to eq(['Unassigned', 'All assigned', 'David Brown', 'John Deere'])
     end
   end
 

--- a/spec/shared_contexts/with_stubbed_assignments_and_reviews.rb
+++ b/spec/shared_contexts/with_stubbed_assignments_and_reviews.rb
@@ -18,34 +18,18 @@ RSpec.shared_context 'with stubbed assignments and reviews', shared_context: :me
   end
 
   let(:johns_applications) { [SecureRandom.uuid, SecureRandom.uuid] }
-  let(:davids_applications) { [SecureRandom.uuid, SecureRandom.uuid] }
+  let(:davids_applications) { [SecureRandom.uuid] }
 
   let(:current_assignment_ids) do
-    [
-      johns_applications.first, johns_applications.last,
-      davids_applications.first, davids_applications.last,
-    ]
+    [johns_applications.first, davids_applications.first]
   end
 
   before do
-    allow(CurrentAssignment).to receive(:assigned_to_ids).with(user_id: john.id) {
-      [johns_applications.first]
-    }
+    # rubocop:disable Rails/SkipsModelValidations
+    CurrentAssignment.insert({ user_id: john.id, assignment_id: johns_applications.first })
+    CurrentAssignment.insert({ user_id: david.id, assignment_id: davids_applications.first })
 
-    allow(CurrentAssignment).to receive(:assigned_to_ids).with(user_id: david.id) {
-      [davids_applications.first]
-    }
-
-    allow(Review).to receive(:reviewed_by_ids).with(user_id: john.id) {
-      [johns_applications.last]
-    }
-
-    allow(Review).to receive(:reviewed_by_ids).with(user_id: david.id) {
-      [davids_applications.last]
-    }
-
-    allow(CurrentAssignment).to receive(:pluck).with(:assignment_id) {
-      current_assignment_ids
-    }
+    Review.insert({ reviewer_id: john.id, application_id: johns_applications.last })
+    # rubocop:enable Rails/SkipsModelValidations
   end
 end


### PR DESCRIPTION
## Description of change
Only list those users that have reviews or active assignments in the search filter. Previously all users were listed.
Also fixes CRIMRE-412 as it is no longer possible to select a user that does not have reviews or current assignments.

## Link to relevant ticket
[CRIMRE-411](https://dsdmoj.atlassian.net/browse/CRIMRE-411)
[CRIMRE-412](https://dsdmoj.atlassian.net/browse/CRIMRE-412)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-411]: https://dsdmoj.atlassian.net/browse/CRIMRE-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMRE-412]: https://dsdmoj.atlassian.net/browse/CRIMRE-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ