### PR TITLE
Set cache security headers

### DIFF
--- a/app/controllers/admin/manage_users_controller.rb
+++ b/app/controllers/admin/manage_users_controller.rb
@@ -2,6 +2,7 @@ module Admin
   class ManageUsersController < ApplicationController
     before_action :authenticate_user!
     before_action :require_user_manager!
+    before_action :set_security_headers
 
     layout 'manage_users'
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,4 +37,9 @@ class ApplicationController < ActionController::Base
     flash[flash_key] = message
     # rubocop:enable Rails/ActionControllerFlashBeforeRender
   end
+
+  def set_security_headers
+    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    response.headers['Pragma'] = 'no-cache'
+  end
 end

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -1,6 +1,7 @@
 class ServiceController < ApplicationController
   before_action :authenticate_user!
   before_action :require_service_user!
+  before_action :set_security_headers
 
   helper_method :assignments_count
 


### PR DESCRIPTION
## Description of change
The zap report flagged that the cache-control header has not been set properly or is missing, allowing the browser and proxies to cache content. This needs to be reviewed to ensure that no sensitive content will be cached.

This PR sets the `cache-control` header as requested and also sets the pragma header. Both headers are meant to prevent the client from caching the response, and `pragma` is the HTTP/1.0 implementation which `cache-control `overrides in modern browsers. These headers are set in the user facing application controllers.

## Link to relevant ticket
[CRIMRE-403](https://dsdmoj.atlassian.net/browse/CRIMRE-403)

## Notes for reviewer
I also looked into setting `config.action_controller.perform_caching = true` to false in the rails production config. I chose not to go with this approach as it can slow down applications and it seems to deviate from general best practise... interested in thoughts on this

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
