### PR TITLE
CRIMRE-411 ignore open reviews in caseworker filter

### DIFF
--- a/app/models/application_search_filter.rb
+++ b/app/models/application_search_filter.rb
@@ -56,11 +56,14 @@ class ApplicationSearchFilter < ApplicationStruct
   private
 
   def assigned_to_user_options
-    user_ids = (
-      CurrentAssignment.distinct.pluck(:user_id) + Review.distinct.pluck(:reviewer_id)
-    ).uniq
+    # builds an array of [User#name, User#id] sorted by first name, last name
+    ids_of_users_with_active_assignments_and_or_reviews.map { |id| [User.name_for(id), id] }.sort
+  end
 
-    user_ids.map { |id| [User.name_for(id), id] }.sort
+  def ids_of_users_with_active_assignments_and_or_reviews
+    (
+      CurrentAssignment.distinct.pluck(:user_id) + Review.distinct.pluck(:reviewer_id)
+    ).compact.uniq
   end
 
   # Returns the value of the DatastoreApi Search "application_id_in" constraint

--- a/spec/shared_contexts/with_stubbed_assignments_and_reviews.rb
+++ b/spec/shared_contexts/with_stubbed_assignments_and_reviews.rb
@@ -30,6 +30,9 @@ RSpec.shared_context 'with stubbed assignments and reviews', shared_context: :me
     CurrentAssignment.insert({ user_id: david.id, assignment_id: davids_applications.first })
 
     Review.insert({ reviewer_id: john.id, application_id: johns_applications.last })
+
+    # Add a non reviewed application
+    Review.insert({ application_id: SecureRandom.uuid })
     # rubocop:enable Rails/SkipsModelValidations
   end
 end


### PR DESCRIPTION
## Description of change
Only closed reviews have a reviewer. Open Reviews need to be excluded when building the list of reviewers for the search dropdown.

## Link to relevant ticket

## Notes for reviewer

This was causing a user with an id of nil being added to the search filter dropdown. When deployed to staging, which has some in progress reviews,  a user called '[deleted]' with an id of nil appeared in the caseworker filter dropdown.

## Screenshots of changes (if applicable)

### Before changes:
<img width="852" alt="Screenshot 2023-07-17 at 16 13 51" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/9f2ce32f-4386-46d6-825f-b4281c5b67e6">

### After changes:
<img width="872" alt="Screenshot 2023-07-17 at 16 14 01" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/43ce8ea2-649e-442c-9639-47e20a7cfe5b">

## How to manually test the feature
