### PR TITLE
CRIMRE-415 extend the workload report by one day

### DIFF
--- a/app/models/reporting/workload_report.rb
+++ b/app/models/reporting/workload_report.rb
@@ -6,7 +6,7 @@ module Reporting
     # to applications that were received zero business days ago. The second row
     # applications received one business day ago, and so on, until the last row, which
     # includes a count up to the specified 'last_row_limit_in_days'.
-    def initialize(number_of_rows: 4, day_zero: Time.current, last_row_limit_in_days: 9)
+    def initialize(number_of_rows: 5, day_zero: Time.current, last_row_limit_in_days: 9)
       @number_of_rows = number_of_rows
       @day_zero = day_zero.in_time_zone('London').to_date
       @last_row_limit_in_days = last_row_limit_in_days

--- a/spec/models/reporting/workload_report_spec.rb
+++ b/spec/models/reporting/workload_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reporting::WorkloadReport do
-  subject(:report) { described_class.new day_zero: }
+  subject(:report) { described_class.new day_zero: day_zero, number_of_rows: 4 }
 
   let(:day_zero) { Date.parse('2023-01-04') }
 
@@ -68,11 +68,7 @@ RSpec.describe Reporting::WorkloadReport do
     end
   end
 
-  describe 'number of rows can be configured using :number_of_days' do
-    subject(:report) { described_class.new(number_of_rows: 7) }
-
-    it 'returns the counts for the four working days up to and including day_zero' do
-      expect(report.table.rows.size).to be 7
-    end
+  it 'number of rows defaults to 5' do
+    expect(described_class.new.table.rows.size).to be 5
   end
 end

--- a/spec/system/reporting/workload_report_spec.rb
+++ b/spec/system/reporting/workload_report_spec.rb
@@ -33,9 +33,15 @@ RSpec.describe 'Workload Report' do
     end
   end
 
-  it 'shows the correct row headers for the last row' do
+  it 'shows the correct row headers for three days' do
     within all('table tbody th')[3] do
-      expect(page).to have_content 'Between 3 and 9 days'
+      expect(page).to have_content '3 days'
+    end
+  end
+
+  it 'shows the correct row headers for the last row' do
+    within all('table tbody th')[4] do
+      expect(page).to have_content 'Between 4 and 9 days'
     end
   end
 end


### PR DESCRIPTION
## Description of change
Add a dedicated row for "3 days" in the workload report.

## Link to relevant ticket
[CRIMRE-415](https://dsdmoj.atlassian.net/browse/CRIMRE-415)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
![image](https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/299432a4-2c48-4260-8603-e61d2dd09c94)


## How to manually test the feature


[CRIMRE-415]: https://dsdmoj.atlassian.net/browse/CRIMRE-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ