### PR TITLE
Fix docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ The last user in the list is "Not.Authorised@example.com." Select this user to s
 
 This authentication strategy can be disabled locally by setting ```DEV_AUTH_ENABLED=false```
 
+**NOTE:** The dev_auth authentication strategy has been enabled for local development and docker-compose by setting ```DEV_AUTH_ENABLED=true``` and ```IS_LOCAL_DOCKER_ENV=true```.
+This must never be enabled in the live (staging/production) service in it's current form as it will expose sensitive information.
+
 ## Local development with the temporary API gem
 
 The app utilises [puma-dev](https://github.com/puma/puma-dev) for local development.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = ENV.key?('DISABLE_HTTPS') ? false : true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -34,10 +34,10 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   #
-  # Uses the DevAuth strategy if local and ENV["DEV_AUTH_ENABLED"] is true
+  # Uses the DevAuth strategy if local/docker env and ENV["DEV_AUTH_ENABLED"] is true
 
-  if HostEnv.production? && FeatureFlags.dev_auth.enabled?
-    raise "The DevAuth strategy must not be used in this environment"
+  unless HostEnv.local? || ENV.key?('IS_LOCAL_DOCKER_ENV')
+    raise "The DevAuth strategy must not be used in this environment" if FeatureFlags.dev_auth.enabled?
   end
 
   strategy_class = FeatureFlags.dev_auth.enabled? ? OmniAuth::Strategies::DevAuth : OmniAuth::Strategies::OpenIDConnect

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -36,7 +36,7 @@ Devise.setup do |config|
   #
   # Uses the DevAuth strategy if local and ENV["DEV_AUTH_ENABLED"] is true
 
-  if !HostEnv.local? && FeatureFlags.dev_auth.enabled?
+  if HostEnv.production? && FeatureFlags.dev_auth.enabled?
     raise "The DevAuth strategy must not be used in this environment"
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 feature_flags:
   dev_auth:
     local: <%= ENV.fetch("DEV_AUTH_ENABLED", false) %>
-    staging: false
+    staging: <%= ENV.fetch("DEV_AUTH_ENABLED", false) %>
     production: false # must never be enabled in the live service
   allow_user_managers_service_access:
     local: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   web:
     build: .
     environment:
-      ENV_NAME: production
+      ENV_NAME: staging
       RAILS_ENV: production
       DATABASE_URL: postgresql://postgres@db/laa-review-criminal-legal-aid
       SECRET_KEY_BASE: f22760a0bd78a9191ba4c247e23a281cb251461cdba6b5215043ca11b694d734
@@ -24,6 +24,7 @@ services:
       RAILS_LOG_TO_STDOUT: "1"
       DATABASE_SSLMODE: disable
       DISABLE_HTTPS: "1"
+      DEV_AUTH_ENABLED: "true"
     ports:
       - "3000:3000" # puma server (rails app)
       - "9394:9394" # prometheus exporter `/metrics` endpoint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       DATABASE_SSLMODE: disable
       DISABLE_HTTPS: "1"
       DEV_AUTH_ENABLED: "true"
+      IS_LOCAL_DOCKER_ENV: "true"
     ports:
       - "3000:3000" # puma server (rails app)
       - "9394:9394" # prometheus exporter `/metrics` endpoint


### PR DESCRIPTION
## Description of change
This PR fixes running docker-compose in review. The docker-compose env name has been changed to staging to enable dev_auth to be used (as dev_auth cannot be used in production) and the running of the app in ssl has been disabled

## Link to relevant ticket
[CRIMRE-370](https://dsdmoj.atlassian.net/browse/CRIMRE-370)

## Notes for reviewer
Fyi I found testing in chrome to be a bit of a pain as it kept forcing ssl. I found Firefox to be easier 

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMRE-370]: https://dsdmoj.atlassian.net/browse/CRIMRE-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ