### PR TITLE
Add 422 error message

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -27,6 +27,7 @@ class ErrorsController < ApplicationController
   def error_page
     return :internal_server_error if status >= 500
     return :forbidden if status == 403
+    return :unprocessable_entity if [422, 400].include? status
 
     :not_found
   end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -13,5 +13,13 @@ module Users
     def failure
       throw(:warden, recall: 'Errors#forbidden', message: :forbidden)
     end
+
+    # Override the #passthru action. It is used when a GET request is made
+    # to the user auth url. Ideally the GET route would not be added by Devise.
+    # The fix for this is in Devise but awaiting release:
+    # https://github.com/heartcombo/devise/pull/5508
+    def passthru
+      redirect_to unauthenticated_root_path
+    end
   end
 end

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,0 +1,10 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t '.heading' %></h1>
+
+    <p class="govuk-body-l"><%=t '.body_1' %></p>
+    <p class="govuk-body-l"><%= sanitize t('.body_2', url: mail_to(Rails.configuration.x.admin.onboarding_email)) %></p>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -41,3 +41,8 @@ en:
       page_title: Unexpected error
       heading: Sorry, something went wrong with our service
       body_1: We cannot connect to our database. This means you cannot view, search, or review applications.
+    unprocessable_entity:
+      page_title: Request error
+      heading: Sorry, there is a problem with your request
+      body_1: You can go back, refresh the page, and try again.
+      body_2: If this problem continues, contact %{url} for help.

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -152,4 +152,12 @@ RSpec.describe 'Authentication Session Initialisation' do
       expect(response.body).to include 'Access to this service is restricted'
     end
   end
+
+  context 'when a get request is made to the user auth path' do
+    it 'redirects to sign in page' do
+      get user_azure_ad_omniauth_authorize_path
+
+      expect(response).to redirect_to(unauthenticated_root_path)
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
Previously invalid authenticity token requests etc were being shown a page not found message. This change shows a request error message suggesting they go back, refresh, and try again.

Also overrides Devise passthru to redirect to sign in. Otherwise a user gets stuck on an unformatted page if they refresh the after an authenticity token failure on the user auth path.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="712" alt="Screenshot 2023-07-20 at 13 18 19" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/ec7f91ed-d316-411f-89e6-32c964149b4e">


### After changes:

<img width="832" alt="Screenshot 2023-07-20 at 16 13 04" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/2a5542d1-abbf-4407-b090-83c33527a03e">


## How to manually test the feature
From the root path, tamper with the authenticity token hidden field on the Start button, and click the button.
To confirm the passthru fix, reload the page and confirm you are redirected to sign_in.
