### PR TITLE
CRIMRE-414 store Business Day Review read model

### DIFF
--- a/app/aggregates/reviewing/review.rb
+++ b/app/aggregates/reviewing/review.rb
@@ -101,5 +101,9 @@ module Reviewing
     def received?
       state != nil
     end
+
+    def business_day
+      BusinessDay.new(day_zero: @submitted_at).date
+    end
   end
 end

--- a/app/read_models/received_on_reports/handler.rb
+++ b/app/read_models/received_on_reports/handler.rb
@@ -15,10 +15,6 @@ module ReceivedOnReports
     end
     # :nocov:
 
-    private
-
-    def business_day
-      @business_day = BusinessDay.new(day_zero: @review.submitted_at).date
-    end
+    delegate :business_day, to: :@review
   end
 end

--- a/app/read_models/reviews/update_from_aggregate.rb
+++ b/app/read_models/reviews/update_from_aggregate.rb
@@ -15,8 +15,6 @@ module Reviews
       update_from_aggregate(review_aggregate)
     end
 
-    private
-
     def update_from_aggregate(review_aggregate)
       Review.upsert(
         {
@@ -25,6 +23,7 @@ module Reviews
           submitted_at: review_aggregate.submitted_at,
           reviewer_id: review_aggregate.reviewer_id,
           parent_id: review_aggregate.parent_id,
+          business_day: review_aggregate.business_day
         },
         unique_by: :application_id
       )

--- a/db/migrate/20230724092947_add_business_day_to_review.rb
+++ b/db/migrate/20230724092947_add_business_day_to_review.rb
@@ -1,0 +1,19 @@
+class AddBusinessDayToReview < ActiveRecord::Migration[7.0]
+  def up
+    add_column :reviews, :business_day, :date
+    add_index :reviews, :business_day
+
+    Review.where(business_day: nil).pluck(:application_id).each do |application_id|
+      aggregate = Reviewing::LoadReview.call(application_id: application_id)
+      Reviews::UpdateFromAggregate.new.update_from_aggregate(aggregate)
+    rescue StandardError => e
+      Rails.logger.warn "Failed to set Business Date for #{application_id} while migrating AddBusinessDayToReview"
+      Rails.logger.warn e
+    end
+  end
+
+  def down
+    remove_index :reviews, :business_day
+    remove_column :reviews, :business_day
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_17_115703) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_24_092947) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -59,7 +59,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_17_115703) do
     t.uuid "reviewer_id"
     t.uuid "parent_id"
     t.datetime "submitted_at", precision: nil
+    t.date "business_day"
     t.index ["application_id"], name: "index_reviews_on_application_id", unique: true
+    t.index ["business_day"], name: "index_reviews_on_business_day"
     t.index ["parent_id"], name: "index_reviews_on_parent_id"
     t.index ["reviewer_id"], name: "index_reviews_on_reviewer_id"
     t.index ["state"], name: "index_reviews_on_state"

--- a/spec/read_models/reviews/update_from_aggreate_spec.rb
+++ b/spec/read_models/reviews/update_from_aggreate_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Reviews::UpdateFromAggregate' do
-  describe '#call' do
+  describe '#call' do # rubocop:disable RSpec/MultipleMemoizedHelpers
     let(:application_id) { SecureRandom.uuid }
-    let(:submitted_at) { '2023-04-25' }
+    let(:submitted_at) { '2023-04-22' }
+    let(:business_day) { BusinessDay.new(day_zero: submitted_at).date }
     let(:state) { 'received' }
     let(:parent_id) { SecureRandom.uuid }
     let(:reviewer_id) { SecureRandom.uuid }
@@ -13,7 +14,7 @@ RSpec.describe 'Reviews::UpdateFromAggregate' do
 
       aggregate = instance_double(
         Reviewing::Review,
-        id:, state:, submitted_at:, reviewer_id:, parent_id:
+        id:, state:, submitted_at:, reviewer_id:, parent_id:, business_day:
       )
 
       allow(Reviewing::LoadReview).to receive(:call).with(application_id:) {
@@ -25,10 +26,10 @@ RSpec.describe 'Reviews::UpdateFromAggregate' do
       Reviews::UpdateFromAggregate.new.call(event)
     end
 
-    describe 'the read model' do
+    describe 'the read model' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       subject(:read_model) { Review.find_by(application_id:) }
 
-      %i[application_id state submitted_at reviewer_id parent_id].each do |attribute|
+      %i[application_id state submitted_at reviewer_id parent_id business_day].each do |attribute|
         it "sets the #{attribute}" do
           expect(read_model.public_send(attribute)).to eq(send(attribute))
         end


### PR DESCRIPTION
## Description of change

Store Business Day Review read model
This is to facilitate grouping and filtering by age in business days.

## Link to relevant ticket
[CRIMRE-414](https://dsdmoj.atlassian.net/browse/CRIMRE-414)

## Notes for reviewer

This is first in a series of changes to add grouping / searching by the business day an application was received on.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
