### PR TITLE
CRIMAP-462 Datastore health engine routes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,8 @@ gem 'lograge'
 gem 'logstash-event'
 
 gem 'laa-criminal-applications-datastore-api-client',
-    github: 'ministryofjustice/laa-criminal-applications-datastore-api-client'
+    github: 'ministryofjustice/laa-criminal-applications-datastore-api-client', tag: 'v1.1.0',
+    require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
-  revision: c70ab780a2384fb156e9ded2213304cd2967254b
+  revision: 0707f4122553b3e72c85ea5df0a242d703fec00a
+  tag: v1.1.0
   specs:
-    laa-criminal-applications-datastore-api-client (1.0.0)
+    laa-criminal-applications-datastore-api-client (1.1.0)
       faraday (~> 2.7)
       moj-simple-jwt-auth (~> 0.1.0)
 

--- a/config/initializers/datastore_client.rb
+++ b/config/initializers/datastore_client.rb
@@ -1,5 +1,3 @@
-require 'datastore_api'
-
 DatastoreApi.configure do |config|
   config.api_root = ENV.fetch('DATASTORE_API_ROOT', nil)
   config.api_path = '/api/v1'

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -5,9 +5,12 @@ Rails.application.configure do
   config.lograge.logger = ActiveSupport::Logger.new($stdout)
   config.lograge.formatter = Lograge::Formatters::Logstash.new
 
+  # Reduce noise in the logs by ignoring the healthcheck actions
   config.lograge.ignore_actions = %w[
     HealthcheckController#show
     HealthcheckController#ping
+    DatastoreApi::HealthEngine::HealthcheckController#show
+    DatastoreApi::HealthEngine::HealthcheckController#ping
   ]
 
   config.lograge.custom_options = lambda do |event|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount DatastoreApi::HealthEngine::Engine => '/datastore'
+
   get :health, to: 'healthcheck#show'
   get :ping,   to: 'healthcheck#ping'
 

--- a/spec/requests/datastore_healthcheck_spec.rb
+++ b/spec/requests/datastore_healthcheck_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe 'Datastore healthcheck endpoints' do
+  describe 'Health endpoint' do
+    context 'when success' do
+      before do
+        stub_request(:get, 'https://datastore-api-stub.test/health')
+          .to_return(body: '{}')
+      end
+
+      it 'reports success' do
+        get '/datastore/health'
+        expect(response.body).to eq('{}')
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when failure' do
+      before do
+        stub_request(:get, 'https://datastore-api-stub.test/health')
+          .to_raise(StandardError)
+      end
+
+      it 'reports failure' do
+        get '/datastore/health'
+        expect(response.body).to eq('{"error":"Exception from WebMock"}')
+        expect(response).to have_http_status(:service_unavailable)
+      end
+    end
+  end
+
+  describe 'Ping endpoint' do
+    context 'when success' do
+      before do
+        stub_request(:get, 'https://datastore-api-stub.test/ping')
+          .to_return(body: '{}')
+      end
+
+      it 'reports success' do
+        get '/datastore/ping'
+        expect(response.body).to eq('{}')
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when failure' do
+      before do
+        stub_request(:get, 'https://datastore-api-stub.test/ping')
+          .to_raise(StandardError)
+      end
+
+      it 'reports failure' do
+        get '/datastore/ping'
+        expect(response.body).to eq('{"error":"Exception from WebMock"}')
+        expect(response).to have_http_status(:service_unavailable)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Following [changes in apply](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/448) to add datastore healthcheck endpoints that pings the datastore so it can be used in Geckoboard, this PR makes those same changes in review.

Description of change from apply pr:
Use the datastore health rails engine on review to act as a proxy for the health and ping endpoints given the datastore is an internal service only accessible from the cluster.

Moved the require 'datastore_api' to the Gemfile declaration as otherwise it wasn't properly loading the engine, I think it may be because the name of the gem is different to the name of the lib require.

Note: the gem ref to be changed with the tag 1.1.0 when new tag is released.

## Link to relevant ticket
[CRIMAP-462](https://dsdmoj.atlassian.net/browse/CRIMAP-462)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Manual testing instructions lifted from apply pr:
Spin up both, datastore and review, and from review, observe how /datastore/ping or /datastore/health reach the datastore. If datastore is down, those endpoints will return error.

Also:
```
$ rails routes | grep datastore
datastore_api_health_engine   /datastore   DatastoreApi::HealthEngine::Engine
health GET  /health(.:format) datastore_api/health_engine/healthcheck#show
  ping GET  /ping(.:format)   datastore_api/health_engine/healthcheck#ping
```


[CRIMAP-462]: https://dsdmoj.atlassian.net/browse/CRIMAP-462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ