### PR TITLE
Remove redundant webdriver gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,5 @@ group :test do
   gem 'rubocop-rspec', require: false
   gem 'selenium-webdriver'
   gem 'simplecov', require: false
-  gem 'webdrivers'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,10 +518,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webfinger (2.1.2)
       activesupport
       faraday (~> 2.0)
@@ -587,7 +583,6 @@ DEPENDENCIES
   sprockets-rails
   turbo-rails
   web-console
-  webdrivers
   webmock
 
 RUBY VERSION

--- a/spec/init/webmock.rb
+++ b/spec/init/webmock.rb
@@ -1,4 +1,4 @@
 # Allow connections to webdriver urls
 #
-driver_urls = Webdrivers::Common.subclasses.map(&:base_url)
+driver_urls = Selenium::WebDriver::Chromium::Driver.subclasses.map(&:base_url)
 WebMock.disable_net_connect!(allow_localhost: true, allow: driver_urls)


### PR DESCRIPTION
## Description of change
Removes redundant webdriver gem that was causing build issues due to webdriver not supporting chrome v115

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
