### PR TITLE
CRIMAP-499 filter by age in business days.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,6 +71,9 @@ Naming/BlockForwarding:
 RSpec/MultipleExpectations:
   Max: 2
 
+RSpec/MultipleMemoizedHelpers:
+  Max: 6
+
 Rails/SkipsModelValidations:
   Exclude:
     - '**/app/read_models/**/*'

--- a/app/aggregates/reviewing/review.rb
+++ b/app/aggregates/reviewing/review.rb
@@ -99,7 +99,7 @@ module Reviewing
     end
 
     def received?
-      state != nil
+      !!state
     end
 
     def business_day

--- a/app/models/application_search.rb
+++ b/app/models/application_search.rb
@@ -6,6 +6,10 @@ class ApplicationSearch
   end
 
   def results
+    # If the result set from the local Review database query is empty, we know we do not need to perform a
+    # datastore search.
+    return [] if @filter.datastore_results_will_be_empty?
+
     @results ||= datastore_search_response.map do |result|
       application = ApplicationSearchResult.new(result)
 

--- a/app/models/application_search_filter.rb
+++ b/app/models/application_search_filter.rb
@@ -1,19 +1,20 @@
 class ApplicationSearchFilter < ApplicationStruct
-  attribute? :assigned_status, Types::AssignedStatus | Types::Uuid
+  REVIEW_FILTERS = %i[assigned_status age_in_business_days].freeze
+  DATASTORE_FILTERS = %i[
+    applicant_date_of_birth application_id_in application_status search_text submitted_after submitted_before
+  ].freeze
+
+  attribute? :age_in_business_days, Types::Params::Nil | Types::Params::Integer
+  attribute? :applicant_date_of_birth, Types::Params::Nil | Types::Params::Date
   attribute? :application_status, Types::ReviewStatusGroup
+  attribute? :assigned_status, Types::AssignedStatus | Types::Uuid
   attribute? :search_text, Types::Params::Nil | Types::Params::String
   attribute? :submitted_after, Types::Params::Nil | Types::Params::Date
   attribute? :submitted_before, Types::Params::Nil | Types::Params::Date
-  attribute? :applicant_date_of_birth, Types::Params::Nil | Types::Params::Date
 
-  #
   # Options for the assigned status filter
-  #
   # Includes "Unassigned", "All assigned" prepended to a list of all user names.
   # Values can be "unassigned", "assigned" or a user id.
-  # If a user is specified, only applications assinged to or reviewed by that
-  # user are returned.
-  #
   def assigned_status_options
     status_options = Types::ASSIGNED_STATUSES.map do |status|
       [I18n.t(status, scope: 'values.assigned_status'), status]
@@ -22,96 +23,127 @@ class ApplicationSearchFilter < ApplicationStruct
     status_options + assigned_to_user_options
   end
 
-  #
   # Options for the application status filter
-  #
   # Includes 'Open', 'Completed', 'Sent back to provider' or 'All applications'
   # Values can be "open", "completed", "sent_back", "all"
-  #
   def application_status_options
     Types::REVIEW_STATUS_GROUPS.keys.map do |status|
       [I18n.t(status, scope: 'values.review_status'), status]
     end
   end
 
-  #
-  # Hash of DatastoreApi search constraints based upon the filter
-  #
-  # NOTE: The DatastoreApi does not understand assigned_status. To filter
-  # DatastoreApi searches by assigned status, we translate the assigned_status into
-  # "application_id_in" and "application_id_not_in" DatastoreApi constraints.
-  #
+  # Options for the application age_in_business_days filter
+  # Includes '0 days', '1 day', '2 days', '3 days'
+  def age_in_business_days_options
+    Array.new(4) do |day|
+      [I18n.t('values.days_passed', count: day), day]
+    end
+  end
+
+  # Hash of Datastore search constraints based on the active filters
   def datastore_params
-    {
-      applicant_date_of_birth: applicant_date_of_birth,
-      application_id_in: application_id_in,
-      application_id_not_in: application_id_not_in,
-      review_status: review_status,
-      submitted_after: submitted_after&.in_time_zone('London'),
-      submitted_before: submitted_before&.in_time_zone('London'),
-      search_text: search_text
-    }
+    active_datastore_filters.each_with_object({}) do |filter, params|
+      params.merge!(send("#{filter}_datastore_param"))
+    end
+  end
+
+  # If the filter includes constraints related to "#age_in_business_days"
+  # or "#assigned_status", we first search the local Review database. The results
+  # of that query are passed as a constraint to the datastore search as the
+  # #application_id_in datastore param.
+  # If the result set from the local Review database query is empty, we know
+  # we do not need to perform a datastore search.
+
+  # Returns:
+  # - true: If there are active review filters and the local Review database
+  #   result set is empty.
+  # - false: If there are no active review filters or the local Review database
+  #   result set is not empty.
+  def datastore_results_will_be_empty?
+    !active_review_filters.empty? && application_id_in&.empty?
   end
 
   private
 
+  def active_filters
+    attributes.compact_blank.keys
+  end
+
+  # Returns an array of the active review filters that will be used in the local Review search.
+  def active_review_filters
+    active_filters & REVIEW_FILTERS
+  end
+
+  # Returns an array of the active datastore filters that will be used in the datastore search.
+  def active_datastore_filters
+    filters = active_filters & DATASTORE_FILTERS
+    filters << :application_id_in if application_id_in
+    filters
+  end
+
+  def applicant_date_of_birth_datastore_param
+    { applicant_date_of_birth: }
+  end
+
+  def application_id_in_datastore_param
+    { application_id_in: }
+  end
+
+  def application_status_datastore_param
+    { review_status: Types::REVIEW_STATUS_GROUPS.fetch(application_status) }
+  end
+
+  def submitted_after_datastore_param
+    { submitted_after: submitted_after&.in_time_zone('London') }
+  end
+
+  def submitted_before_datastore_param
+    { submitted_before: submitted_before&.in_time_zone('London') }
+  end
+
+  def search_text_datastore_param
+    { search_text: }
+  end
+
+  # Returns the intersection of all active review filters' application_ids.
+  def application_id_in
+    active_review_filters_application_ids.reduce(:&)
+  end
+
+  # Returns an array application_ids for each active review filter
+  def active_review_filters_application_ids
+    active_review_filters.map do |filter|
+      send("#{filter}_filter_application_ids")
+    end
+  end
+
+  # Returns the application_ids on Review that meet the business day filter
+  # constraint for the given date.
+  def age_in_business_days_filter_application_ids
+    Review.by_age_in_business_days(age_in_business_days).pluck(:application_id)
+  end
+
+  # Returns the application_ids on Review that meet the assigned status filter
+  # constraint for the given status.
+  # If a user is specified, only applications assigned to, or reviewed by, that user are returned.
+  def assigned_status_filter_application_ids
+    case assigned_status
+    when 'unassigned'
+      Review.unassigned.pluck(:application_id)
+    when 'assigned'
+      CurrentAssignment.pluck(:assignment_id)
+    else
+      user_id = assigned_status
+      CurrentAssignment.assigned_to_ids(user_id:) | Review.reviewed_by_ids(user_id:)
+    end
+  end
+
+  # builds an array of [User#name, User#id] sorted by first name, last name
   def assigned_to_user_options
-    # builds an array of [User#name, User#id] sorted by first name, last name
     ids_of_users_with_active_assignments_and_or_reviews.map { |id| [User.name_for(id), id] }.sort
   end
 
   def ids_of_users_with_active_assignments_and_or_reviews
-    (
-      CurrentAssignment.distinct.pluck(:user_id) + Review.distinct.pluck(:reviewer_id)
-    ).compact.uniq
-  end
-
-  # Returns the value of the DatastoreApi Search "application_id_in" constraint
-  # according to the #assigned_status. Assigned status can be either nil, 'unassigned',
-  # 'assigned' or a user_id.
-  #
-  # When assigned_status is a user_id, it returns the application_ids of those
-  # applications that are either currently assigned to or were reviewed by
-  # the given user.
-  def application_id_in
-    case assigned_status
-    when nil, 'unassigned'
-      []
-    when 'assigned'
-      all_assigned_application_ids
-    else
-      application_ids_for_user(assigned_status)
-    end
-  end
-
-  def application_ids_for_user(user_id)
-    CurrentAssignment.assigned_to_ids(user_id:) +
-      Review.reviewed_by_ids(user_id:)
-  end
-
-  #
-  # returns the value of the DatastoreApi Search "review_status" constraint
-  # according to the #application_status
-  #
-  def review_status
-    Types::REVIEW_STATUS_GROUPS.fetch(application_status)
-  end
-
-  #
-  # returns the value of the DatastoreApi Search "application_id_not_in" constraint
-  # according to the #assigned_status
-  #
-  # In order to get a list of unassigned applications from the Datastore,
-  # we use this constraint to get a list of applications not in the list of current
-  # assignments.
-  #
-  def application_id_not_in
-    return [] unless assigned_status == 'unassigned'
-
-    all_assigned_application_ids
-  end
-
-  def all_assigned_application_ids
-    @all_assigned_application_ids ||= CurrentAssignment.pluck(:assignment_id)
+    CurrentAssignment.distinct.pluck(:user_id) | Review.closed.distinct.pluck(:reviewer_id)
   end
 end

--- a/app/models/business_day.rb
+++ b/app/models/business_day.rb
@@ -1,5 +1,5 @@
 class BusinessDay
-  def initialize(day_zero:, age_in_business_days: 0, calendar: Calendar.new)
+  def initialize(day_zero: Time.current, age_in_business_days: 0, calendar: Calendar.new)
     @age_in_business_days = age_in_business_days
     @day_zero = day_zero.in_time_zone('London').to_date
     @calendar = calendar

--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -3,7 +3,8 @@ module Reviewable
     @review ||= Reviewing::LoadReview.call(application_id: id)
   end
 
-  delegate :reviewed_at, :reviewer_id, :reviewed?, :superseded_by, :superseded_at, to: :review
+  delegate :reviewed_at, :reviewer_id, :reviewed?, :superseded_by, :superseded_at,
+           :business_day, to: :review
 
   def review_status
     review.state

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,4 +1,15 @@
 class Review < ApplicationRecord
+  scope :closed, -> { where.not(reviewer_id: nil) }
+  scope :open, -> { where(reviewer_id: nil) }
+
+  scope :unassigned, lambda {
+    open.where.not(application_id: CurrentAssignment.pluck(:assignment_id))
+  }
+
+  scope :by_age_in_business_days, lambda { |age|
+    where(business_day: BusinessDay.new(age_in_business_days: age).date)
+  }
+
   #
   # Review is a CQRS read model. It is configured by the
   # Reviews::Configuration class

--- a/app/views/application/_application_search_filter.html.erb
+++ b/app/views/application/_application_search_filter.html.erb
@@ -18,30 +18,66 @@
     </div>
 
     <label class="govuk-label govuk-label--s"><%= t('labels.search_criteria')%></label>
-    <div class="input-group">
-      <%= f.govuk_select(
-            :application_status,
-            application_search_filter.application_status_options,
-            label: { text: t('labels.application_status') }
-          ) %>
-      <%= f.search_date_field(
-            :submitted_after,
-            as: :date,
-            label: { text: t('labels.start_on') }
-          ) %>
-      <%= f.search_date_field(
-            :submitted_before,
-            as: :date,
-            label: { text: t('labels.end_on') }
-          ) %>
 
-      <%= f.govuk_select(
-            :assigned_status,
-            application_search_filter.assigned_status_options,
-            options: { include_blank: '' },
-            label: { text: t('labels.caseworker') }
-          ) %>
-    </div>
+    <% if FeatureFlags.filter_search_by_age_in_business_days.enabled? %>
+      <div class="input-group">
+        <%= f.govuk_select(
+              :application_status,
+              application_search_filter.application_status_options,
+              label: { text: t('labels.application_status') }
+            ) %>
+
+        <%= f.govuk_select(
+              :assigned_status,
+              application_search_filter.assigned_status_options,
+              options: { include_blank: '' },
+              label: { text: t('labels.caseworker') }
+            ) %>
+      </div>
+      <div class="input-group">
+        <%= f.search_date_field(
+              :submitted_after,
+              as: :date,
+              label: { text: t('labels.start_on') }
+            ) %>
+        <%= f.search_date_field(
+              :submitted_before,
+              as: :date,
+              label: { text: t('labels.end_on') }
+            ) %>
+        <%= f.govuk_select(
+              :age_in_business_days,
+              application_search_filter.age_in_business_days_options,
+              options: { include_blank: '' },
+              label: { text: t('labels.age_in_business_days') }
+            ) %>
+      </div>
+    <% else %>
+      <div class="input-group">
+        <%= f.govuk_select(
+              :application_status,
+              application_search_filter.application_status_options,
+              label: { text: t('labels.application_status') }
+            ) %>
+        <%= f.search_date_field(
+              :submitted_after,
+              as: :date,
+              label: { text: t('labels.start_on') }
+            ) %>
+        <%= f.search_date_field(
+              :submitted_before,
+              as: :date,
+              label: { text: t('labels.end_on') }
+            ) %>
+
+        <%= f.govuk_select(
+              :assigned_status,
+              application_search_filter.assigned_status_options,
+              options: { include_blank: '' },
+              label: { text: t('labels.caseworker') }
+            ) %>
+      </div>
+    <% end %>
 
     <div class="govuk-button-group">
       <%= f.govuk_submit t('calls_to_action.search') %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -23,7 +23,8 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
+
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,58 +88,58 @@ en:
     manage_users: Manage users
 
   labels: &LABELS
-    select_return_reason: Select the reason for returning this application
-    return_reason_details_legend: Give further details
-    return_reason_details: We'll share this information with the provider
+    age_in_business_days: Business days since received
+    applicant_date_of_birth: Applicant's date of birth
+    application_information: Application information
+    application_start_date: Date stamp
+    application_status: Status
+    application_type: Application type
     assigned_to: 'Assigned to:'
+    case_type: Case type
+    caseworker: Caseworker
     closed_by: 'Closed by:'
-    date_received: 'Date received:'
+    codefendant: Co-defendant %{number}
+    codefendants: Co-defendants
+    correspondence_address: Correspondence address
     date:
       sent_back: 'Date closed:'
       completed: 'Date closed:'
-
-    application_information: Application information
-    search_criteria: Search criteria
-    applicant_date_of_birth: Applicant's date of birth
-    caseworker: Caseworker
-    start_on: Date from
-    end_on: Date to
-    first_name: First name
-    last_name: Last name
-    other_names: Other names
-    case_type: Case type
     date_appeal_lodged: Date the appeal was lodged
-    financial_change_details: Changes in the client’s financial circumstances
-    previous_maat_id: Previous MAAT ID
-    national_insurance_number: National Insurance number
     date_of_birth: Date of birth
-    application_type: Application type
-    means_type: Means type
-    urn: Unique reference number
-    application_start_date: Date stamp
-    telephone_number: UK Telephone number
-    partner: Partner
+    date_received: 'Date received:'
+    end_on: Date to
+    financial_change_details: Changes in the client’s financial circumstances
+    first_name: First name
     hearing_court_name: Court hearing the case
     hearing_date: Next court hearing
     home_address: Home address
-    correspondence_address: Correspondence address
-    codefendant: Co-defendant %{number}
-    codefendants: Co-defendants
-    offence: Offence
-    offence_date: Offence date
-    overall_offence_class: Overall offence class
     interests_of_justice_type: Criteria
     justification: Justification
-    office_account_number: Office account number
+    last_name: Last name
     legal_representative: Legal representative
-    provider_phone_number: Phone
+    means_type: Means type
+    national_insurance_number: National Insurance number
+    offence: Offence
+    offence_date: Offence date
+    office_account_number: Office account number
+    other_names: Other names
+    overall_offence_class: Overall offence class
+    partner: Partner
+    previous_maat_id: Previous MAAT ID
     provider_email: Email address
+    provider_phone_number: Phone
+    return_reason_details: We'll share this information with the provider
+    return_reason_details_legend: Give further details
+    search_criteria: Search criteria
     search_text: Reference number or applicant's first or last name
+    select_return_reason: Select the reason for returning this application
+    start_on: Date from
+    telephone_number: UK Telephone number
+    undetermined: Undetermined
+    urn: Unique reference number
+    what: What
     when: When
     who: Who
-    what: What
-    application_status: Status
-    undetermined: Undetermined
 
   table_headings: &TABLE_HEADINGS
     applicant_name: Applicant's name

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,3 +7,7 @@ feature_flags:
     local: false
     staging: true
     production: false # user managers should not access the service in production
+  filter_search_by_age_in_business_days:
+    local: true
+    staging: false
+    production: false

--- a/spec/read_models/reviews/update_from_aggreate_spec.rb
+++ b/spec/read_models/reviews/update_from_aggreate_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Reviews::UpdateFromAggregate' do
-  describe '#call' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+  describe '#call' do
     let(:application_id) { SecureRandom.uuid }
     let(:submitted_at) { '2023-04-22' }
     let(:business_day) { BusinessDay.new(day_zero: submitted_at).date }
@@ -26,7 +26,7 @@ RSpec.describe 'Reviews::UpdateFromAggregate' do
       Reviews::UpdateFromAggregate.new.call(event)
     end
 
-    describe 'the read model' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    describe 'the read model' do
       subject(:read_model) { Review.find_by(application_id:) }
 
       %i[application_id state submitted_at reviewer_id parent_id business_day].each do |attribute|

--- a/spec/shared_contexts/with_stubbed_assignments_and_reviews.rb
+++ b/spec/shared_contexts/with_stubbed_assignments_and_reviews.rb
@@ -24,6 +24,8 @@ RSpec.shared_context 'with stubbed assignments and reviews', shared_context: :me
     [johns_applications.first, davids_applications.first]
   end
 
+  let(:unassigned_application_ids) { [SecureRandom.uuid] }
+
   before do
     # rubocop:disable Rails/SkipsModelValidations
     CurrentAssignment.insert({ user_id: john.id, assignment_id: johns_applications.first })
@@ -31,8 +33,14 @@ RSpec.shared_context 'with stubbed assignments and reviews', shared_context: :me
 
     Review.insert({ reviewer_id: john.id, application_id: johns_applications.last })
 
-    # Add a non reviewed application
-    Review.insert({ application_id: SecureRandom.uuid })
+    # Add non reviewed applications
+    unassigned_application_ids.each do |application_id|
+      Review.insert({
+                      application_id: application_id,
+        submitted_at: Time.current,
+        business_day: BusinessDay.new(day_zero: Time.current).date
+                    })
+    end
     # rubocop:enable Rails/SkipsModelValidations
   end
 end

--- a/spec/system/assigning/get_next_application_spec.rb
+++ b/spec/system/assigning/get_next_application_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Assigning an application to myself' do
   context 'when there is a next application' do
+    include_context 'with stubbed assignments and reviews'
     include_context 'when search results are returned'
 
     it 'allows you to get the next application' do

--- a/spec/system/closed_applications_dashboard_spec.rb
+++ b/spec/system/closed_applications_dashboard_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe 'Closed Applications Dashboard' do
   end
 
   it 'shows only closed applications' do
-    assert_api_searched_with_filter(
-      { application_status: 'closed' },
+    expect_datastore_to_have_been_searched_with(
+      { review_status: Types::REVIEW_STATUS_GROUPS['closed'] },
       sorting: Sorting.new(sort_by: 'reviewed_at', sort_direction: 'descending')
     )
   end

--- a/spec/system/errors_spec.rb
+++ b/spec/system/errors_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe 'Error pages' do
     end
 
     context 'when a datastore api error exists' do
+      include_context 'with stubbed assignments and reviews'
+
       before do
         stub_request(:post, "#{ENV.fetch('DATASTORE_API_ROOT')}/api/v1/searches")
           .to_raise error

--- a/spec/system/manage_users/revive_a_user_spec.rb
+++ b/spec/system/manage_users/revive_a_user_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'Revive a user' do
     end
   end
 
-  describe 'when user is not dormant' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+  describe 'when user is not dormant' do
     let(:normal_user) do
       User.create!(
         auth_subject_id: SecureRandom.uuid,
@@ -153,7 +153,7 @@ RSpec.describe 'Revive a user' do
     end
   end
 
-  describe 'when dormant user is deactivated' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+  describe 'when dormant user is deactivated' do
     let!(:inactive_user) do
       User.create!(
         auth_subject_id: SecureRandom.uuid,

--- a/spec/system/searching/filter_by_age_in_business_days_spec.rb
+++ b/spec/system/searching/filter_by_age_in_business_days_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe 'Search applications by age in business days' do
+  include_context 'with stubbed assignments and reviews'
+  include_context 'when search results are returned'
+
+  before do
+    visit '/'
+    click_link 'Search'
+  end
+
+  context 'when unassigned status is selected' do
+    let(:age) { '0 days' }
+
+    before do
+      select age, from: 'Business days since received'
+      click_button 'Search'
+    end
+
+    it 'passes the ids of applications of that age to the datastore search' do
+      expect_datastore_to_have_been_searched_with(
+        {
+          application_id_in: unassigned_application_ids,
+          review_status: Types::REVIEW_STATUS_GROUPS['open']
+        }
+      )
+    end
+
+    context 'when there are no applications of that age' do
+      let(:age) { '1 day' }
+
+      it 'returns an empty results set' do
+        expect(page).to have_content 'There are no results that match the search criteria'
+      end
+
+      it 'does not search the datastore' do
+        expect_datastore_not_to_have_been_searched
+      end
+
+      it '"1 day" remains selected on the results page' do
+        expect(page).to have_select('Business days since received', selected: '1 day')
+      end
+    end
+  end
+
+  describe 'options for selecting assigned status' do
+    it 'can choose from "", "0 days", "1 day", "2 days", "3 days"' do
+      choices = ['', '0 days', '1 day', '2 days', '3 days']
+      expect(page).to have_select('Business days since received', options: choices)
+    end
+  end
+end

--- a/spec/system/searching/filter_by_date_of_birth_spec.rb
+++ b/spec/system/searching/filter_by_date_of_birth_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe 'Search applications applicant date of birth filter' do
   end
 
   it 'searches by applicant date of birth' do
-    assert_api_searched_with_filter(:applicant_date_of_birth, dob)
+    expect_datastore_to_have_been_searched_with({
+                                                  applicant_date_of_birth: '2011-06-09',
+      review_status: Types::REVIEW_STATUS_GROUPS['open']
+                                                })
   end
 
   it 'remains selected on the results page' do

--- a/spec/system/searching/filter_by_date_range_spec.rb
+++ b/spec/system/searching/filter_by_date_range_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Search by submitted date' do
+  include_context 'with stubbed assignments and reviews'
   include_context 'when search results are returned'
 
   let(:after_date) { Date.parse('2023-06-08') }
@@ -10,16 +11,24 @@ RSpec.describe 'Search by submitted date' do
     visit '/'
     click_link 'Search'
 
-    fill_in 'filter-submitted-after-field', with: after_date
-    fill_in 'filter-submitted-before-field', with: before_date
+    fill_in 'Date from', with: after_date
+    fill_in 'Date to', with: before_date
 
     click_button 'Search'
   end
 
   it 'searches by submitted date' do
-    assert_api_searched_with_filter(
-      :submitted_before, before_date,
-      :submitted_after, after_date
+    expect_datastore_to_have_been_searched_with(
+      {
+        submitted_before: '2023-01-09 00:00:00 +0000',
+        submitted_after: '2023-06-08 00:00:00 +0100',
+        review_status: Types::REVIEW_STATUS_GROUPS['open']
+      }
     )
+  end
+
+  it 'remains selected on the results page' do
+    expect(page).to have_field('Date from', with: after_date)
+    expect(page).to have_field('Date to', with: before_date)
   end
 end

--- a/spec/system/searching/filter_by_status_spec.rb
+++ b/spec/system/searching/filter_by_status_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe 'Search applications status filter' do
       end
 
       it 'filters by status "completed"' do
-        assert_api_searched_with_filter(:application_status, 'sent_back')
+        expect_datastore_to_have_been_searched_with(
+          { review_status: Types::REVIEW_STATUS_GROUPS['sent_back'] }
+        )
         expect(page).to have_select(filter_field, selected: 'Sent back to provider')
       end
     end
@@ -44,7 +46,9 @@ RSpec.describe 'Search applications status filter' do
       end
 
       it 'filters by all statuses"' do
-        assert_api_searched_with_filter(:application_status, 'all')
+        expect_datastore_to_have_been_searched_with(
+          { review_status: Types::REVIEW_STATUS_GROUPS['all'] }
+        )
         expect(page).to have_select(filter_field, selected: 'All applications')
       end
     end


### PR DESCRIPTION
## Description of change
Users can search applications by age in business days.
This feature is currently only enabled in local environments.

## Link to relevant ticket
[CRIMAP-499](https://dsdmoj.atlassian.net/browse/CRIMAP-499)

## Notes for reviewer
The code surrounding the filter is more complex than I'd like. Most of this complexity arises because the data source for the search changes depending on which filters are active. "Caseworker" and "Business days since received" both use local data, while the remaining filters are for the datastore.

## Screenshots of changes (if applicable)

### Without the feature flag enabled:
<img width="882" alt="Screenshot 2023-07-28 at 14 04 04" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/91e1f9ce-0946-42bc-b2da-630b79d5d3ab">

### With the feature flag enabled:
<img width="887" alt="Screenshot 2023-07-28 at 14 03 30" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/35dea534-59f5-4412-a066-6fea23a330be">

## How to manually test the feature


[CRIMAP-499]: https://dsdmoj.atlassian.net/browse/CRIMAP-499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ