### PR TITLE
[CRIMAP-508] Introduce UserRole feature flag and db change

### DIFF
--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -34,12 +34,13 @@ module Types
     *REVIEW_STATUS_GROUPS.keys
   )
 
-  USER_ROLES = %w[
-    caseworker
-    supervisor
+  CASEWORKER_ROLE = 'caseworker'.freeze
+  SUPERVISOR_ROLE = 'supervisor'.freeze
+  USER_ROLES = [
+    CASEWORKER_ROLE,
+    SUPERVISOR_ROLE
   ].freeze
-  UserRole = String.enum(*USER_ROLES)
-  UserRoles = Array.of(UserRole)
+  UserRole = String.default(CASEWORKER_ROLE).enum(*USER_ROLES)
 
   ASSIGNED_STATUSES = %w[
     unassigned

--- a/app/models/concerns/user_role.rb
+++ b/app/models/concerns/user_role.rb
@@ -1,0 +1,41 @@
+module UserRole
+  extend ActiveSupport::Concern
+
+  # Deliberately duplicate constant names for use in
+  # permissions checks for brevity and explicitness
+  CASEWORKER = Types::CASEWORKER_ROLE
+  SUPERVISOR = Types::SUPERVISOR_ROLE
+
+  included do
+    # NOTE: mapping to PostgreSQL enum type via dry-types definition
+    enum role: Types::UserRole.mapping
+  end
+
+  def can_read_application?
+    [CASEWORKER, SUPERVISOR].include?(@role)
+  end
+
+  def can_write_application?
+    [SUPERVISOR].include?(@role)
+  end
+
+  def service_user?
+    [CASEWORKER, SUPERVISOR].include?(@role) && !can_manage_others?
+  end
+
+  def user_manager?
+    can_manage_others?
+  end
+
+  # TODO: Any reason to not allow supervisor to be 'downgraded' to caseworker?
+  def can_change_role?
+    return false if dormant?
+    return false unless activated?
+
+    FeatureFlags.basic_user_roles.enabled? && activated?
+  end
+
+  def toggle_role
+    self.role = @toggle_role ||= ([CASEWORKER, SUPERVISOR] - [role]).first.to_s
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   include AuthUpdateable
   include Reauthable
   include Revivable
+  include UserRole
 
   before_create :set_invitation_expires_at
 
@@ -96,10 +97,6 @@ class User < ApplicationRecord
 
   def set_invitation_expires_at
     self.invitation_expires_at = Rails.configuration.x.auth.invitation_ttl.from_now
-  end
-
-  def service_user?
-    !can_manage_others?
   end
 
   # Overwrite the Devise model's #active_for_authentication? to return false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,6 +7,10 @@ feature_flags:
     local: false
     staging: true
     production: false # user managers should not access the service in production
+  basic_user_roles:
+    local: true
+    staging: true
+    production: false
   filter_search_by_age_in_business_days:
     local: true
     staging: false

--- a/db/migrate/20230726220616_add_role_enum_to_users.rb
+++ b/db/migrate/20230726220616_add_role_enum_to_users.rb
@@ -1,0 +1,19 @@
+class AddRoleEnumToUsers < ActiveRecord::Migration[7.0]
+  def up
+    roles = Types::UserRole.values.map { |r| "'#{r}'" }.join(', ')
+
+    execute <<-SQL
+      CREATE TYPE user_role AS ENUM (#{roles});
+    SQL
+
+    add_column :users, :role, :user_role, null: false, default: 'caseworker', index: true
+  end
+
+  def down
+    remove_column :users, :role
+
+    execute <<-SQL
+      DROP TYPE user_role;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_24_092947) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_26_220616) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  # Custom types defined in this database.
+  # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "user_role", ["caseworker", "supervisor"]
 
   create_table "current_assignments", id: false, force: :cascade do |t|
     t.uuid "user_id", null: false
@@ -77,10 +81,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_092947) do
     t.datetime "last_auth_at", precision: nil
     t.datetime "first_auth_at", precision: nil
     t.string "auth_subject_id"
-    t.boolean "can_manage_others", default: false, null: false
     t.datetime "deactivated_at", precision: nil
     t.datetime "invitation_expires_at"
     t.datetime "revive_until"
+    t.boolean "can_manage_others", default: false, null: false
+    t.enum "role", default: "caseworker", null: false, enum_type: "user_role"
     t.index ["auth_subject_id"], name: "index_users_on_auth_subject_id", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
   end


### PR DESCRIPTION
## Description of change
Adds feature flag and db change only to show usage of `Types::UserRole` dry-struct in postgresql enum

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-508

## Notes for reviewer
1. Is the re-use of the Types::UserRole appropriate? [See](https://github.com/ministryofjustice/laa-review-criminal-legal-aid/pull/377) for the `ChangeRole` command which enforces the role type using a dry-struct attribute.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
