### PR TITLE
[CRIMAP-509/510] Add supervisor performance tracking page

### DIFF
--- a/app/controllers/performance_tracking_controller.rb
+++ b/app/controllers/performance_tracking_controller.rb
@@ -1,0 +1,14 @@
+class PerformanceTrackingController < ServiceController
+  before_action :require_supervisor!
+
+  def index; end
+
+  private
+
+  def require_supervisor!
+    return if current_user.supervisor? && FeatureFlags.basic_user_roles.enabled?
+
+    render status: :not_found, template: 'errors/not_found', layout: 'errors'
+    false
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -2,6 +2,8 @@
   <%= header.with_navigation_item(text: current_user.name) %>
   <% if current_user.can_manage_others %>
     <%= header.with_navigation_item(text: t('.manage_users'), href: admin_manage_users_root_path) %>
+  <% elsif current_user.supervisor? && FeatureFlags.basic_user_roles.enabled? %>
+    <%= header.with_navigation_item(text: t('.performance_tracking'), href: performance_tracking_index_path) %>
   <% end %>
   <%= header.with_navigation_item(text: t('calls_to_action.sign_out'), href: destroy_user_session_path) %>
 <% end %>

--- a/app/views/performance_tracking/index.html.erb
+++ b/app/views/performance_tracking/index.html.erb
@@ -1,0 +1,9 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">
+      <%= t '.heading' %>
+    </h1>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
   layouts:
     header:
       manage_users: Manage users
+      performance_tracking: Performance tracking
 
   date:
     formats:

--- a/config/locales/en/performance_tracking.yml
+++ b/config/locales/en/performance_tracking.yml
@@ -1,0 +1,5 @@
+en:
+  performance_tracking:
+    index:
+      page_title: Performance tracking
+      heading: Performance tracking

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,8 @@ Rails.application.routes.draw do
     get :search, on: :collection
   end
 
+  resources :performance_tracking, only: [:index]
+
   resources :assigned_applications, only: [:index, :destroy, :create] do
     post :next_application, on: :collection
   end

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe 'Authorisation' do
     include_context 'with stubbed search'
 
     before do
-      user = User.create(email: 'Ben.EXAMPLE@example.com', can_manage_others: true, role: Types::CASEWORKER_ROLE)
+      user = User.create(email: 'Ben.EXAMPLE@example.com', can_manage_others: true)
       sign_in user
     end
 

--- a/spec/shared_contexts/with_a_logged_in_user.rb
+++ b/spec/shared_contexts/with_a_logged_in_user.rb
@@ -15,11 +15,14 @@ RSpec.shared_context 'with a logged in user', shared_context: :metadata do
       auth_subject_id: current_user_auth_subject_id,
       first_auth_at: 1.month.ago,
       last_auth_at: 1.hour.ago,
-      can_manage_others: current_user_can_manage_others
+      can_manage_others: current_user_can_manage_others,
+      role: current_user_role
     )
   end
 
   let(:current_user_can_manage_others) { false }
+
+  let(:current_user_role) { UserRole::CASEWORKER }
 
   let(:current_user_id) { current_user.id }
 

--- a/spec/system/header_nav_spec.rb
+++ b/spec/system/header_nav_spec.rb
@@ -82,4 +82,29 @@ RSpec.describe 'Header navigation' do
       end
     end
   end
+
+  context 'when user does not have access to the performance tracking tab' do
+    before do
+      visit '/'
+    end
+
+    it 'does not have a link to performance tracking' do
+      header = page.first('.govuk-header__navigation-list').text
+      expect(header).not_to include('Performance tracking')
+    end
+  end
+
+  context 'when a user has access to the performance tracking tab' do
+    let(:current_user_role) { UserRole::SUPERVISOR }
+
+    before do
+      visit '/'
+    end
+
+    it 'shows the "Performance tracking" link and can follow it' do
+      expect { click_link('Performance tracking') }.to change {
+        page.first('.govuk-heading-xl').text
+      }.from('Your list').to('Performance tracking')
+    end
+  end
 end

--- a/spec/system/performance_tracking/viewing_spec.rb
+++ b/spec/system/performance_tracking/viewing_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Performance Tracking Dashboard' do
+RSpec.describe 'Performance Tracking' do
   describe 'User does not have access to performance tracking' do
     include_context 'when logged in user is admin'
 

--- a/spec/system/performance_tracking/viewing_spec.rb
+++ b/spec/system/performance_tracking/viewing_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe 'Performance Tracking Dashboard' do
+  describe 'User does not have access to performance tracking' do
+    include_context 'when logged in user is admin'
+
+    context 'when logged in as user manager' do
+      before do
+        visit performance_tracking_index_path
+      end
+
+      it 'redirects to "Manage Users" dashboard' do
+        heading_text = page.first('.govuk-heading-xl').text
+        expect(heading_text).to eq('Manage users')
+      end
+    end
+
+    context 'when logged in as caseworker' do
+      let(:current_user_can_manage_others) { false }
+
+      before do
+        visit performance_tracking_index_path
+      end
+
+      it 'redirects to "Page not" found' do
+        heading_text = page.first('.govuk-heading-xl').text
+        expect(heading_text).to eq('Page not found')
+      end
+    end
+  end
+
+  describe 'User does have access to performance tracking' do
+    context 'when logged in as supervisor' do
+      let(:current_user_role) { UserRole::SUPERVISOR }
+
+      before do
+        visit performance_tracking_index_path
+      end
+
+      it 'can access "Performance tracking" page' do
+        heading_text = page.first('.govuk-heading-xl').text
+        expect(heading_text).to eq('Performance tracking')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Adds performance tracking page `/performance_tracking` which is hidden behind the `BasicUserRoles` feature flag and access is restricted to supervisors only.
Upon hitting the url, caseworkers are shown a 404 page and user managers are redirected to the manage users dashboard. The tab is also hidden from both user types. 

## Link to relevant ticket
[CRIMAP-509](https://dsdmoj.atlassian.net/browse/CRIMAP-509)
[CRIMAP-510](https://dsdmoj.atlassian.net/browse/CRIMAP-510)

## Notes for reviewer
Not a fan of the Performance tracking name 😅 I'm assuming this is just a placeholder but other names are welcome 😄
Also now that we are introducing new roles and routes, it is worth potentially rethinking the current `authentication_spec.rb` format as I can see it becoming a big file down the line. Perhaps the testing of which areas of the service each role has access to could be split into different files?  

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

**Supervisor view** 
<img width="1352" alt="Screenshot 2023-08-04 at 11 51 44" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/80256341-8ff1-4941-b3cf-774df08be6c2">

**Caseworker view**
<img width="1070" alt="Screenshot 2023-08-04 at 11 52 26" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/6787530f-257c-41b5-a8db-4ce9163d03aa">

<img width="1337" alt="Screenshot 2023-08-04 at 11 52 37" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/85ca24a3-0398-4d2c-982f-2576b0009379">

**User manager view**

<img width="1070" alt="Screenshot 2023-08-04 at 11 52 12" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/865c37cc-3b9a-43c3-9ccf-3e9cd8d8a713">

## How to manually test the feature


[CRIMAP-509]: https://dsdmoj.atlassian.net/browse/CRIMAP-509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAP-510]: https://dsdmoj.atlassian.net/browse/CRIMAP-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ