### PR TITLE
CRIMRE-499 Update filter label text

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -16,6 +16,10 @@ form.search {
   input[type=date] {
     width: 8em;
   }
+
+  select#filter-age-in-business-days-field.govuk-select {
+    width: 100%;
+  }
 }
 
 p.help-text, #superseded_style  {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,7 +89,7 @@ en:
     manage_users: Manage users
 
   labels: &LABELS
-    age_in_business_days: Business days since received
+    age_in_business_days: Business days since application was received
     applicant_date_of_birth: Applicant's date of birth
     application_information: Application information
     application_start_date: Date stamp

--- a/spec/system/searching/filter_by_age_in_business_days_spec.rb
+++ b/spec/system/searching/filter_by_age_in_business_days_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Search applications by age in business days' do
     let(:age) { '0 days' }
 
     before do
-      select age, from: 'Business days since received'
+      select age, from: 'Business days since application was received'
       click_button 'Search'
     end
 
@@ -38,7 +38,7 @@ RSpec.describe 'Search applications by age in business days' do
       end
 
       it '"1 day" remains selected on the results page' do
-        expect(page).to have_select('Business days since received', selected: '1 day')
+        expect(page).to have_select('Business days since application was received', selected: '1 day')
       end
     end
   end
@@ -46,7 +46,7 @@ RSpec.describe 'Search applications by age in business days' do
   describe 'options for selecting assigned status' do
     it 'can choose from "", "0 days", "1 day", "2 days", "3 days"' do
       choices = ['', '0 days', '1 day', '2 days', '3 days']
-      expect(page).to have_select('Business days since received', options: choices)
+      expect(page).to have_select('Business days since application was received', options: choices)
     end
   end
 end


### PR DESCRIPTION
## Description of change
Update the filter label copy and increase the select width to be the same as the label.

## Link to relevant ticket
[CRIMAP-499](https://dsdmoj.atlassian.net/browse/CRIMAP-499)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1049" alt="Screenshot 2023-08-07 at 14 52 46" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/85cae46f-7235-4fed-9161-39686d75c4f1">


### After changes:
<img width="908" alt="Screenshot 2023-08-07 at 14 53 41" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/606b2e06-fd3b-4200-87c8-c86a68c92def">


<img width="897" alt="Screenshot 2023-08-07 at 14 41 19" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/008762b2-281e-44c9-a950-e43fde518177">

## How to manually test the feature


[CRIMAP-499]: https://dsdmoj.atlassian.net/browse/CRIMAP-499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ