### PR TITLE
Ensure only user managers can access parts of the service on staging

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   end
 
   def allow_user_managers_service_access?
-    FeatureFlags.allow_user_managers_service_access.enabled?
+    current_user.can_manage_others? && FeatureFlags.allow_user_managers_service_access.enabled?
   end
 
   # Redirect user managers to manage users' admin on sign in

--- a/spec/system/performance_tracking/viewing_spec.rb
+++ b/spec/system/performance_tracking/viewing_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Performance Tracking' do
   describe 'User does not have access to performance tracking' do
     include_context 'when logged in user is admin'
 
-    context 'when logged in as user manager (non staging)' do
+    context 'when logged in as a user manager' do
       before do
         visit performance_tracking_index_path
       end
@@ -15,7 +15,7 @@ RSpec.describe 'Performance Tracking' do
       end
     end
 
-    context 'when logged in as caseworker' do
+    context 'when logged in as a caseworker' do
       let(:current_user_can_manage_others) { false }
 
       before do
@@ -30,7 +30,7 @@ RSpec.describe 'Performance Tracking' do
   end
 
   describe 'User does have access to performance tracking' do
-    context 'when logged in as supervisor' do
+    context 'when logged in as a supervisor' do
       let(:current_user_role) { UserRole::SUPERVISOR }
 
       before do

--- a/spec/system/performance_tracking/viewing_spec.rb
+++ b/spec/system/performance_tracking/viewing_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe 'Performance Tracking' do
     end
 
     context 'when user managers are logged in on staging' do
+      let(:current_user_can_manage_others) { true }
+
       before do
         allow(FeatureFlags).to receive(:allow_user_managers_service_access) {
           instance_double(FeatureFlags::EnabledFeature, enabled?: true)

--- a/spec/system/performance_tracking/viewing_spec.rb
+++ b/spec/system/performance_tracking/viewing_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Performance Tracking' do
   describe 'User does not have access to performance tracking' do
     include_context 'when logged in user is admin'
 
-    context 'when logged in as user manager' do
+    context 'when logged in as user manager (non staging)' do
       before do
         visit performance_tracking_index_path
       end
@@ -43,9 +43,7 @@ RSpec.describe 'Performance Tracking' do
       end
     end
 
-    context 'when user managers are logged in on staging' do
-      let(:current_user_can_manage_others) { true }
-
+    context 'when logged in on staging' do
       before do
         allow(FeatureFlags).to receive(:allow_user_managers_service_access) {
           instance_double(FeatureFlags::EnabledFeature, enabled?: true)
@@ -53,9 +51,18 @@ RSpec.describe 'Performance Tracking' do
         visit performance_tracking_index_path
       end
 
-      it 'can access "Performance tracking" page' do
+      it 'redirects to "Page not" found for caseworkers' do
         heading_text = page.first('.govuk-heading-xl').text
-        expect(heading_text).to eq('Performance tracking')
+        expect(heading_text).to eq('Page not found')
+      end
+
+      context 'when logged in as a user manager' do
+        let(:current_user_can_manage_others) { true }
+
+        it 'can access "Performance tracking" page as a user manager' do
+          heading_text = page.first('.govuk-heading-xl').text
+          expect(heading_text).to eq('Performance tracking')
+        end
       end
     end
   end


### PR DESCRIPTION
## Description of change
The service and performance tracking page are accessible to user managers by enabling the `allow_user_managers_service_access` feature flag on staging. However, whether the feature flag was enabled was the only condition being checked in the controllers meaning every user has access to the feature on staging as the feature flag is enabled for all on staging. This was not obvious previously as the service is also accessible to caseworkers and supervisors.

This condition has been changed to check whether a user can manage others as well as checking that the feature flag is enabled and tests have been modified to check both caseworker and user manager access of the performance tracking page on staging

## Link to relevant ticket
[CRIMAP-535](https://dsdmoj.atlassian.net/browse/CRIMAP-535)

## Notes for reviewer
Merging this PR initially to prevent merging being blocked, will follow up with a pr to refactor specs 

## Screenshots of changes (if applicable)

### Before changes:
Currently on staging the performance tracking tab is accessible to caseworkers when it shouldn't be 
<img width="1487" alt="Screenshot 2023-08-09 at 10 05 40" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/ea141d13-c8a2-40a3-bea4-8742ca3555b7">

### After changes:

## How to manually test the feature


[CRIMAP-535]: https://dsdmoj.atlassian.net/browse/CRIMAP-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ