### PR TITLE
Set default puma port to 3001 to avoid clashing

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -26,6 +26,11 @@ DEV_AUTH_ENABLED=true
 # Notify API change here to test actual Notify calls in Dev
 GOVUK_NOTIFY_API_KEY=notify-api-key
 
+# Specify a port to avoid clashing with other local services
+PORT=3001
+# Or set a development host for the app
+# DEVELOPMENT_HOST='review-criminal-applications.test'
+
 # If set, enables prometheus middleware and server
 # ENABLE_PROMETHEUS_EXPORTER=true
 # PROMETHEUS_EXPORTER_VERBOSE=false

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-web: bin/rails server -p 3000
+web: bin/rails server -p 3001
 css: bin/rails dartsass:watch

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,4 +70,7 @@ Rails.application.configure do
 
   # Add the development host if set
   config.hosts += [ENV["DEVELOPMENT_HOST"]]
+
+  # Allow connections from inside a docker container to this host machine
+  config.hosts += %w[host.docker.internal]
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     environment:
       ENV_NAME: staging
       RAILS_ENV: production
+      PORT: 3001
       DATABASE_URL: postgresql://postgres@db/laa-review-criminal-legal-aid
       SECRET_KEY_BASE: f22760a0bd78a9191ba4c247e23a281cb251461cdba6b5215043ca11b694d734
       GOVUK_NOTIFY_API_KEY: notify-api-key
@@ -27,7 +28,7 @@ services:
       DEV_AUTH_ENABLED: "true"
       IS_LOCAL_DOCKER_ENV: "true"
     ports:
-      - "3000:3000" # puma server (rails app)
+      - "3001:3001" # puma server (rails app)
       - "9394:9394" # prometheus exporter `/metrics` endpoint
     depends_on:
       - db


### PR DESCRIPTION
## Description of change
We run Apply on port 3000 and Datastore on port 3003 by default, either when running the rails application locally or when using docker-compose.

However Review was by default using port 3000 too, clashing with Apply when all 3 apps needed to be run to produce an end-to-end journey.

This change makes the port 3001 the default one for Review. It is still possible to locally override this by exposing `PORT=X` in your `.env.development.local` file if you are used to a different port.

Additionally support connections from _inside_ a docker container (for instance localstack) to the application running in the host machine (_not_ as a container).

## How to manually test the feature
Running `rails s` and running `docker-compose up` should run both the app in port 3001 (unless you override it with the ENV variable PORT).