### PR TITLE
Lock down permissions for access to performance tracking

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   end
 
   def allow_user_managers_service_access?
-    current_user.can_manage_others? && FeatureFlags.allow_user_managers_service_access.enabled?
+    FeatureFlags.allow_user_managers_service_access.enabled?
   end
 
   # Redirect user managers to manage users' admin on sign in

--- a/app/controllers/performance_tracking_controller.rb
+++ b/app/controllers/performance_tracking_controller.rb
@@ -10,7 +10,7 @@ class PerformanceTrackingController < ServiceController
   # Users that can manage others can access this on staging for testing purposes.
   def require_supervisor!
     return if current_user.service_user_supervisor?
-    return if allow_user_managers_service_access? && current_user.admin_user_supervisor?
+    return if allow_user_managers_service_access? && current_user.user_manager_supervisor?
 
     render status: :not_found, template: 'errors/not_found', layout: 'errors'
     false

--- a/app/controllers/performance_tracking_controller.rb
+++ b/app/controllers/performance_tracking_controller.rb
@@ -7,8 +7,8 @@ class PerformanceTrackingController < ServiceController
 
   # Users that can manage others can access this on staging for testing purposes.
   def require_supervisor!
-    return if current_user.supervisor? && FeatureFlags.basic_user_roles.enabled?
-    return if allow_user_managers_service_access?
+    return if current_user.service_user_supervisor?
+    return if allow_user_managers_service_access? && current_user.admin_user_supervisor?
 
     render status: :not_found, template: 'errors/not_found', layout: 'errors'
     false

--- a/app/models/concerns/user_role.rb
+++ b/app/models/concerns/user_role.rb
@@ -23,8 +23,17 @@ module UserRole
     [CASEWORKER, SUPERVISOR].include?(role) && !can_manage_others?
   end
 
+  def service_user_supervisor?
+    FeatureFlags.basic_user_roles.enabled? && [SUPERVISOR].include?(role) && !can_manage_others?
+  end
+
   def user_manager?
     can_manage_others?
+  end
+
+  # A dev only user state for debugging in staging, not found in production environments
+  def user_manager_supervisor?
+    user_manager? && FeatureFlags.basic_user_roles.enabled? && [SUPERVISOR].include?(role)
   end
 
   # TODO: Any reason to not allow supervisor to be 'downgraded' to caseworker?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,15 +51,6 @@ class User < ApplicationRecord
     email
   end
 
-  def service_user_supervisor?
-    FeatureFlags.basic_user_roles.enabled? && supervisor? && !can_manage_others?
-  end
-
-  # A dev only user state for debugging in staging, not found in production environments
-  def admin_user_supervisor?
-    FeatureFlags.basic_user_roles.enabled? && supervisor? && can_manage_others?
-  end
-
   def history
     @history ||= AuthorisationHistory.new(user_id: id)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,15 @@ class User < ApplicationRecord
     email
   end
 
+  def service_user_supervisor?
+    FeatureFlags.basic_user_roles.enabled? && supervisor? && !can_manage_others?
+  end
+
+  # A dev only user state for debugging in staging, not found in production environments
+  def admin_user_supervisor?
+    FeatureFlags.basic_user_roles.enabled? && supervisor? && can_manage_others?
+  end
+
   def history
     @history ||= AuthorisationHistory.new(user_id: id)
   end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,7 +3,7 @@
   <% if current_user.can_manage_others %>
     <%= header.with_navigation_item(text: t('.manage_users'), href: admin_manage_users_root_path) %>
   <% end %>
-  <% if (current_user.supervisor? && FeatureFlags.basic_user_roles.enabled?) || allow_user_managers_service_access? %>
+  <% if current_user.service_user_supervisor? || (allow_user_managers_service_access? && current_user.admin_user_supervisor?)%>
     <%= header.with_navigation_item(text: t('.performance_tracking'), href: performance_tracking_index_path) %>
   <% end %>
   <%= header.with_navigation_item(text: t('calls_to_action.sign_out'), href: destroy_user_session_path) %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,7 +3,7 @@
   <% if current_user.can_manage_others %>
     <%= header.with_navigation_item(text: t('.manage_users'), href: admin_manage_users_root_path) %>
   <% end %>
-  <% if current_user.service_user_supervisor? || (allow_user_managers_service_access? && current_user.admin_user_supervisor?)%>
+  <% if current_user.service_user_supervisor? || (allow_user_managers_service_access? && current_user.user_manager_supervisor?)%>
     <%= header.with_navigation_item(text: t('.performance_tracking'), href: performance_tracking_index_path) %>
   <% end %>
   <%= header.with_navigation_item(text: t('calls_to_action.sign_out'), href: destroy_user_session_path) %>

--- a/spec/system/header_nav_spec.rb
+++ b/spec/system/header_nav_spec.rb
@@ -81,10 +81,18 @@ RSpec.describe 'Header navigation' do
                                                  }.from('Your list').to('Manage users')
       end
 
-      it 'shows the "Performance tracking" link and it can be followed' do
-        expect { click_link('Performance tracking') }.to change {
-          page.first('.govuk-heading-xl').text
-        }.from('Your list').to('Performance tracking')
+      it 'does not show the "Performance tracking" link' do
+        expect(page).not_to have_link('Performance tracking')
+      end
+
+      context 'when user managers are logged in as supervisors' do
+        let(:current_user_role) { UserRole::SUPERVISOR }
+
+        it 'shows the "Performance tracking" link and it can be followed' do
+          expect { click_link('Performance tracking') }.to change {
+                                                             page.first('.govuk-heading-xl').text
+                                                           }.from('Your list').to('Performance tracking')
+        end
       end
     end
   end


### PR DESCRIPTION
## Description of change
Ensure that should a user_manager have a Supervisor role in prod that they cannot see the Performance tracking nav link

Make user_manager permissions in staging when holding a caseworker role the same as they would be for a non-user manager caseworker in prod for QA and debugging.

## Link to relevant ticket

## Notes for reviewer
Please can someone read the performance_tracking/viewing_spec fairly carefully to check my logic.

My assumption has been to that if manually testing a caseworker-only feature on staging a dev will still be set as a user_manager and will want to see what a caseworker would see in prod. And if manually testing a supervisor feature, then would want to see what a supervisor can see and therefore will need to get another user_manager to toggle them to be a supervisor - and only then see the feature.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
