### PR TITLE
Skip some SNS security controls in development mode

### DIFF
--- a/app/services/aws/sns_service.rb
+++ b/app/services/aws/sns_service.rb
@@ -11,19 +11,25 @@ module Aws
     end
 
     # @return [Symbol] rails HTTP status name
+    # rubocop:disable Metrics/AbcSize
     def call
       if sns_event.confirmation? && confirmation_allowed?
+        Rails.logger.info "[#{self.class.name}] Confirmation event. URL: #{sns_event.subscribe_url}"
         sns_event.confirm!
+        Rails.logger.info "[#{self.class.name}] Subscription successfully confirmed."
         :ok
       elsif sns_event.notification?
+        Rails.logger.info "[#{self.class.name}] Event received: #{sns_event.message}"
         sns_event.create!
         :created
       else
         :forbidden
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     def allowed?
+      return true if local_bypass?
       return false unless topic_allowed?
 
       message_verifier.authenticate!(sns_event.to_json)
@@ -40,12 +46,17 @@ module Aws
     end
 
     def confirmation_allowed?
+      return true if local_bypass?
       return false if sns_event.subscribe_url.blank?
 
       ALLOWED_AWS_ACCOUNTS.any? { |arn| sns_event.subscribe_url.include?(arn) }
     end
 
     private
+
+    def local_bypass?
+      Rails.env.development?
+    end
 
     def message_verifier
       @message_verifier ||= Aws::SNS::MessageVerifier.new


### PR DESCRIPTION
## Description of change
With the purpose of facilitate an end-to-end journey in localhost, using LocalStack for SNS and http callbacks, we skip the ARN allowlist, and the Signature verification.

Also added some meaningful logging which is interesting to have to diagnose any issues. Also if running Review in a docker container, the subscription will not be confirmed automatically, so logging the URL is needed to confirm it manually by visiting the URL.

This works along with PR in datastore:
https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/144

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-530

## Notes for reviewer
Happy to discuss if this is not desirable or if we favour a different approach. This is the simplest thing it came to mind without causing too much trouble.

## How to manually test the feature
Checkout this branch and start the rails app locally (do not use docker-compose)
Checkout the datastore PR and run `docker-compose up localstack`
At this point the subscription confirmation should have been received on Review and successfully confirmed.

Expose `EVENTS_SNS_TOPIC_ARN` env variable in data store and restart server if you also want to test events, like when an application is submitted from Apply, the event will be received in the SNS and published to the Review endpoint where it will be processed successfully.