### PR TITLE
Tweak docker-compose

### DIFF
--- a/app/lib/prometheus_metrics/configuration.rb
+++ b/app/lib/prometheus_metrics/configuration.rb
@@ -4,9 +4,6 @@ module PrometheusMetrics
     require_relative 'collectors'
 
     DEFAULT_PREFIX = 'ruby_'.freeze
-    SERVER_BINDING_HOST = '0.0.0.0'.freeze
-    SERVER_BINDING_PORT = 9394
-
     CUSTOM_COLLECTORS = [
       # Add custom collector classes here
     ].freeze
@@ -28,7 +25,7 @@ module PrometheusMetrics
     # exporter process separately (`bundle exec prometheus_exporter`)
     def self.start_server
       server = PrometheusExporter::Server::WebServer.new(
-        bind: SERVER_BINDING_HOST, port: SERVER_BINDING_PORT,
+        bind: '0.0.0.0', port: ENV.fetch('PROMETHEUS_EXPORTER_PORT', 9394).to_i,
         verbose: ENV.fetch('PROMETHEUS_EXPORTER_VERBOSE', 'false').inquiry.true?
       )
 

--- a/app/services/aws/sns_service.rb
+++ b/app/services/aws/sns_service.rb
@@ -55,7 +55,7 @@ module Aws
     private
 
     def local_bypass?
-      Rails.env.development?
+      Rails.env.development? || ENV.key?('IS_LOCAL_DOCKER_ENV')
     end
 
     def message_verifier

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,12 @@ services:
       PORT: 3001
       DATABASE_URL: postgresql://postgres@db/laa-review-criminal-legal-aid
       SECRET_KEY_BASE: f22760a0bd78a9191ba4c247e23a281cb251461cdba6b5215043ca11b694d734
+      DATASTORE_API_ROOT: http://host.docker.internal:3003
+      DATASTORE_API_AUTH_SECRET: foobar
       GOVUK_NOTIFY_API_KEY: notify-api-key
       RAILS_SERVE_STATIC_FILES: "1"
-      ENABLE_PROMETHEUS_EXPORTER: "true"
+      ENABLE_PROMETHEUS_EXPORTER: "false" # can be enabled for quick tests
+      PROMETHEUS_EXPORTER_PORT: 9395
       RAILS_LOG_TO_STDOUT: "1"
       DATABASE_SSLMODE: disable
       DISABLE_HTTPS: "1"
@@ -29,6 +32,6 @@ services:
       IS_LOCAL_DOCKER_ENV: "true"
     ports:
       - "3001:3001" # puma server (rails app)
-      - "9394:9394" # prometheus exporter `/metrics` endpoint
+      - "9395:9395" # prometheus exporter `/metrics` endpoint
     depends_on:
       - db


### PR DESCRIPTION
## Description of change
With the objective of being able to run all 3 services (apply, review and datastore) at the same time as docker containers, some tweaks are needed.

Prometheus exporter port was hardcoded, it needs to be different in each container otherwise it will clash. Also by default now is disabled as most of the time we will never need it locally, but can be enabled for quick tests.

Added the datastore dummy credentials and endpoint (it works wether datastore is running also in a container, or on the host machine, assuming it's running in port 3003).

Added local docker to SNS bypass, for when Review is running as docker container.

## How to manually test the feature
`docker-compose up` will no longer run prometheus exporter. If datastore is up and running in port 3003, Review container will be able to talk to datastore too. SNS will work but requires manually confirming the subscription by visiting the URL logged to stdout.