### PR TITLE
Docker compose works with apple silicon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN apk --no-cache add --virtual build-deps \
   linux-headers \
   xz-libs \
   tzdata \
-  yarn
+  yarn \
+  gcompat
 
 # Alpine does not have a glibc, and this is needed for dart-sass
 # Refer to: https://github.com/sgerrand/alpine-pkg-glibc

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,6 @@ RUN apk --no-cache add --virtual build-deps \
   yarn \
   gcompat
 
-# Alpine does not have a glibc, and this is needed for dart-sass
-# Refer to: https://github.com/sgerrand/alpine-pkg-glibc
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk
-RUN apk add --force-overwrite glibc-2.34-r0.apk
-RUN apk fix --force-overwrite alpine-baselayout-data
-
-
 # add non-root user and group with alpine first available uid, 1000
 RUN addgroup -g 1000 -S appgroup && \
     adduser -u 1000 -S appuser -G appgroup

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'turbo-rails'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false
 
-gem 'dartsass-rails', '~> 0.4.0'
+gem 'dartsass-rails', '~> 0.5.0'
 
 # Exceptions notifications
 gem 'sentry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,8 +147,9 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    dartsass-rails (0.4.1)
+    dartsass-rails (0.5.0)
       railties (>= 6.0.0)
+      sass-embedded (~> 1.63)
     date (3.3.3)
     debug (1.8.0)
       irb (>= 1.5.0)
@@ -215,6 +216,7 @@ GEM
     faraday-net_http (3.0.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    google-protobuf (3.24.0)
     govuk-components (4.0.0)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (~> 6.0)
@@ -460,6 +462,9 @@ GEM
       rack
       ruby_event_store (= 2.9.1)
     rubyzip (2.3.2)
+    sass-embedded (1.64.2)
+      google-protobuf (~> 3.23)
+      rake (>= 13.0.0)
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -547,7 +552,7 @@ DEPENDENCIES
   brakeman
   business
   capybara
-  dartsass-rails (~> 0.4.0)
+  dartsass-rails (~> 0.5.0)
   debug
   devise
   dotenv-rails


### PR DESCRIPTION
## Description of change

Add gcombat and update dart-sass to allow ```docker-compose up``` with Apple Silicon

## Link to relevant ticket

## Notes for reviewer

gcombat allows glibc programs to be run in Alpine Linux (https://wiki.alpinelinux.org/wiki/Running_glibc_programs)

It was also necessary to update dart-sass to a version that correctly understands the architecture it is working in.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

To make sure this does not introduce a regression on Intel Mac, remove any docker files you may already have and run  ```docker-compose up``` 