### PR TITLE
Update postgres client to fix vulns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@ MAINTAINER LAA Crime Apply Team
 
 RUN apk --no-cache add --virtual build-deps \
   build-base \
-  postgresql-dev \
+  postgresql15-dev \
   git \
   bash \
   curl \
 && apk --no-cache add \
-  postgresql-client \
+  postgresql15-client \
   shared-mime-info \
   linux-headers \
   xz-libs \


### PR DESCRIPTION
## Description of change
The `postgresql-dev` and `postgresql-client` packages used in the Dockerfile were outdated, now that we are running postgres 15.x (locally, CI and also cloud platform through RDS).

This ensure alpine build the image using latest versions of the postgres libraries.

## Link to relevant ticket
More info in slack thread
https://mojdt.slack.com/archives/C056U956ESH/p1692175607705879