### PR TITLE
CRIMAP-534 Link to caseworker events to temporal streams.

### DIFF
--- a/app/read_models/caseworker_reports/configuration.rb
+++ b/app/read_models/caseworker_reports/configuration.rb
@@ -1,0 +1,21 @@
+module CaseworkerReports
+  # CaseworkerReports read model event store configuration
+  #
+  # Links caseworker report related events to day, week, and month streams.
+  #
+  class Configuration
+    READ_MODEL_CHANGING_EVENTS = [
+      Assigning::AssignedToUser,
+      Assigning::ReassignedToUser,
+      Assigning::UnassignedFromUser,
+      Reviewing::SentBack,
+      Reviewing::Completed
+    ].freeze
+
+    def call(event_store)
+      event_store.subscribe(
+        CaseworkerReports::LinkToTemporalStreams, to: READ_MODEL_CHANGING_EVENTS
+      )
+    end
+  end
+end

--- a/app/read_models/caseworker_reports/link_to_temporal_streams.rb
+++ b/app/read_models/caseworker_reports/link_to_temporal_streams.rb
@@ -1,0 +1,15 @@
+module CaseworkerReports
+  class LinkToTemporalStreams
+    def initialize(event_store: Rails.configuration.event_store)
+      @event_store = event_store
+    end
+
+    def call(event)
+      date = event.timestamp.in_time_zone('London').to_date
+
+      @event_store.link [event.event_id], stream_name: date.strftime('MonthlyCaseworker$%Y-%m')
+      @event_store.link [event.event_id], stream_name: date.strftime('WeeklyCaseworker$%G-%V')
+      @event_store.link [event.event_id], stream_name: date.strftime('DailyCaseworker$%Y-%j')
+    end
+  end
+end

--- a/config/initializers/event_store.rb
+++ b/config/initializers/event_store.rb
@@ -8,4 +8,5 @@ Rails.configuration.to_prepare do
   CurrentAssignments::Configuration.new.call(event_store)
   ReceivedOnReports::Configuration.new.call(event_store)
   Reviews::Configuration.new.call(event_store)
+  CaseworkerReports::Configuration.new.call(event_store)
 end

--- a/spec/read_models/caseworker_reports/configuration_spec.rb
+++ b/spec/read_models/caseworker_reports/configuration_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe CaseworkerReports::Configuration do
+  let(:event_store) { Rails.configuration.event_store }
+  let(:event) { Reviewing::Completed.new }
+
+  describe '#configuration' do
+    before do
+      described_class.new.call(event_store)
+
+      travel_to Time.zone.local(2023, 8, 1, 0, 1)
+      event_store.publish(event)
+    end
+
+    it 'links caseworker report events to monthly, weekly, and daily temporal streams' do
+      ['MonthlyCaseworker$2023-08', 'WeeklyCaseworker$2023-31', 'DailyCaseworker$2023-213'].each do |stream_name|
+        stream_events = event_store.read.stream(stream_name).to_a
+        expect(stream_events.map(&:event_id)).to contain_exactly(event.event_id)
+      end
+    end
+  end
+end

--- a/spec/read_models/caseworker_reports/link_to_temporal_streams_spec.rb
+++ b/spec/read_models/caseworker_reports/link_to_temporal_streams_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe CaseworkerReports::LinkToTemporalStreams do
+  let(:event_store) { instance_double(RailsEventStore::Client) }
+  let(:event) { Reviewing::Completed.new(metadata: { timestamp: }) }
+  let(:timestamp) { Time.zone.local(2023, 8, 1, 22, 59) }
+
+  describe '#call' do
+    subject(:call) { described_class.new(event_store:).call(event) }
+
+    before do
+      allow(event_store).to receive(:link)
+      call
+    end
+
+    it 'links to the monthly stream based on the year and month of the year' do
+      stream_name = 'MonthlyCaseworker$2023-08'
+      expect(event_store).to have_received(:link).with([event.event_id], stream_name:)
+    end
+
+    it 'links to the weekly stream based on year and week of the year' do
+      stream_name = 'WeeklyCaseworker$2023-31'
+      expect(event_store).to have_received(:link).with([event.event_id], stream_name:)
+    end
+
+    it 'links to the daily stream based on year and day of the year' do
+      stream_name = 'DailyCaseworker$2023-213'
+      expect(event_store).to have_received(:link).with([event.event_id], stream_name:)
+    end
+
+    context 'when the event timestamp in utc is a different day in TZ London' do
+      let(:timestamp) { Time.zone.local(2023, 7, 31, 23) }
+
+      it 'converts the utc timestamps to the London time zone before determining the day of the year' do
+        stream_name = 'DailyCaseworker$2023-213'
+        expect(event_store).to have_received(:link).with([event.event_id], stream_name:)
+      end
+    end
+
+    context 'when week of the year is from the previous year' do
+      # although the date is in 2023, the week year is still 2022
+      let(:timestamp) { Time.zone.local(2023, 1) }
+
+      it 'converts the utc timestamps to the London time zone before determining the day of the year' do
+        stream_name = 'WeeklyCaseworker$2022-52'
+        expect(event_store).to have_received(:link).with([event.event_id], stream_name:)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Create event streams for monthly, daily and weekly caseworker reports.

## Link to relevant ticket
[CRIMAP-543](https://dsdmoj.atlassian.net/browse/CRIMAP-543)

## Notes for reviewer
Create discrete linked streams for each month day and week so that caseworker reports can be viewed according to the day week and month.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAP-543]: https://dsdmoj.atlassian.net/browse/CRIMAP-543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ