### PR TITLE
Fix docker tag issue where too many args were being passed

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -113,7 +113,7 @@ jobs:
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}
-          IMAGE_TAG: ${{ secrets.ECR_NAME }}:${{ github.sha }}, ${{ secrets.ECR_NAME }}:staging.latest
+          IMAGE_TAG: ${{ github.sha }}:staging.latest
         run: |
           docker tag app $REGISTRY/$REPOSITORY:${{ github.sha }}
           docker tag app $REGISTRY/$REPOSITORY:$IMAGE_TAG


### PR DESCRIPTION
## Description of change
Image tag sting had a comma in it which was causing the tag command to fail

## Link to relevant ticket
[CRIMAP-577](https://dsdmoj.atlassian.net/browse/CRIMAP-577)


[CRIMAP-577]: https://dsdmoj.atlassian.net/browse/CRIMAP-577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ