### PR TITLE
Update deploy workflow with fix for ECR_URL

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -80,12 +80,15 @@ jobs:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
 
+    outputs:
+      ecr_url: ${{ steps.ecr-url-output.outputs.ecr_url }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       # Assume role in Cloud Platform
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.ECR_REGION }}
@@ -93,6 +96,10 @@ jobs:
       # Login to container repository
       - uses: aws-actions/amazon-ecr-login@v1
         id: login-ecr
+
+      - name: Store ECR endpoint as output
+        id: ecr-url-output
+        run: echo "ecr_url=${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}" >> $GITHUB_OUTPUT
 
       - name: Store current date
         run: echo "BUILD_DATE=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
@@ -111,14 +118,12 @@ jobs:
       - name: Push to ECR
         id: ecr
         env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: ${{ vars.ECR_REPOSITORY }}
-          IMAGE_TAG: ${{ github.sha }}-staging.latest
+          ECR_URL: ${{ steps.ecr-url-output.outputs.ecr_url }}
         run: |
-          docker tag app $REGISTRY/$REPOSITORY:${{ github.sha }}
-          docker tag app $REGISTRY/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:${{ github.sha }}
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag app $ECR_URL:${{ github.sha }}
+          docker tag app $ECR_URL:staging.latest
+          docker push $ECR_URL:${{ github.sha }}
+          docker push $ECR_URL:staging.latest
 
   deploy-staging:
     runs-on: ubuntu-latest
@@ -134,7 +139,7 @@ jobs:
         with:
           environment-name: staging
           git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
-          ecr-url: ${{ secrets.ECR_URL }}
+          ecr-url: ${{ needs.build.outputs.ecr_url }}
           kube-cert: ${{ secrets.KUBE_STAGING_CERT }}
           kube-token: ${{ secrets.KUBE_STAGING_TOKEN }}
           kube-cluster: ${{ secrets.KUBE_STAGING_CLUSTER }}
@@ -142,7 +147,7 @@ jobs:
 
   deploy-production:
     runs-on: ubuntu-latest
-    needs: deploy-staging
+    needs: [build, deploy-staging]
     environment: production
 
     steps:
@@ -154,7 +159,7 @@ jobs:
         with:
           environment-name: production
           git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
-          ecr-url: ${{ secrets.ECR_URL }}
+          ecr-url: ${{ needs.build.outputs.ecr_url }}
           kube-cert: ${{ secrets.KUBE_PRODUCTION_CERT }}
           kube-token: ${{ secrets.KUBE_PRODUCTION_TOKEN }}
           kube-cluster: ${{ secrets.KUBE_PRODUCTION_CLUSTER }}


### PR DESCRIPTION
## Description of change
Same as we did in Datastore and Apply repos.

The previously used `secrets.ECR_URL` is now removed as part of ECR migration to short-term creds so is not available anymore to use in the ./.github/actions/deploy action.

However we can reference job outputs in other job steps to propagate this value.

