### PR TITLE
CRIMAP-617 show means type undetermined when not passported

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -29,8 +29,8 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
 
   delegate :date_of_birth, to: :applicant, prefix: true
 
-  def means_type
-    :passported
+  def means_passported?
+    !means_passport.empty?
   end
 
   def history

--- a/app/views/casework/crime_applications/_overview.html.erb
+++ b/app/views/casework/crime_applications/_overview.html.erb
@@ -17,8 +17,11 @@
       <%= label_text(:means_type) %>
     </dt>
     <dd class="govuk-summary-list__value">
-    <%# TODO implement means type once we handle it - currently hardcoded %>
-      <span class="moj-badge moj-badge--blue"><%= overview.means_type %></span>
+      <% if overview.means_passported? %>
+        <span class="moj-badge moj-badge--blue"><%= t(:passported, scope: 'values') %></span>
+      <% else %>
+        <span class="moj-badge moj-badge--red"><%= label_text('undetermined') %></span>
+      <% end %>
     </dd>
   </div>
 

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe CrimeApplication do
 
     context 'when a re-submission' do
       let(:parent_id) { SecureRandom.uuid }
-      let(:attributes) { JSON.parse(LaaCrimeSchemas.fixture(1.0).read).merge({ 'parent_id' => parent_id }) }
+      let(:attributes) { super().merge({ 'parent_id' => parent_id }) }
       let(:parent) { instance_double(described_class) }
 
       before do
@@ -107,9 +107,7 @@ RSpec.describe CrimeApplication do
 
     context 'when parent id is same as the id' do
       let(:attributes) do
-        JSON.parse(LaaCrimeSchemas.fixture(1.0).read).merge(
-          { 'parent_id' => '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
-        )
+        super().merge({ 'parent_id' => '696dd4fd-b619-4637-ab42-a5f4565bcf4a' })
       end
 
       it { is_expected.to be_nil }
@@ -122,10 +120,28 @@ RSpec.describe CrimeApplication do
     it { is_expected.to eq 'John Doe' }
   end
 
-  describe '#means_type' do
-    subject(:means_type) { application.means_type }
+  describe '#means_passported?' do
+    subject(:means_passported?) { application.means_passported? }
 
-    it { is_expected.to eq :passported }
+    let(:attributes) { super().merge({ 'means_passport' => means_passport }) }
+
+    context 'when application is means passported on DWP' do
+      let(:means_passport) { [Types::MeansPassportType['on_benefit_check']] }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when application is means passported on DWP and under 18' do
+      let(:means_passport) { Types::MeansPassportType.values }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when application is not means passported' do
+      let(:means_passport) { [] }
+
+      it { is_expected.to be false }
+    end
   end
 
   describe '#reviewable_by?' do

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -37,6 +37,28 @@ RSpec.describe 'Viewing an application unassigned, open application' do
     expect(page).to have_content('Initial application')
   end
 
+  describe 'showing the means type' do
+    subject(:means_type_badge) do
+      find('.govuk-summary-list__key', text: 'Means type').sibling('.govuk-summary-list__value')
+    end
+
+    context 'when the application is means passported' do
+      it 'shows the blue passported badge' do
+        expect(means_type_badge).to have_content('Passported')
+        expect(means_type_badge).to have_css('.moj-badge--blue')
+      end
+    end
+
+    context 'when the application is not means passported' do
+      let(:application_data) { super().merge('means_passport' => []) }
+
+      it 'shows the red undetermined badge' do
+        expect(means_type_badge).to have_content('Undetermined')
+        expect(means_type_badge).to have_css('.moj-badge--red')
+      end
+    end
+  end
+
   context 'when date stamp is earlier than date received' do
     let(:application_data) { super().deep_merge('date_stamp' => '2022-11-21T16:57:51.000+00:00') }
 


### PR DESCRIPTION
## Description of change

Show the red undetermined badge, when an applications means type is undetermined.

## Link to relevant ticket
[CRIMAP-617](https://dsdmoj.atlassian.net/browse/CRIMAP-617)

## Notes for reviewer
Review no longer assumes that all applications are means passported.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

passported:
<img width="683" alt="Screenshot 2023-09-21 at 13 55 41" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/817300d7-45ea-462c-b28c-4f28270d8c64">

undetermined:
<img width="788" alt="Screenshot 2023-09-21 at 13 55 15" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/3ae15f59-3731-4aeb-9ea6-69d7b771fd30">

## How to manually test the feature


[CRIMAP-617]: https://dsdmoj.atlassian.net/browse/CRIMAP-617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ