### PR TITLE
CRIMAP-589 link workload reporting events to business day streams

### DIFF
--- a/app/models/reporting/temporal_report.rb
+++ b/app/models/reporting/temporal_report.rb
@@ -49,7 +49,7 @@ module Reporting
     # :nocov:
 
     def stream_name
-      date.strftime(CaseworkerReports::STREAM_NAME_FORMATS.fetch(interval))
+      date.strftime(CaseworkerReports::Configuration::STREAM_NAME_FORMATS.fetch(interval))
     end
 
     private

--- a/app/read_models/caseworker_reports.rb
+++ b/app/read_models/caseworker_reports.rb
@@ -1,7 +1,2 @@
 module CaseworkerReports
-  STREAM_NAME_FORMATS = ActiveSupport::HashWithIndifferentAccess.new(
-    monthly: 'MonthlyCaseworker$%Y-%m',
-    weekly: 'WeeklyCaseworker$%G-%V',
-    daily: 'DailyCaseworker$%Y-%j'
-  ).freeze
 end

--- a/app/read_models/caseworker_reports/configuration.rb
+++ b/app/read_models/caseworker_reports/configuration.rb
@@ -4,6 +4,12 @@ module CaseworkerReports
   # Links caseworker report related events to day, week, and month streams.
   #
   class Configuration
+    STREAM_NAME_FORMATS = ActiveSupport::HashWithIndifferentAccess.new(
+      monthly: 'MonthlyCaseworker$%Y-%m',
+      weekly: 'WeeklyCaseworker$%G-%V',
+      daily: 'DailyCaseworker$%Y-%j'
+    ).freeze
+
     READ_MODEL_CHANGING_EVENTS = [
       Assigning::AssignedToUser,
       Assigning::ReassignedToUser,

--- a/app/read_models/caseworker_reports/link_to_temporal_streams.rb
+++ b/app/read_models/caseworker_reports/link_to_temporal_streams.rb
@@ -7,10 +7,13 @@ module CaseworkerReports
     def call(event)
       date = event.timestamp.in_time_zone('London').to_date
 
-      STREAM_NAME_FORMATS.each_value do |format|
-        stream_name = date.strftime(format)
-        @event_store.link [event.event_id], stream_name:
+      stream_name_formats.each_value do |format|
+        @event_store.link [event.event_id], stream_name: date.strftime(format)
       end
+    end
+
+    def stream_name_formats
+      CaseworkerReports::Configuration::STREAM_NAME_FORMATS
     end
   end
 end

--- a/app/read_models/received_on_reports/close_application.rb
+++ b/app/read_models/received_on_reports/close_application.rb
@@ -1,6 +1,6 @@
 module ReceivedOnReports
   class CloseApplication < Handler
-    def store_event!
+    def process_event!
       Reporting::ReceivedOnReport.increment_counter :total_closed, business_day
     end
   end

--- a/app/read_models/received_on_reports/configuration.rb
+++ b/app/read_models/received_on_reports/configuration.rb
@@ -1,5 +1,7 @@
 module ReceivedOnReports
   class Configuration
+    STREAM_NAME_FORMAT = 'ReceivedOn$%Y-%j'.freeze
+
     OPENING_EVENTS = [
       Reviewing::ApplicationReceived
     ].freeze
@@ -15,6 +17,10 @@ module ReceivedOnReports
 
       event_store.subscribe(
         ReceivedOnReports::CloseApplication, to: CLOSING_EVENTS
+      )
+
+      event_store.subscribe(
+        ReceivedOnReports::LinkToReceivedOnStream, to: OPENING_EVENTS + CLOSING_EVENTS
       )
     end
   end

--- a/app/read_models/received_on_reports/handler.rb
+++ b/app/read_models/received_on_reports/handler.rb
@@ -6,11 +6,11 @@ module ReceivedOnReports
 
       @review = Reviewing::LoadReview.call(application_id:)
 
-      store_event!
+      process_event!
     end
 
     # :nocov:
-    def store_event!
+    def process_event!
       raise 'Implement in sub class.'
     end
     # :nocov:

--- a/app/read_models/received_on_reports/link_to_received_on_stream.rb
+++ b/app/read_models/received_on_reports/link_to_received_on_stream.rb
@@ -1,0 +1,22 @@
+module ReceivedOnReports
+  class LinkToReceivedOnStream
+    def initialize(event_store: Rails.configuration.event_store)
+      @event_store = event_store
+    end
+
+    def call(event)
+      application_id = event.data.fetch(:application_id, nil)
+      return unless application_id
+
+      revieved_on = Reviewing::LoadReview.call(application_id:).business_day
+
+      @event_store.link(
+        event.event_id, stream_name: revieved_on.strftime(stream_name_format)
+      )
+    end
+
+    def stream_name_format
+      ReceivedOnReports::Configuration::STREAM_NAME_FORMAT
+    end
+  end
+end

--- a/app/read_models/received_on_reports/receive_application.rb
+++ b/app/read_models/received_on_reports/receive_application.rb
@@ -1,6 +1,6 @@
 module ReceivedOnReports
   class ReceiveApplication < Handler
-    def store_event!
+    def process_event!
       Reporting::ReceivedOnReport.insert({ business_day: })
       Reporting::ReceivedOnReport.increment_counter :total_received, business_day
     end

--- a/spec/read_models/received_on_reports/configuration_spec.rb
+++ b/spec/read_models/received_on_reports/configuration_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe ReceivedOnReports::Configuration do
+  let(:application_id) { SecureRandom.uuid }
+  let(:user_id) { SecureRandom.uuid }
+  let(:event_store) { Rails.configuration.event_store }
+  let(:submitted_at) { Time.zone.local(2023, 7, 30) }
+
+  describe '#configuration' do
+    before do
+      # subscribe the handler to the event store
+      described_class.new.call(event_store)
+
+      allow(DatastoreApi::Requests::UpdateApplication).to receive(:new) {
+        instance_double(DatastoreApi::Requests::UpdateApplication, call: {})
+      }
+
+      travel_to submitted_at
+
+      Reviewing::ReceiveApplication.call(
+        application_id: application_id, submitted_at: submitted_at.to_s
+      )
+
+      travel_to submitted_at + 3.days
+
+      Reviewing::Complete.call(application_id:, user_id:)
+    end
+
+    it 'links events to the business day the application was first recived on' do
+      reviewed_on_events = event_store.read.stream('ReceivedOn$2023-212').to_a
+      review_events = event_store.read.stream("Reviewing$#{application_id}").to_a
+
+      expect(reviewed_on_events).to eq(review_events)
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Link workload reporting events to received on business day streams.

## Link to relevant ticket
[CRIMAP-589](https://dsdmoj.atlassian.net/browse/CRIMAP-589)

## Notes for reviewer
This is in preparation for building the workload report directly from events, which will allow workload reports to be generated for any time in the past.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAP-589]: https://dsdmoj.atlassian.net/browse/CRIMAP-589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ