### PR TITLE
CRIMAP-597 Show passporting benefit type on review page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.2'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 1c7d156ea6ddf0fb997706e3d59d66f4f102e0e7
-  tag: v1.0.0
+  revision: 1d653fab9b4a666c31321189552ed4b0033ef4de
+  tag: v1.0.2
   specs:
     laa-criminal-legal-aid-schemas (1.0.0)
       dry-struct (~> 1.6.0)

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -27,14 +27,14 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
     ].join ' '
   end
 
-  delegate :date_of_birth, to: :applicant, prefix: true
+  delegate :date_of_birth, :benefit_type, to: :applicant, prefix: true
 
   def means_passported?
     !means_passport.empty?
   end
 
   def passporting_benefit?
-    means_passport.include?('on_benefit_check')
+    means_passport.include?(Types::MeansPassportType['on_benefit_check'])
   end
 
   delegate :benefit_type, to: :applicant

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -33,6 +33,12 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
     !means_passport.empty?
   end
 
+  def passporting_benefit?
+    means_passport.include?('on_benefit_check')
+  end
+
+  delegate :benefit_type, to: :applicant
+
   def history
     @history ||= ApplicationHistory.new(application: self)
   end

--- a/app/views/casework/crime_applications/_overview.html.erb
+++ b/app/views/casework/crime_applications/_overview.html.erb
@@ -25,6 +25,17 @@
     </dd>
   </div>
 
+  <% if overview.passporting_benefit? %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:passporting_benefit) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= t(overview.benefit_type.presence, scope: 'values') || t(:not_requested, scope: 'values') %>
+      </dd>
+    </div>
+  <% end %>
+
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
       <%= label_text(:urn) %>

--- a/app/views/casework/crime_applications/_overview.html.erb
+++ b/app/views/casework/crime_applications/_overview.html.erb
@@ -31,7 +31,7 @@
         <%= label_text(:passporting_benefit) %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= t(overview.benefit_type.presence, scope: 'values') || t(:not_requested, scope: 'values') %>
+        <%= t(overview.benefit_type.presence, scope: 'values') || t(:not_asked, scope: 'values') %>
       </dd>
     </div>
   <% end %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -53,6 +53,7 @@ en:
     application_start_date: Date stamp
     application_status: Status
     application_type: Application type
+    passporting_benefit: Passporting Benefit
     assigned_to: 'Assigned to:'
     case_details: Case details
     case_type: Case type
@@ -120,9 +121,15 @@ en:
     "true": "Yes"
     "false": "No"
     not_provided: Not provided
+    not_requested: Not requested
     deleted_user_name: '[deleted]'
     no_one: no one
     initial: Initial application
+    universal_credit: Universal Credit
+    guarantee_pension: Guarantee Credit element of Pension Credit
+    jsa: Income-based Jobseeker's Allowance (JSA)
+    esa: Income-related Employment and Support Allowance (ESA)
+    income_support: Income Support
     no_home_address: Does not have a home address
     home_address: Same as home address
     provider_address: Same as provider address

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -121,7 +121,7 @@ en:
     "true": "Yes"
     "false": "No"
     not_provided: Not provided
-    not_requested: Not requested
+    not_asked: Not asked when this application was submitted
     deleted_user_name: '[deleted]'
     no_one: no one
     initial: Initial application

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -144,6 +144,50 @@ RSpec.describe CrimeApplication do
     end
   end
 
+  describe '#passporting_benefit?' do
+    subject(:passporting_benefit?) { application.passporting_benefit? }
+
+    let(:attributes) { super().merge({ 'means_passport' => means_passport }) }
+
+    context 'when application is passported on benefits' do
+      let(:means_passport) { [Types::MeansPassportType['on_benefit_check']] }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when application is passported on age' do
+      let(:means_passport) { [Types::MeansPassportType['on_age_under18']] }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when application has no means passport' do
+      let(:means_passport) { [] }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#benefit_type' do
+    subject(:benefit_type) { application.benefit_type }
+
+    let(:attributes) do
+      super().deep_merge({ 'client_details' => { 'applicant' => { 'benefit_type' => passporting_benefit_type } } })
+    end
+
+    context 'when application has a benefit type' do
+      let(:passporting_benefit_type) { Types::BenefitType['universal_credit'] }
+
+      it { is_expected.to eq 'universal_credit' }
+    end
+
+    context 'when application does not have a benefit type' do
+      let(:passporting_benefit_type) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe '#reviewable_by?' do
     subject(:reviewable_by?) { application.reviewable_by?(user_id) }
 

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -65,13 +65,13 @@ RSpec.describe 'Viewing an application unassigned, open application' do
         expect(page).to have_content('Passporting Benefit Universal Credit')
       end
 
-      context 'when it was not requested at time of application' do
+      context 'when it was not asked at time of application' do
         let(:application_data) do
           super().deep_merge('client_details' => { 'applicant' => { 'benefit_type' => nil } })
         end
 
-        it 'shows `Not requested`' do
-          expect(page).to have_content('Passporting Benefit Not requested')
+        it 'shows `Not asked`' do
+          expect(page).to have_content('Passporting Benefit Not asked when this application was submitted')
         end
       end
     end

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -59,6 +59,32 @@ RSpec.describe 'Viewing an application unassigned, open application' do
     end
   end
 
+  describe 'showing the passporting benefit' do
+    context 'when the application has a passporting benefit' do
+      it 'shows the benefit type' do
+        expect(page).to have_content('Passporting Benefit Universal Credit')
+      end
+
+      context 'when it was not requested at time of application' do
+        let(:application_data) do
+          super().deep_merge('client_details' => { 'applicant' => { 'benefit_type' => nil } })
+        end
+
+        it 'shows `Not requested`' do
+          expect(page).to have_content('Passporting Benefit Not requested')
+        end
+      end
+    end
+
+    context 'when the applicant is under 18' do
+      let(:application_data) { super().merge('means_passport' => ['on_age_under18']) }
+
+      it 'does not show the passporting benefit row' do
+        expect(page).not_to have_content('Passporting Benefit')
+      end
+    end
+  end
+
   context 'when date stamp is earlier than date received' do
     let(:application_data) { super().deep_merge('date_stamp' => '2022-11-21T16:57:51.000+00:00') }
 


### PR DESCRIPTION
## Description of change
Surface passporting benefit type when it is provided.

If the applicant is passported but it is a historic application that did not have benefit type requested, list as 'Not requested'

If under 18, (or error has let through a non-means passported applicant) whole row is not shown. 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-597

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
![image](https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/49fe21e2-c8ed-4296-bdb1-ed2170f1353f)

### After changes:
![image](https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/142d223d-59d0-4c76-b03f-746b04c4dd6f)

## How to manually test the feature
