### PR TITLE
Only show one ioj passport, with under 18 taking precedence

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -37,7 +37,14 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
     means_passport.include?(Types::MeansPassportType['on_benefit_check'])
   end
 
-  delegate :benefit_type, to: :applicant
+  def relevant_ioj_passport
+    # Being under 18 trumps any other interest of justice
+    if ioj_passport.include?('on_age_under18')
+      'on_age_under18'
+    elsif ioj_passport == ['on_offence']
+      'on_offence'
+    end
+  end
 
   def history
     @history ||= ApplicationHistory.new(application: self)

--- a/app/views/casework/crime_applications/_interests_of_justice.html.erb
+++ b/app/views/casework/crime_applications/_interests_of_justice.html.erb
@@ -27,17 +27,6 @@
       <% end %>
     </tbody>
   </table>
-<% elsif crime_application.ioj_passport.include?('on_age_under18') %>
-  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= label_text(:justification) %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= t('on_age_under18', scope: 'values') %>
-      </dd>
-    </div>
-  </dl>
 <% else %>
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <div class="govuk-summary-list__row">
@@ -45,7 +34,11 @@
         <%= label_text(:justification) %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= t('on_offence', scope: 'values') %>
+        <% if crime_application.ioj_passport.include?('on_age_under18') %>
+          <%= t('on_age_under18', scope: 'values') %>
+        <% else %>
+          <%= t(crime_application.ioj_passport.first, scope: 'values') %>
+        <% end %>
       </dd>
     </div>
   </dl>

--- a/app/views/casework/crime_applications/_interests_of_justice.html.erb
+++ b/app/views/casework/crime_applications/_interests_of_justice.html.erb
@@ -34,11 +34,7 @@
         <%= label_text(:justification) %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <% if crime_application.ioj_passport.include?('on_age_under18') %>
-          <%= t('on_age_under18', scope: 'values') %>
-        <% else %>
-          <%= t(crime_application.ioj_passport.first, scope: 'values') %>
-        <% end %>
+        <%= t(crime_application.relevant_ioj_passport, scope: 'values') %>
       </dd>
     </div>
   </dl>

--- a/app/views/casework/crime_applications/_interests_of_justice.html.erb
+++ b/app/views/casework/crime_applications/_interests_of_justice.html.erb
@@ -27,17 +27,26 @@
       <% end %>
     </tbody>
   </table>
+<% elsif crime_application.ioj_passport.include?('on_age_under18') %>
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:justification) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= t('on_age_under18', scope: 'values') %>
+      </dd>
+    </div>
+  </dl>
 <% else %>
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-    <% crime_application.ioj_passport.each do |passport| %>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= label_text(:justification) %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= t(passport, scope: 'values') %>
-        </dd>
-      </div>
-    <% end %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:justification) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= t('on_offence', scope: 'values') %>
+      </dd>
+    </div>
   </dl>
 <% end %>

--- a/app/views/casework/crime_applications/_overview.html.erb
+++ b/app/views/casework/crime_applications/_overview.html.erb
@@ -31,7 +31,7 @@
         <%= label_text(:passporting_benefit) %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= t(overview.benefit_type.presence, scope: 'values') || t(:not_asked, scope: 'values') %>
+        <%= t(overview.applicant_benefit_type.presence, scope: 'values') || t(:not_asked, scope: 'values') %>
       </dd>
     </div>
   <% end %>

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe CrimeApplication do
   end
 
   describe '#benefit_type' do
-    subject(:benefit_type) { application.benefit_type }
+    subject(:benefit_type) { application.applicant_benefit_type }
 
     let(:attributes) do
       super().deep_merge({ 'client_details' => { 'applicant' => { 'benefit_type' => passporting_benefit_type } } })

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -261,42 +261,61 @@ RSpec.describe 'Viewing an application unassigned, open application' do
   context 'with ioj reasons' do
     context 'with ioj reason only' do
       it 'shows a table with ioj reason' do
-        ioj_table = find(:xpath,
-                         "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
+        ioj_row = find(:xpath,
+                       "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
                         //tr[contains(td[1], 'Loss of liberty')]")
 
-        expect(ioj_table).to have_content('More details about loss of liberty.')
+        expect(ioj_row).to have_content('More details about loss of liberty.')
       end
     end
 
     context 'with ioj passport and no ioj reason' do
-      let(:application_data) do
-        super().deep_merge(
-          'ioj_passport' => ['on_age_under18'],
-          'interests_of_justice' => nil
-        )
+      context 'with only an `on_offence` passport' do
+        let(:application_data) do
+          super().deep_merge(
+            'ioj_passport' => ['on_offence'],
+            'interests_of_justice' => nil
+          )
+        end
+
+        it 'shows a summary list with the correct passport reason' do
+          ioj_row = find(:xpath,
+                         "//dl[@class='govuk-summary-list govuk-!-margin-bottom-9']
+                              //div[contains(dt[1], 'Justification')]")
+
+          expect(ioj_row).to have_content('Not needed based on offence')
+        end
       end
 
-      it 'shows a summary list with passport reason' do
-        summary_list = find(:xpath,
-                            "//dl[@class='govuk-summary-list govuk-!-margin-bottom-9']
-                            //div[contains(dt[1], 'Justification')]")
+      context 'with both ioj passports' do
+        let(:application_data) do
+          super().deep_merge(
+            'ioj_passport' => %w[on_age_under18 on_offence],
+            'interests_of_justice' => nil
+          )
+        end
 
-        expect(summary_list).to have_content('Not needed because the client is under 18 years old')
+        it 'shows a summary list with the correct passport reason' do
+          ioj_row = find(:xpath,
+                         "//dl[@class='govuk-summary-list govuk-!-margin-bottom-9']
+                              //div[contains(dt[1], 'Justification')]")
+
+          expect(ioj_row).to have_content('Not needed because the client is under 18 years old')
+        end
       end
     end
 
     context 'when a passported application is a split case and resubmitted with ioj passport' do
       let(:application_data) do
-        super().deep_merge('ioj_passport' => ['on_age_under18'])
+        super().deep_merge('ioj_passport' => ['on_offence'])
       end
 
       it 'shows a table with ioj reason' do
-        ioj_table = find(:xpath,
-                         "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
+        ioj_row = find(:xpath,
+                       "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
                         //tr[contains(td[1], 'Loss of liberty')]")
 
-        expect(ioj_table).to have_content('More details about loss of liberty.')
+        expect(ioj_row).to have_content('More details about loss of liberty.')
       end
     end
   end


### PR DESCRIPTION
## Description of change
Review should only show one IoJ passport
If there are both IoJ passports present ( 'on_offence', and 'on_age_under18') age passport is the only one that should be shown. 
## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
