### PR TITLE
allow_user_managers_service_access to reman true in local

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,7 @@ feature_flags:
     staging: <%= ENV.fetch("DEV_AUTH_ENABLED", false) %>
     production: false # must never be enabled in the live service
   allow_user_managers_service_access:
-    local: false
+    local: true
     staging: true
     production: false # user managers should not access the service in production
   basic_user_roles:

--- a/spec/models/concerns/user_role_spec.rb
+++ b/spec/models/concerns/user_role_spec.rb
@@ -75,6 +75,8 @@ RSpec.describe UserRole do
     end
 
     context 'when user is user manager' do
+      include_context 'when logged in user is admin'
+
       before { user.can_manage_others = true }
 
       it { is_expected.to be false }
@@ -111,6 +113,8 @@ RSpec.describe UserRole do
     end
 
     context 'when user is a user manager' do
+      include_context 'when logged in user is admin'
+
       it 'returns false for all user roles' do
         user.can_manage_others = true
 
@@ -257,6 +261,8 @@ RSpec.describe UserRole do
     end
 
     context 'when user is user manager' do
+      include_context 'when logged in user is admin'
+
       before { user.can_manage_others = true }
 
       it { is_expected.to be_empty }

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -132,6 +132,8 @@ RSpec.describe 'Authentication Session Initialisation' do
       end
 
       context 'when user is a `user_manager`' do
+        include_context 'when logged in user is admin'
+
         let(:user) do
           User.create(auth_subject_id: auth_subject_id, email: 'test@eg.com', can_manage_others: true)
         end

--- a/spec/shared_contexts/when_logged_in_user_is_admin.rb
+++ b/spec/shared_contexts/when_logged_in_user_is_admin.rb
@@ -1,3 +1,9 @@
 RSpec.shared_context 'when logged in user is admin', shared_context: :metadata do
   let(:current_user_can_manage_others) { true }
+
+  before do
+    allow(FeatureFlags).to receive(:allow_user_managers_service_access) {
+      instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+    }
+  end
 end

--- a/spec/system/authenticating/an_invited_user_spec.rb
+++ b/spec/system/authenticating/an_invited_user_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe 'Authenticating an invited user' do
     end
 
     describe 'viewing the activation in the user\'s account history' do
+      include_context 'when logged in user is admin'
+
       let(:invited_user) { User.create(email: 'Invited.Test@example.com', can_manage_others: true) }
       let(:cells) { page.first('table tbody tr').all('td') }
 


### PR DESCRIPTION
## Description of change

Modify tests to allow for allow_user_managers_service_access to reman true in local

Toggling allow_user_managers_service_access in local development feels unnecessary and more helpful to leave it on.

