### PR TITLE
[CRIMAP-601] Show first court hearing location

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.2'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.3'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 1d653fab9b4a666c31321189552ed4b0033ef4de
-  tag: v1.0.2
+  revision: b2f94b5b4e952477435358d23f5f14fb38c87b0a
+  tag: v1.0.3
   specs:
-    laa-criminal-legal-aid-schemas (1.0.0)
+    laa-criminal-legal-aid-schemas (1.0.3)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 

--- a/app/views/casework/crime_applications/_case_details.html.erb
+++ b/app/views/casework/crime_applications/_case_details.html.erb
@@ -47,6 +47,16 @@
       <%= case_details.hearing_court_name %>
     </dd>
   </div>
+  <% if case_details.first_court_hearing_name.present? %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:first_court_hearing_name) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= case_details.first_court_hearing_name %>
+      </dd>
+    </div>
+  <% end %>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
       <%= label_text(:hearing_date) %>

--- a/app/views/casework/crime_applications/_case_details.html.erb
+++ b/app/views/casework/crime_applications/_case_details.html.erb
@@ -41,42 +41,30 @@
   <% end%>
 
   <!-- Court hearing -->
-  <% if case_details.is_first_court_hearing == LaaCrimeSchemas::Types::FirstHearingAnswerValues['no_hearing_yet'] %>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <%= label_text(:hearing_date) %>
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= l case_details.hearing_date, format: :compact %>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <%= label_text(:hearing_court_name) %>
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= case_details.hearing_court_name %>
+    </dd>
+  </div>
+  <% if case_details.first_court_hearing_name.present? %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        <%= label_text(:hearing_date) %>
+        <%= label_text(:first_court_hearing_name) %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= t(LaaCrimeSchemas::Types::FirstHearingAnswerValues['no_hearing_yet'], scope: 'values') %>
+        <%= case_details.first_court_hearing_name %>
       </dd>
     </div>
-  <% else %>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= label_text(:hearing_date) %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= l case_details.hearing_date, format: :compact %>
-      </dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= label_text(:hearing_court_name) %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= case_details.hearing_court_name %>
-      </dd>
-    </div>
-
-    <% if (case_details.is_first_court_hearing == LaaCrimeSchemas::Types::FirstHearingAnswerValues['no']) && case_details.first_court_hearing_name.present? %>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= label_text(:first_court_hearing_name) %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= case_details.first_court_hearing_name %>
-        </dd>
-      </div>
-    <% end %>
   <% end %>
 </dl>

--- a/app/views/casework/crime_applications/_case_details.html.erb
+++ b/app/views/casework/crime_applications/_case_details.html.erb
@@ -41,30 +41,42 @@
   <% end%>
 
   <!-- Court hearing -->
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      <%= label_text(:hearing_date) %>
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <%= l case_details.hearing_date, format: :compact %>
-    </dd>
-  </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      <%= label_text(:hearing_court_name) %>
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <%= case_details.hearing_court_name %>
-    </dd>
-  </div>
-  <% if case_details.first_court_hearing_name.present? %>
+  <% if case_details.is_first_court_hearing == LaaCrimeSchemas::Types::FirstHearingAnswerValues['no_hearing_yet'] %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        <%= label_text(:first_court_hearing_name) %>
+        <%= label_text(:hearing_date) %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= case_details.first_court_hearing_name %>
+        <%= t(LaaCrimeSchemas::Types::FirstHearingAnswerValues['no_hearing_yet'], scope: 'values') %>
       </dd>
     </div>
+  <% else %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:hearing_date) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= l case_details.hearing_date, format: :compact %>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:hearing_court_name) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= case_details.hearing_court_name %>
+      </dd>
+    </div>
+
+    <% if (case_details.is_first_court_hearing == LaaCrimeSchemas::Types::FirstHearingAnswerValues['no']) && case_details.first_court_hearing_name.present? %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:first_court_hearing_name) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= case_details.first_court_hearing_name %>
+        </dd>
+      </div>
+    <% end %>
   <% end %>
 </dl>

--- a/app/views/casework/crime_applications/_case_details.html.erb
+++ b/app/views/casework/crime_applications/_case_details.html.erb
@@ -39,6 +39,16 @@
       </dd>
     </div>
   <% end%>
+
+  <!-- Court hearing -->
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <%= label_text(:hearing_date) %>
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= l case_details.hearing_date, format: :compact %>
+    </dd>
+  </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
       <%= label_text(:hearing_court_name) %>
@@ -57,12 +67,4 @@
       </dd>
     </div>
   <% end %>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      <%= label_text(:hearing_date) %>
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <%= l case_details.hearing_date, format: :compact %>
-    </dd>
-  </div>
 </dl>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -199,7 +199,6 @@ en:
       completed: green
       marked_as_ready: blue
     download_file: "Download file <br> (%{file_extension}, %{file_size})"
-    no_hearing_yet: There has not been a hearing yet
 
   calls_to_action:
     abandon_reassign_to_self: No, do not reassign

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -72,6 +72,7 @@ en:
     file_name: File name
     financial_change_details: Changes in the client’s financial circumstances
     first_name: First name
+    first_court_hearing_name: Initial court
     hearing_court_name: Court hearing the case
     hearing_date: Next court hearing
     home_address: Home address
@@ -288,7 +289,7 @@ en:
         total:
           one: 1 search result
           other: "%{count} search results"
-      no_search_results: 
+      no_search_results:
         heading: There are no results that match the search criteria
         no_results_list:
           - Check the spelling of the applicant’s name

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -74,7 +74,7 @@ en:
     first_name: First name
     first_court_hearing_name: Initial court
     hearing_court_name: Court hearing the case
-    hearing_date: Next court hearing
+    hearing_date: Next court hearing date
     home_address: Home address
     interests_of_justice: Interest of Justice
     interests_of_justice_type: Criteria

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -199,6 +199,7 @@ en:
       completed: green
       marked_as_ready: blue
     download_file: "Download file <br> (%{file_extension}, %{file_size})"
+    no_hearing_yet: There has not been a hearing yet
 
   calls_to_action:
     abandon_reassign_to_self: No, do not reassign

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -365,4 +365,43 @@ RSpec.describe 'Viewing an application unassigned, open application' do
       end
     end
   end
+
+  context 'with court hearing' do
+    let(:application_data) do
+      super().deep_merge('case_details' => { 'hearing_court_name' => 'Westminster Magistrates Court' })
+    end
+
+    it 'shows the court hearing the case name' do
+      row = first(:xpath, "//div[@class='govuk-summary-list__row'][contains(dt, 'Court hearing the case')]")
+
+      expect(row).to have_content('Westminster Magistrates Court')
+    end
+
+    it 'does not have a first court hearing the case' do
+      row = first(:xpath, "//div[@class='govuk-summary-list__row'][contains(dt, 'Initial court')]")
+
+      expect(row).not_to have_content('Soutwark Crown Court')
+    end
+
+    context 'when the court location has changed' do
+      let(:application_data) do
+        super().deep_merge('case_details' => {
+                             'hearing_court_name' => 'Southwark Crown Court',
+                             'first_court_hearing_name' => 'Westminster Magistrates Court'
+                           })
+      end
+
+      it 'shows the current court hearing the case name' do
+        row = first(:xpath, "//div[@class='govuk-summary-list__row'][contains(dt, 'Court hearing the case')]")
+
+        expect(row).to have_content('Southwark Crown Court')
+      end
+
+      it 'shows the first court hearing the case name' do
+        row = first(:xpath, "//div[@class='govuk-summary-list__row'][contains(dt, 'Initial court')]")
+
+        expect(row).to have_content('Westminster Magistrates Court')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
Shows the first court hearing location name ('Initial court')

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-601

## Notes for reviewer
Not sure whether the `is_first_court_hearing` value needs to be checked as well to determine output?

## Screenshots of changes (if applicable)


### Before changes:
<img width="713" alt="Screenshot 2023-10-03 at 21 53 11" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/47113046/b73d2c6c-b03f-4377-abcc-4f9b3e6ad68c">


### After changes:
<img width="709" alt="Screenshot 2023-10-03 at 21 50 55" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/47113046/fd159223-aaec-4051-bace-39ef7ec1b766">


## How to manually test the feature
Create and application and in the court hearing section enter appropriate values.