### PR TITLE
[CRIMAP-526] download supporting evidence

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'lograge'
 gem 'logstash-event'
 
 gem 'laa-criminal-applications-datastore-api-client',
-    github: 'ministryofjustice/laa-criminal-applications-datastore-api-client', tag: 'v1.1.0',
+    github: 'ministryofjustice/laa-criminal-applications-datastore-api-client', tag: 'v1.2.0',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
-  revision: 0707f4122553b3e72c85ea5df0a242d703fec00a
-  tag: v1.1.0
+  revision: 0fb6084fce58f09c156b661c2c7d053f2ae86a78
+  tag: v1.2.0
   specs:
     laa-criminal-applications-datastore-api-client (1.1.0)
       faraday (~> 2.7)

--- a/app/controllers/casework/documents_controller.rb
+++ b/app/controllers/casework/documents_controller.rb
@@ -13,7 +13,7 @@ module Casework
       raise CannotDownloadDocNotPartOfApp unless doc_uploaded_to_current_app?
 
       presign_download = Datastore::Documents::Download.new(document: @document).call
-      redirect_to(presign_download.url, allow_other_host: true)
+      redirect_to(presign_download.url, allow_other_host: true) if presign_download
     rescue CannotDownloadUnlessAssigned
       set_flash(:cannot_download_unless_assigned, success: false)
       redirect_to crime_application_path(params[:crime_application_id])

--- a/app/controllers/casework/documents_controller.rb
+++ b/app/controllers/casework/documents_controller.rb
@@ -3,22 +3,22 @@ module Casework
     before_action :set_crime_application, :set_document
 
     class CannotDownloadUnlessAssigned < StandardError; end
-    class CannotDownload < StandardError; end
+    class CannotDownloadDocNotPartOfApp < StandardError; end
 
     def show; end
 
     # rubocop:disable Metrics/AbcSize
     def download
       raise CannotDownloadUnlessAssigned unless @crime_application.assigned_to?(current_user_id)
-      raise CannotDownload unless doc_uploaded_to_current_app?
+      raise CannotDownloadDocNotPartOfApp unless doc_uploaded_to_current_app?
 
       presign_download = Datastore::Documents::Download.new(document: @document).call
       redirect_to(presign_download.url, allow_other_host: true)
     rescue CannotDownloadUnlessAssigned
       set_flash(:cannot_download_unless_assigned, success: false)
       redirect_to crime_application_path(params[:crime_application_id])
-    rescue CannotDownload
-      set_flash(:cannot_download, success: false)
+    rescue CannotDownloadDocNotPartOfApp
+      set_flash(:cannot_download_doc_uploaded_to_another_app, success: false)
       redirect_to crime_application_path(params[:crime_application_id])
     end
     # rubocop:enable Metrics/AbcSize

--- a/app/controllers/casework/documents_controller.rb
+++ b/app/controllers/casework/documents_controller.rb
@@ -1,27 +1,17 @@
 module Casework
   class DocumentsController < Casework::BaseController
     before_action :set_crime_application, :set_document
+    before_action :require_assigned_user
 
     class CannotDownloadUnlessAssigned < StandardError; end
     class CannotDownloadDocNotPartOfApp < StandardError; end
 
     def show; end
 
-    # rubocop:disable Metrics/AbcSize
     def download
-      raise CannotDownloadUnlessAssigned unless @crime_application.assigned_to?(current_user_id)
-      raise CannotDownloadDocNotPartOfApp unless doc_uploaded_to_current_app?
-
       presign_download = Datastore::Documents::Download.new(document: @document).call
       redirect_to(presign_download.url, allow_other_host: true) if presign_download
-    rescue CannotDownloadUnlessAssigned
-      set_flash(:cannot_download_unless_assigned, success: false)
-      redirect_to crime_application_path(params[:crime_application_id])
-    rescue CannotDownloadDocNotPartOfApp
-      set_flash(:cannot_download_doc_uploaded_to_another_app, success: false)
-      redirect_to crime_application_path(params[:crime_application_id])
     end
-    # rubocop:enable Metrics/AbcSize
 
     private
 
@@ -33,9 +23,16 @@ module Casework
       @document = @crime_application.supporting_evidence.find { |evidence| evidence.s3_object_key == params[:id] }
     end
 
-    def doc_uploaded_to_current_app?
+    def require_assigned_user
       # To ensure users can only download documents that are part of the current application
-      @document.present?
+      raise CannotDownloadDocNotPartOfApp if @document.blank?
+      raise CannotDownloadUnlessAssigned unless @crime_application.assigned_to?(current_user_id)
+    rescue CannotDownloadUnlessAssigned
+      set_flash(:cannot_download_unless_assigned, success: false)
+      redirect_to crime_application_path(params[:crime_application_id])
+    rescue CannotDownloadDocNotPartOfApp
+      set_flash(:cannot_download_doc_uploaded_to_another_app, success: false)
+      redirect_to crime_application_path(params[:crime_application_id])
     end
   end
 end

--- a/app/controllers/casework/documents_controller.rb
+++ b/app/controllers/casework/documents_controller.rb
@@ -5,6 +5,9 @@ module Casework
     class CannotDownloadUnlessAssigned < StandardError; end
     class CannotDownload < StandardError; end
 
+    def show; end
+
+    # rubocop:disable Metrics/AbcSize
     def download
       raise CannotDownloadUnlessAssigned unless @crime_application.assigned_to?(current_user_id)
       raise CannotDownload unless doc_uploaded_to_current_app?
@@ -18,6 +21,7 @@ module Casework
       set_flash(:cannot_download, success: false)
       redirect_to crime_application_path(params[:crime_application_id])
     end
+    # rubocop:enable Metrics/AbcSize
 
     private
 

--- a/app/controllers/casework/documents_controller.rb
+++ b/app/controllers/casework/documents_controller.rb
@@ -1,0 +1,37 @@
+module Casework
+  class DocumentsController < Casework::BaseController
+    before_action :set_crime_application, :set_document
+
+    class CannotDownloadUnlessAssigned < StandardError; end
+    class CannotDownload < StandardError; end
+
+    def download
+      raise CannotDownloadUnlessAssigned unless @crime_application.assigned_to?(current_user_id)
+      raise CannotDownload unless doc_uploaded_to_current_app?
+
+      presign_download = Datastore::Documents::Download.new(document: @document).call
+      redirect_to(presign_download.url, allow_other_host: true)
+    rescue CannotDownloadUnlessAssigned
+      set_flash(:cannot_download_unless_assigned, success: false)
+      redirect_to crime_application_path(params[:crime_application_id])
+    rescue CannotDownload
+      set_flash(:cannot_download, success: false)
+      redirect_to crime_application_path(params[:crime_application_id])
+    end
+
+    private
+
+    def set_crime_application
+      @crime_application = ::CrimeApplication.find(params[:crime_application_id])
+    end
+
+    def set_document
+      @document = @crime_application.supporting_evidence.find { |evidence| evidence.s3_object_key == params[:id] }
+    end
+
+    def doc_uploaded_to_current_app?
+      # To ensure users can only download documents that are part of the current application
+      @document.present?
+    end
+  end
+end

--- a/app/services/datastore/documents/download.rb
+++ b/app/services/datastore/documents/download.rb
@@ -1,0 +1,34 @@
+module Datastore
+  module Documents
+    class Download
+      PRESIGNED_URL_EXPIRES_IN = 15 # seconds
+
+      attr_accessor :document
+
+      def initialize(document:)
+        @document = document
+      end
+
+      def call
+        DatastoreApi::Requests::Documents::PresignDownload.new(
+          object_key:, expires_in:, response_content_disposition:
+        ).call
+      end
+
+      private
+
+      def object_key
+        @document.s3_object_key
+      end
+
+      def expires_in
+        PRESIGNED_URL_EXPIRES_IN
+      end
+
+      def response_content_disposition
+        # To force download of file rather than opening in another window
+        "attachment; filename=#{@document.filename}"
+      end
+    end
+  end
+end

--- a/app/services/datastore/documents/download.rb
+++ b/app/services/datastore/documents/download.rb
@@ -10,9 +10,11 @@ module Datastore
       end
 
       def call
-        DatastoreApi::Requests::Documents::PresignDownload.new(
-          object_key:, expires_in:, response_content_disposition:
-        ).call
+        Rails.error.handle(fallback: -> { false }) do
+          DatastoreApi::Requests::Documents::PresignDownload.new(
+            object_key:, expires_in:, response_content_disposition:
+          ).call
+        end
       end
 
       private

--- a/app/views/casework/crime_applications/_supporting_evidence.html.erb
+++ b/app/views/casework/crime_applications/_supporting_evidence.html.erb
@@ -20,7 +20,12 @@
             <%= evidence.filename %>
           </td>
           <td class="govuk-table__cell govuk-!-text-align-right">
-              <%= sanitize(t(:download_file, scope: 'values', file_extension: evidence.file_extension, file_size: number_to_human_size(evidence.file_size))) %>
+            <%= govuk_link_to(
+                  sanitize(t(:download_file, scope: 'values',
+                             file_extension: evidence.file_extension,
+                             file_size: number_to_human_size(evidence.file_size))),
+                  download_documents_path(crime_application_id: crime_application.id, id: evidence.s3_object_key)
+                ) %>
           </td>
         </tr>
       <% end %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -37,7 +37,7 @@ en:
       cannot_send_back_when_completed: This application was already marked as complete
       cannot_send_back_when_marked_as_ready: This application was already marked as ready for assessment
       cannot_download_unless_assigned: You must assign this application to your list to download files
-      cannot_download: File must be uploaded to current application to download
+      cannot_download_doc_uploaded_to_another_app: File must be uploaded to current application to download
 
   primary_navigation:
     your_list: "Your list (%{count})"

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -36,6 +36,8 @@ en:
       cannot_mark_as_ready_when_sent_back: This application was already sent back to the provider
       cannot_send_back_when_completed: This application was already marked as complete
       cannot_send_back_when_marked_as_ready: This application was already marked as ready for assessment
+      cannot_download_unless_assigned: You must assign this application to your list to download files
+      cannot_download: File must be uploaded to current application to download
 
   primary_navigation:
     your_list: "Your list (%{count})"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,10 @@ Rails.application.routes.draw do
     resources :assigned_applications, only: [:index, :destroy, :create] do
       post :next_application, on: :collection
     end
+
+    resource :documents, only: [:show] do
+      get :download, on: :member
+    end
   end
 
   namespace :reporting do

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'Authorisation' do
       crime_application_reassign
       crime_application_return
       crime_applications
+      download_documents
+      documents
       history_crime_application
       new_application_searches
       new_crime_application_reassign

--- a/spec/services/datastore/documents/download_spec.rb
+++ b/spec/services/datastore/documents/download_spec.rb
@@ -3,19 +3,9 @@ require 'rails_helper'
 RSpec.describe Datastore::Documents::Download do
   subject(:download_service) { described_class.new(document:) }
 
+  include_context 'when downloading a document'
+
   let(:document) { instance_double(Document, filename:, s3_object_key:) }
-
-  let(:filename) { 'test.pdf' }
-  let(:s3_object_key) { '123/abcdef1234' }
-
-  let(:expected_query) do
-    { object_key: %r{123/.*}, s3_opts: { expires_in: Datastore::Documents::Download::PRESIGNED_URL_EXPIRES_IN,
-                                         response_content_disposition:  "attachment; filename=#{filename}" } }
-  end
-
-  let(:presign_download_url) do
-    'https://localhost.localstack.cloud:4566/crime-apply-documents-dev/42/WtpJTOwsQ2?response-content-disposition=attachment%3B%20filename%3Dtest.pdf&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test%2F20231005%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231005T112229Z&X-Amz-Expires=15&X-Amz-SignedHeaders=host&X-Amz-Signature=ca6081d4060ab8fc692f53b1746740f13a6bf3e46a6df0cf0acc06ed2367084e'
-  end
 
   describe '#call' do
     context 'when a document download link is retrieved successfully' do

--- a/spec/services/datastore/documents/download_spec.rb
+++ b/spec/services/datastore/documents/download_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Datastore::Documents::Download do
+  subject(:download_service) { described_class.new(document:) }
+
+  let(:document) { instance_double(Document, filename:, s3_object_key:) }
+
+  let(:filename) { 'test.pdf' }
+  let(:s3_object_key) { '123/abcdef1234' }
+
+  let(:expected_query) do
+    { object_key: %r{123/.*}, s3_opts: { expires_in: Datastore::Documents::Download::PRESIGNED_URL_EXPIRES_IN,
+                                         response_content_disposition:  "attachment; filename=#{filename}" } }
+  end
+
+  let(:presign_download_url) do
+    'https://localhost.localstack.cloud:4566/crime-apply-documents-dev/42/WtpJTOwsQ2?response-content-disposition=attachment%3B%20filename%3Dtest.pdf&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test%2F20231005%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231005T112229Z&X-Amz-Expires=15&X-Amz-SignedHeaders=host&X-Amz-Signature=ca6081d4060ab8fc692f53b1746740f13a6bf3e46a6df0cf0acc06ed2367084e'
+  end
+
+  describe '#call' do
+    context 'when a document download link is retrieved successfully' do
+      before do
+        stub_request(:put, 'https://datastore-api-stub.test/api/v1/documents/presign_download')
+          .with(body: expected_query)
+          .to_return(status: 201, body: { url: presign_download_url }.to_json)
+      end
+
+      it 'returns presign download url' do
+        expect(download_service.call.url).to eq(presign_download_url)
+      end
+    end
+  end
+end

--- a/spec/services/datastore/documents/download_spec.rb
+++ b/spec/services/datastore/documents/download_spec.rb
@@ -19,5 +19,17 @@ RSpec.describe Datastore::Documents::Download do
         expect(download_service.call.url).to eq(presign_download_url)
       end
     end
+
+    context 'when there is a problem connecting to the API' do
+      before do
+        stub_request(:put, 'https://datastore-api-stub.test/api/v1/documents/presign_download')
+          .with(body: expected_query)
+          .to_return(status: 500)
+      end
+
+      it 'returns false' do
+        expect(download_service.call).to be(false)
+      end
+    end
   end
 end

--- a/spec/services/datastore/documents/download_spec.rb
+++ b/spec/services/datastore/documents/download_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Datastore::Documents::Download do
           .to_return(status: 201, body: { url: presign_download_url }.to_json)
       end
 
-      it 'returns presign download url' do
+      it 'returns a presigned download url' do
         expect(download_service.call.url).to eq(presign_download_url)
       end
     end

--- a/spec/shared_contexts/when_downloading_a_document.rb
+++ b/spec/shared_contexts/when_downloading_a_document.rb
@@ -1,0 +1,19 @@
+RSpec.shared_context 'when downloading a document' do
+  let(:filename) { 'test.pdf' }
+  let(:s3_object_key) { '123/abcdef1234' }
+
+  let(:expected_query) do
+    { object_key: %r{123/.*}, s3_opts: { expires_in: Datastore::Documents::Download::PRESIGNED_URL_EXPIRES_IN,
+                                         response_content_disposition:  "attachment; filename=#{filename}" } }
+  end
+
+  let(:presign_download_url) do
+    'https://localhost.localstack.cloud:4566/crime-apply-documents-dev/42/WtpJTOwsQ2?response-content-disposition=attachment%3B%20filename%3Dtest.pdf&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test%2F20231005%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231005T112229Z&X-Amz-Expires=15&X-Amz-SignedHeaders=host&X-Amz-Signature=ca6081d4060ab8fc692f53b1746740f13a6bf3e46a6df0cf0acc06ed2367084e'
+  end
+
+  before do
+    stub_request(:put, 'https://datastore-api-stub.test/api/v1/documents/presign_download')
+      .with(body: expected_query)
+      .to_return(status: 201, body: { url: presign_download_url }.to_json)
+  end
+end

--- a/spec/system/casework/viewing_an_application/that_is_assigned_to_me_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_assigned_to_me_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Viewing an application that is assigned to me' do
+  include_context 'when downloading a document'
+
   let(:application_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
 
   before do
@@ -42,6 +44,12 @@ RSpec.describe 'Viewing an application that is assigned to me' do
       it 'raises error if document is not part of current application' do
         visit download_documents_path(crime_application_id: application_id, id: '321/hijklm5678')
         expect(page).to have_content('File must be uploaded to current application to download')
+      end
+
+      it 'successfully downloads if document is part of current application' do
+        # as there is no visual change on the page, we assert the expect redirect occurred
+        click_on 'Download file (pdf, 12 Bytes)'
+        expect(page).to have_current_path(presign_download_url)
       end
     end
   end

--- a/spec/system/casework/viewing_an_application/that_is_assigned_to_me_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_assigned_to_me_spec.rb
@@ -37,5 +37,12 @@ RSpec.describe 'Viewing an application that is assigned to me' do
         expect(page).not_to have_content('Mark as ready for MAAT')
       end
     end
+
+    context 'when a user attempts to download supporting evidence' do
+      it 'raises error if document is not part of current application' do
+        visit download_documents_path(crime_application_id: application_id, id: '321/hijklm5678')
+        expect(page).to have_content('File must be uploaded to current application to download')
+      end
+    end
   end
 end

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -350,19 +350,23 @@ RSpec.describe 'Viewing an application unassigned, open application' do
     it 'shows a table with supporting evidence' do
       evidence_row = find(:xpath,
                           "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
-                          //tr[contains(td[1], 'test.pdf')]")
-
+                            //tr[contains(td[1], 'test.pdf')]")
       expect(evidence_row).to have_content('test.pdf Download file (pdf, 12 Bytes)')
     end
 
-    context 'with supporting evidence not provided' do
-      let(:application_data) do
-        super().deep_merge('supporting_evidence' => [])
-      end
+    it 'raises an error if user attempts to download the file' do
+      click_on 'Download file (pdf, 12 Bytes)'
+      expect(page).to have_content('You must assign this application to your list to download files')
+    end
+  end
 
-      it 'does not show supporting evidence section' do
-        expect(page).not_to have_content('Supporting evidence')
-      end
+  context 'with no supporting evidence' do
+    let(:application_data) do
+      super().deep_merge('supporting_evidence' => [])
+    end
+
+    it 'does not show supporting evidence section' do
+      expect(page).not_to have_content('Supporting evidence')
     end
   end
 


### PR DESCRIPTION
## Description of change
This is the second part of two PR's to implement downloading supporting evidence on review. This PR enables users to download evidence. There are two restrictions to downloading evidence: 1) You must be assigned to the application 2) You must be downloading a file that is uploaded to the current application (this is to prevent malicious actors from changing the application id of a link to an application they are assigned to, to download files in other applications). 

Videos are linked below to demonstrate the functionality 

## Link to relevant ticket
[CRIMAP-526](https://dsdmoj.atlassian.net/browse/CRIMAP-526)

## Notes for reviewer
Note there is slightly different download behaviour per browser and we found that with a firefox browser, pdf files are downloaded and also opened in another tab. This didn't occur for png files and we haven't tested all file types so we're not sure what other file types are impacted. Not sure if this is something that can be fixed with JS in some way but we didn't explore for now as it is only happening in one browser and we will potentially explore opening the file in a new tab vs. downloading (according to the ticket). 

Also error message content needs review from content/design.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

**Scenario: successfully downloading files**

https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/89aa307f-9234-4047-a1a3-7c582917b599

**Scenario: Attempting to download a file when user is not assigned to the current application**

https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/cbf32ec7-6e73-46e5-b4e2-77f92597a5bb

**Scenario: Attempting to download a file that is not uploaded to the current application**

https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/98e91503-5b8e-4abe-9c66-0ed10276119d

## How to manually test the feature


[CRIMAP-526]: https://dsdmoj.atlassian.net/browse/CRIMAP-526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ