### PR TITLE
CRIMRE-589 event source the workload mini report

### DIFF
--- a/app/models/reporting/business_day_age_range_row.rb
+++ b/app/models/reporting/business_day_age_range_row.rb
@@ -1,0 +1,48 @@
+module Reporting
+  class BusinessDayAgeRangeRow
+    def initialize(age_range_in_business_days:, observed_at:)
+      @age_range_in_business_days = age_range_in_business_days
+      @observed_at = observed_at.in_time_zone('London')
+      @day_zero = observed_at.to_date
+    end
+
+    # Business days since application were received header column for table.
+    # With current defaults, returns an array of header cells with contents:
+    #
+    # 0 days
+    # 1 day
+    # 2 days
+    # Between 3 and 9 days
+    def label
+      if first == last
+        I18n.t('values.days_passed', count: first)
+      else
+        I18n.t('values.days_passed_range', first:, last:)
+      end
+    end
+
+    def total_received
+      dataset.fetch(:total_received)
+    end
+
+    def total_open
+      total_received - dataset.fetch(:total_closed)
+    end
+
+    private
+
+    delegate :first, :last, to: :age_range_in_business_days
+
+    attr_reader :day_zero, :observed_at, :age_range_in_business_days
+
+    def dataset
+      @dataset ||= ReceivedOnReports::Projection.for_dates(business_days, observed_at:).dataset
+    end
+
+    def business_days
+      @business_days ||= [*age_range_in_business_days].map do |age_in_business_days|
+        BusinessDay.new(age_in_business_days:, day_zero:).date
+      end
+    end
+  end
+end

--- a/app/models/reporting/workload_report.rb
+++ b/app/models/reporting/workload_report.rb
@@ -1,107 +1,39 @@
 module Reporting
   class WorkloadReport
-    # Builds a Workload Report table with 'n' number of rows. The first row corresponds
-    # to applications that were received zero business days ago. The second row
-    # applications received one business day ago, and so on, until the last row, which
-    # includes a count up to the specified 'last_row_limit_in_days'.
-    def initialize(number_of_rows: 5, day_zero: Time.current, last_row_limit_in_days: 9)
-      @number_of_rows = number_of_rows
-      @day_zero = day_zero.in_time_zone('London').to_date
-      @last_row_limit_in_days = last_row_limit_in_days
+    # Builds a Workload Report from "observed_at" until "age_limit" business days
+    # ago.
+    #
+    # If the "number_of_rows" limit is set to be less than the number of rows
+    # required to accomodate 1 business day per row, the remaining days are
+    # combined into the final row. For example:
+    #   "0 days", "1 day", "2 days", "Between 3 and 9 days"
+    #
+    def initialize(observed_at: Time.current, age_limit: 9, number_of_rows: 5)
+      @observed_at = observed_at
+      @age_limit = age_limit
+      @number_of_rows = number_of_rows || (age_limit + 1)
     end
+
+    attr_reader :observed_at
 
     def rows
-      [days_passed, received_applications_by_age, open_applications_by_age].transpose
-    end
-
-    private
-
-    attr_reader :number_of_rows, :day_zero, :last_row_limit_in_days
-
-    def open_applications_by_age
-      reports.map { |report| Cell.new(report.total_open, numeric: true) }
-    end
-
-    def received_applications_by_age
-      reports.map { |report| Cell.new(report.total_received, numeric: true) }
-    end
-
-    #
-    # Business days since application were received header column for table.
-    # With current defaults, returns an array of header cells with contents:
-    #
-    # 0 days
-    # 1 day
-    # 2 days
-    # Between 3 and 9 days
-    #
-    def days_passed
-      # All bar last row header
-      row_headers = Array.new(number_of_rows - 1) do |day|
-        I18n.t('values.days_passed', count: day)
-      end
-
-      # Add the last row header.
-      row_headers << last_row_header_text
-
-      row_headers.map { |text| Cell.new(text, header: true, numeric: false) }
-    end
-
-    def business_days
-      @business_days ||= Array.new(number_of_rows) do |age_in_business_days|
-        BusinessDay.new(
-          age_in_business_days:,
-          day_zero:
+      @rows ||= Array.new(@number_of_rows) do |row|
+        BusinessDayAgeRangeRow.new(
+          age_range_in_business_days: age_range_for_row(row),
+          observed_at: observed_at
         )
       end
     end
 
-    def reports
-      @reports ||= business_days.map do |business_day|
-        if business_day == business_days.last
-          last_day_or_more_report
-        else
-          Reporting::ReceivedOnReport.find_or_initialize_by(
-            business_day: business_day.date
-          )
-        end
-      end
+    def age_range_for_row(row_index)
+      min_age = row_index
+      max_age = last_row?(row_index) ? @age_limit : min_age
+
+      min_age..max_age
     end
 
-    # The date of the youngest business day not included in the last
-    # row counts -- all applications in the last row must have a business
-    # date younger than this date.
-    def last_row_cut_off_date
-      @last_row_cut_off_date ||= BusinessDay.new(
-        age_in_business_days: last_row_limit_in_days + 1,
-        day_zero: day_zero
-      ).date
-    end
-
-    def last_row_header_text
-      I18n.t(
-        'values.days_passed.last',
-        count: number_of_rows - 1,
-        limit: last_row_limit_in_days
-      )
-    end
-
-    #
-    # The last row of the report differs from the preceding rows in that it
-    # includes the counts for the previous business days up to and including the
-    # #last_row_limit_in_days business day period.
-    #
-    def last_day_or_more_report
-      scope = Reporting::ReceivedOnReport.where(
-        'business_day > ? AND business_day <= ? ',
-        last_row_cut_off_date,
-        business_days.last.date
-      )
-
-      total_received = scope.sum(:total_received)
-      total_closed = scope.sum(:total_closed)
-
-      Reporting::ReceivedOnReport.new(total_received:, total_closed:)
+    def last_row?(row_index)
+      @number_of_rows == row_index + 1
     end
   end
 end

--- a/app/read_models/received_on_reports/link_to_received_on_stream.rb
+++ b/app/read_models/received_on_reports/link_to_received_on_stream.rb
@@ -15,6 +15,8 @@ module ReceivedOnReports
       )
     end
 
+    private
+
     def stream_name_format
       ReceivedOnReports::Configuration::STREAM_NAME_FORMAT
     end

--- a/app/read_models/received_on_reports/projection.rb
+++ b/app/read_models/received_on_reports/projection.rb
@@ -1,0 +1,43 @@
+module ReceivedOnReports
+  class Projection
+    def initialize(stream_names:, observed_at: Time.current)
+      @stream_names = stream_names.uniq
+      @observed_at = observed_at
+    end
+
+    attr_reader :observed_at
+
+    def dataset
+      return @dataset if @dataset
+
+      total_received = 0
+      total_closed = 0
+
+      @stream_names.each do |stream_name|
+        scope = scope(stream_name)
+        total_received += scope.of_type(Configuration::OPENING_EVENTS).count
+        total_closed += scope.of_type(Configuration::CLOSING_EVENTS).count
+      end
+
+      @dataset = { total_received:, total_closed: }
+    end
+
+    private
+
+    def scope(stream_name)
+      Rails.application.config.event_store.read.stream(stream_name)
+           .older_than_or_equal(observed_at)
+    end
+
+    class << self
+      def for_dates(business_days, observed_at: nil)
+        stream_names = [*business_days].map { |day| business_day_stream_name(day) }
+        new(stream_names:, observed_at:)
+      end
+
+      def business_day_stream_name(business_day)
+        business_day.strftime(ReceivedOnReports::Configuration::STREAM_NAME_FORMAT)
+      end
+    end
+  end
+end

--- a/app/views/reporting/base/_workload_report.html.erb
+++ b/app/views/reporting/base/_workload_report.html.erb
@@ -9,14 +9,19 @@
   <%= table.with_body do |body|
         report.rows.each do |data_row|
           body.with_row do |row|
-            data_row.each do |data_cell|
-              row.with_cell(
-                text: data_cell.content,
-                numeric: data_cell.numeric,
-                header: data_cell.header
-              )
-            end
+            row.with_cell(
+              text: data_row.label,
+              header: true
+            )
+            row.with_cell(
+              text: data_row.total_received,
+              numeric: true
+            )
+            row.with_cell(
+              text: data_row.total_open,
+              numeric: true
+            )
           end
         end
       end %>
-<% end %>
+  <% end %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -7,7 +7,7 @@
       "check_name": "UnsafeReflection",
       "message": "Unsafe reflection method `const_get` called with parameter value",
       "file": "app/controllers/reporting/user_reports_controller.rb",
-      "line": 15,
+      "line": 13,
       "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
       "code": "Reporting.const_get(Types::Report[params.require(:report_type).presence_in(*Types::TemporalReportType)].camelize)",
       "render_path": null,
@@ -21,7 +21,7 @@
       "cwe_id": [
         470
       ],
-      "note": "Constrained by Type"
+      "note": "Scoped by Type"
     },
     {
       "warning_type": "Dynamic Render Path",
@@ -38,7 +38,7 @@
           "type": "controller",
           "class": "Reporting::UserReportsController",
           "method": "show",
-          "line": 16,
+          "line": 14,
           "file": "app/controllers/reporting/user_reports_controller.rb",
           "rendered": {
             "name": "reporting/user_reports/show",
@@ -55,7 +55,7 @@
       "cwe_id": [
         22
       ],
-      "note": "Constrained by Types"
+      "note": "Scoped by Type"
     },
     {
       "warning_type": "Dynamic Render Path",
@@ -89,9 +89,9 @@
       "cwe_id": [
         22
       ],
-      "note": "Constrained by Types"
+      "note": "Scoped by Type"
     }
   ],
-  "updated": "2023-09-19 17:32:11 +0100",
+  "updated": "2023-10-05 12:41:33 +0100",
   "brakeman_version": "6.0.1"
 }

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -174,6 +174,7 @@ en:
       one: 1 day
       other: "%{count} days"
       last: "Between %{count} and %{limit} days"
+    days_passed_range: "Between %{first} and %{last} days"
     review_status:
       submitted: Open
       open: Open

--- a/spec/models/reporting/business_day_age_range_row_spec.rb
+++ b/spec/models/reporting/business_day_age_range_row_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe Reporting::BusinessDayAgeRangeRow do
+  subject(:row) do
+    described_class.new(observed_at:, age_range_in_business_days:)
+  end
+
+  let(:observed_at) { Date.parse('2023-01-04').in_time_zone('London').end_of_day }
+  let(:age_range_in_business_days) { 0..0 }
+  let(:dataset) { { total_closed: 57, total_received: 199 } }
+
+  before do
+    projection = instance_double(ReceivedOnReports::Projection, dataset:)
+    allow(ReceivedOnReports::Projection).to receive(:for_dates) { projection }
+  end
+
+  describe '#label' do
+    subject(:label) { row.label }
+
+    context 'when age is zero business days' do
+      it { is_expected.to eq '0 days' }
+    end
+
+    context 'when age is one business day' do
+      let(:age_range_in_business_days) { 1..1 }
+
+      it { is_expected.to eq '1 day' }
+    end
+
+    context 'when age is two business day' do
+      let(:age_range_in_business_days) { 2..2 }
+
+      it { is_expected.to eq '2 days' }
+    end
+
+    context 'when age range' do
+      let(:age_range_in_business_days) { 2..5 }
+
+      it { is_expected.to eq 'Between 2 and 5 days' }
+    end
+  end
+
+  describe '#total_received' do
+    subject(:total_received) { row.total_received }
+
+    it { is_expected.to be 199 }
+  end
+
+  describe '#total_open' do
+    subject(:total_open) { row.total_open }
+
+    it { is_expected.to be 142 }
+  end
+end

--- a/spec/models/reporting/workload_report_spec.rb
+++ b/spec/models/reporting/workload_report_spec.rb
@@ -1,64 +1,61 @@
 require 'rails_helper'
 
 RSpec.describe Reporting::WorkloadReport do
-  subject(:report) { described_class.new day_zero: day_zero, number_of_rows: 4 }
-
-  let(:day_zero) { Date.parse('2023-01-04') }
-
-  before do
-    received_on_reports = [
-      ['2023-01-05', 100, 0],
-      ['2023-01-04', 10, 5],
-      ['2023-01-03', 8, 8],
-      ['2022-12-30', 5, 1],
-      ['2022-12-29', 4, 3],
-      ['2022-12-18', 50, 49],
-      ['2022-12-17', 1000, 999],
-      ['2022-12-16', 10_000, 1]
-    ].map do |business_day, total_received, total_closed|
-      { business_day:, total_received:, total_closed: }
-    end
-
-    # rubocop:disable Rails/SkipsModelValidations
-    Reporting::ReceivedOnReport.insert_all(received_on_reports)
-    # rubocop:enable Rails/SkipsModelValidations
+  subject(:report) do
+    described_class.new(observed_at:, age_limit:, number_of_rows:)
   end
+
+  let(:observed_at) { Date.parse('2023-01-04').in_time_zone('London').end_of_day }
+  let(:age_limit) { 2 }
+  let(:number_of_rows) { 3 }
 
   describe '#rows' do
     subject(:rows) { report.rows }
 
-    it 'all but the first column are numeric' do
-      expect(rows.first.map(&:numeric)).to eq [false, true, true]
+    it 'returns an array of BusinessDayAgeRangeRow up to the configured age limit' do
+      expect(rows.size).to eq(3)
+      expect(rows).to all(be_a(Reporting::BusinessDayAgeRangeRow))
     end
 
-    it 'includes 4 rows of data' do
-      expect(rows.size).to eq(4)
+    it 'each row contains data for a single business day' do
+      allow(Reporting::BusinessDayAgeRangeRow).to receive(:new)
+      rows
+      [0..0, 1..1, 2..2].each do |age_range_in_business_days|
+        expect(Reporting::BusinessDayAgeRangeRow).to have_received(:new).with(
+          age_range_in_business_days:, observed_at:
+        )
+      end
     end
 
-    it 'row headers with "0 days", "1 day", "2 days", and "Between 3 and 9 days"' do
-      expect(rows.map { |row| row.first.content }).to eq(
-        ['0 days', '1 day', '2 days', 'Between 3 and 9 days']
-      )
-    end
+    context 'when the number_of_rows cannot accomodate 1 day per row' do
+      let(:age_limit) { 9 }
+      let(:number_of_rows) { 3 }
 
-    describe 'data' do
-      subject(:columns) { rows.map { |r| r[1, 2] }.transpose }
+      it 'combines the remaining days into the final row' do
+        allow(Reporting::BusinessDayAgeRangeRow).to receive(:new)
+        rows
 
-      describe 'received applications' do
-        subject(:received_counts) { columns.first.map(&:content) }
-
-        it { is_expected.to eq([10, 8, 5, 1054]) }
+        [0..0, 1..1, 2..9].each do |age_range_in_business_days|
+          expect(Reporting::BusinessDayAgeRangeRow).to have_received(:new).with(
+            age_range_in_business_days:, observed_at:
+          )
+        end
       end
 
-      describe 'open applications' do
-        subject(:open_counts) { columns.last.map(&:content) }
-
-        it { is_expected.to eq([5, 0, 4, 3]) }
+      it 'labels the rows accordingly' do
+        expected_rows = ['0 days', '1 day', 'Between 2 and 9 days']
+        expect(rows.map(&:label)).to eq(expected_rows)
       end
     end
   end
 
-  it 'number of rows defaults to 5' do
-    expect(described_class.new.rows.size).to be 5
+  it 'the age limit defaults to 9 days old' do
+    expect(described_class.new.rows.last.label).to eq 'Between 4 and 9 days'
+  end
+
+  it 'the "number_of_rows" defaults to the number required to reach the age limit' do
+    report = described_class.new(age_limit: 11, number_of_rows: nil)
+    expect(report.rows.size).to eq 12
+    expect(report.rows.last.label).to eq '11 days'
   end
 end

--- a/spec/read_models/received_on_reports/projection_spec.rb
+++ b/spec/read_models/received_on_reports/projection_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe ReceivedOnReports::Projection do
+  let(:event_store) { Rails.configuration.event_store }
+
+  describe 'instance' do
+    let(:stream_names) { ['ReceivedOn$2023-278', 'ReceivedOn$2023-279'] }
+    let(:split_time) { Time.zone.local(2023, 10, 5, 1, 21) }
+    let(:observed_at) { Time.current }
+
+    describe '#dataset' do
+      subject(:dataset) { described_class.new(stream_names:, observed_at:).dataset }
+
+      before do
+        # We use the "split_time" to test being able to observe the stream at a given time.
+        travel_to split_time - 1.day
+
+        events = [
+          Reviewing::ApplicationReceived.new,
+          Reviewing::ApplicationReceived.new,
+          Reviewing::SentBack.new
+        ]
+
+        event_store.publish(events, stream_name: stream_names.first)
+        event_store.publish(Reviewing::ApplicationReceived.new, stream_name: stream_names.last)
+
+        travel_to split_time
+
+        event_store.publish(Reviewing::SentBack.new, stream_name: stream_names.first)
+
+        travel_back
+      end
+
+      it 'returns a tally of received applications' do
+        expect(dataset.fetch(:total_received)).to be 3
+      end
+
+      it 'returns a tally of closed applications' do
+        expect(dataset.fetch(:total_closed)).to be 2
+      end
+
+      context 'when observing 1 second before an event' do
+        let(:observed_at) { split_time.in_time_zone('London') - 1.second }
+
+        it 'excludes the event from the tally' do
+          expect(dataset.fetch(:total_closed)).to be 1
+        end
+      end
+
+      context 'when observing at the time of an event' do
+        let(:observed_at) { split_time.in_time_zone('London') }
+
+        it 'includes the event in the tally' do
+          expect(dataset.fetch(:total_closed)).to be 2
+        end
+      end
+    end
+  end
+
+  describe '.for_dates' do
+    before do
+      allow(described_class).to receive(:new)
+      described_class.for_dates(business_days)
+    end
+
+    context 'when for more than one date' do
+      let(:business_days) { [Date.new(2023, 10, 5), Date.new(2023, 10, 4)] }
+
+      it 'initializes the projection with the stream names for the business days' do
+        expect(described_class).to have_received(:new).with(
+          stream_names: ['ReceivedOn$2023-278', 'ReceivedOn$2023-277'],
+          observed_at: nil
+        )
+      end
+    end
+
+    context 'when for a single date' do
+      let(:business_days) { Date.new(2023, 10, 5) }
+
+      it 'initializes the projection with the stream name for the business day' do
+        expect(described_class).to have_received(:new).with(
+          stream_names: ['ReceivedOn$2023-278'],
+          observed_at: nil
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
CRIMRE-589 refactor workload report to event source its data.

## Link to relevant ticket
[CRIMAP-589](https://dsdmoj.atlassian.net/browse/CRIMAP-589)

## Notes for reviewer

The workload report has only been available as a snapshot of current state. CRIMRE-589  adds functionality to view this report as it was at any given time. This PR is a prepares for that by event sourcing the report rather than relying on the data cached in the ReceivedOnReport table.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

Confirm that the mini report on the open applications page is correct.


[CRIMAP-589]: https://dsdmoj.atlassian.net/browse/CRIMAP-589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ