### PR TITLE
[CHORE] Add modsec exception for SNS events STAGING ONLY

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -24,6 +24,9 @@ metadata:
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
       SecRuleUpdateTargetById 941100-941350 !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetById 942100 !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
+      SecRule REQUEST_URI "@beginsWith /api/events" "id:555001, phase:1, pass, t:none, nolog, chain" \
+        SecRule REQUEST_METHOD "@streq POST" "chain" \
+          SecRule REQUEST_HEADERS:Content-Type "@streq text/plain" "ctl:ruleRemoveById=920480"
 spec:
   ingressClassName: modsec
   tls:


### PR DESCRIPTION
## Description of change
Adds an exception to modsec to allow SNS events sent to /api/events

## Link to relevant ticket
N/A

## Notes for reviewer
The following log error in kibana showed modsecurity rejecting AWS SNS Event notifications to /api/events because `text/plain` headers are disallowed by default by the OWASP Core ruleset.

Kibana log:
```
{
  "transaction": {
    "client_ip": "52.94.39.44",
    "time_stamp": "Fri Oct  6 08:56:32 2023",
    "server_id": "7e6bcce3ecf046b75f697a6d36c2d328899efc7c",
    "client_port": 28793,
    "host_ip": "172.20.63.31",
    "host_port": 443,
    "unique_id": "cfa545c3306c2ee94755b1339a5d472a",
    "request": { "method": "POST", "http_version": 1.1, "uri": "/api/events" },
    "response": {
      "body": "<html>\r\n<head><title>403 Forbidden</title></head>\r\n<body>\r\n<center><h1>403 Forbidden</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n",
      "http_code": 403,
      "headers": {
        "Server": "",
        "Server": "",
        "Date": "Fri, 06 Oct 2023 08:56:32 GMT",
        "Content-Length": "146",
        "Content-Type": "text/html",
        "Connection": "keep-alive",
        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
      }
    },
    "producer": {
      "modsecurity": "ModSecurity v3.0.8 (Linux)",
      "connector": "ModSecurity-nginx v1.0.3",
      "secrules_engine": "Enabled",
      "components": ["OWASP_CRS/3.3.4\""]
    },
    "messages": [
      {
        "message": "Request content type is not allowed by policy",
        "details": {
          "match": "Matched \"Operator `Within' with parameter `|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/cloudevents+json| |application/cloudev (16 characters omitted)' against variable `TX:content_type' (Value: `|text/plain|' )",
          "reference": "o0,10v420,25t:lowercase",
          "ruleId": "920420",
          "file": "/etc/nginx/owasp-modsecurity-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf",
          "lineNumber": "938",
          "data": "|text/plain|",
          "severity": "2",
          "ver": "OWASP_CRS/3.3.4",
          "rev": "",
          "tags": [
            "github_team=laa-crime-apply",
            "github_team=laa-crime-apply",
            "application-multi",
            "language-multi",
            "platform-multi",
            "attack-protocol",
            "paranoia-level/1",
            "OWASP_CRS",
            "capec/1000/255/153",
            "PCI/12.1"
          ],
          "maturity": "0",
          "accuracy": "0"
        }
      },
      {
        "message": "Inbound Anomaly Score Exceeded (Total Score: 5)",
        "details": {
          "match": "Matched \"Operator `Ge' with parameter `5' against variable `TX:ANOMALY_SCORE' (Value: `5' )",
          "reference": "",
          "ruleId": "949110",
          "file": "/etc/nginx/owasp-modsecurity-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf",
          "lineNumber": "81",
          "data": "",
          "severity": "2",
          "ver": "OWASP_CRS/3.3.4",
          "rev": "",
          "tags": [
            "github_team=laa-crime-apply",
            "application-multi",
            "language-multi",
            "platform-multi",
            "attack-generic"
          ],
          "maturity": "0",
          "accuracy": "0"
        }
      }
    ]
  }
}

```

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
