### PR TITLE
[CRIMAP-655] Use regex for sns modsecurity (STAGING ONLY)

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -26,7 +26,7 @@ metadata:
       SecRuleUpdateTargetById 942100 !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRule REQUEST_URI "@beginsWith /api/events" "id:555001, phase:1, pass, t:none, nolog, chain" \
         SecRule REQUEST_METHOD "@streq POST" "chain" \
-          SecRule REQUEST_HEADERS:Content-Type "@streq text/plain" "ctl:ruleRemoveById=920480"
+          SecRule REQUEST_HEADERS:Content-Type "@rx ^[ \s]*text/plain[ \s]*$" "ctl:ruleRemoveById=920420"
 spec:
   ingressClassName: modsec
   tls:

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -26,7 +26,7 @@ metadata:
       SecRuleUpdateTargetById 942100 !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRule REQUEST_URI "@beginsWith /api/events" "id:555001, phase:1, pass, t:none, nolog, chain" \
         SecRule REQUEST_METHOD "@streq POST" "chain" \
-          SecRule REQUEST_HEADERS:Content-Type "@rx ^[ \s]*text/plain[ \s]*$" "ctl:ruleRemoveById=920420"
+          SecRule REQUEST_HEADERS:Content-Type "@rx [\s]*text/plain[\s]*" "ctl:ruleRemoveById=920420"
 spec:
   ingressClassName: modsec
   tls:


### PR DESCRIPTION
## Description of change
Attempts to allow legitimate AWS SNS messages through using a regex. The actual header sent by AWS is: `Content-Type: text/plain; charset=UTF-8`

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-655

## Notes for reviewer
Tried to remove the regex so that ANY POST request would have the rule `920420` removed however that didn't work as intended with limited testing directly against staging. Using this PR to confirm properly the ingress is working for AWS SNS events.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
