### PR TITLE
[CRIMAP-655] Enable AWS SNS messages through modsecurity (PRODUCTION ONLY)

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -24,6 +24,9 @@ metadata:
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
       SecRuleUpdateTargetById 941100-941350 !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetById 942100 !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
+      SecRule REQUEST_URI "@beginsWith /api/events" "id:555001, phase:1, pass, t:none, nolog, chain" \
+        SecRule REQUEST_METHOD "@streq POST" "chain" \
+          SecRule REQUEST_HEADERS:Content-Type "@rx [\s]*text/plain[\s]*" "ctl:ruleRemoveById=920420"
 spec:
   ingressClassName: modsec
   tls:


### PR DESCRIPTION
## Description of change
Allows AWS SNS messages with `content-type: text/plain; charset=UTF-8` style header through the firewall.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-655

## Notes for reviewer
This rule is already active in Staging.

The following curl request should return 422:
```
curl -X GET -H "Content-Type: text/plain; charset=UTF-8" https://review-criminal-legal-aid.service.justice.gov.uk -v
```

However the following curl request fails - the regex has given us a lot of grief so we will evaluate effectiveness over time:

```
curl -X POST -H "Content-Type: text/plain;" https://staging.review-criminal-legal-aid.service.justice.gov.uk/api/events -v
```


## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Use curl as per above