### PR TITLE
CRIMRE-589 prototype processed snapshot report

### DIFF
--- a/app/controllers/reporting/snapshots_controller.rb
+++ b/app/controllers/reporting/snapshots_controller.rb
@@ -1,0 +1,22 @@
+module Reporting
+  class SnapshotsController < Reporting::BaseController
+    before_action :set_report_type
+    before_action :require_report_access!
+
+    def show
+      @report = Reporting::Snapshot.from_param(report_type: @report_type, date: params[:date], time: params[:time])
+    end
+
+    def now
+      @report = Reporting::Snapshot.new(report_type: @report_type)
+
+      render :show
+    end
+
+    private
+
+    def set_report_type
+      @report_type = params.require(:report_type).presence_in(*Types::SnapshotReportType)
+    end
+  end
+end

--- a/app/controllers/reporting/user_reports_controller.rb
+++ b/app/controllers/reporting/user_reports_controller.rb
@@ -7,6 +7,7 @@ module Reporting
 
     def index
       @latest_temporal_reports = latest_temporal_reports
+      @snapshot_report_types = snapshot_report_types
     end
 
     def show
@@ -35,6 +36,10 @@ module Reporting
 
     def temporal_report_types
       current_user.reports & Types::TemporalReportType.values
+    end
+
+    def snapshot_report_types
+      current_user.reports & Types::SnapshotReportType.values
     end
   end
 end

--- a/app/helpers/app_text_helper.rb
+++ b/app/helpers/app_text_helper.rb
@@ -27,6 +27,8 @@ module AppTextHelper
 
   def named_text(text_type, key, options = {})
     namespace = controller.try(:text_namespace)
-    I18n.t(key, scope: [namespace, text_type].compact, **options)
+    scope = [namespace, text_type, *options.delete(:scope)]
+
+    I18n.t(key, scope:, **options)
   end
 end

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -21,9 +21,7 @@ module Types
       Types::ReviewApplicationStatus['assessment_completed'],
       Types::ReviewApplicationStatus['returned_to_provider']
     ],
-    'completed' => [
-      Types::ReviewApplicationStatus['assessment_completed']
-    ],
+    'completed' => [Types::ReviewApplicationStatus['assessment_completed']],
     'sent_back' => [
       Types::ReviewApplicationStatus['returned_to_provider']
     ],
@@ -56,6 +54,8 @@ module Types
   )
 
   Report = String.enum('caseworker_report', 'processed_report', 'workload_report')
+
+  SnapshotReportType = String.enum(Report['workload_report'])
   TemporalReportType = String.enum(Report['caseworker_report'])
   TemporalInterval = String.enum('monthly', 'weekly', 'daily')
 

--- a/app/models/reporting/workload_report.rb
+++ b/app/models/reporting/workload_report.rb
@@ -25,6 +25,8 @@ module Reporting
       end
     end
 
+    private
+
     def age_range_for_row(row_index)
       min_age = row_index
       max_age = last_row?(row_index) ? @age_limit : min_age
@@ -33,7 +35,7 @@ module Reporting
     end
 
     def last_row?(row_index)
-      @number_of_rows == row_index + 1
+      row_index == @number_of_rows - 1
     end
   end
 end

--- a/app/read_models/received_on_reports/projection.rb
+++ b/app/read_models/received_on_reports/projection.rb
@@ -1,7 +1,7 @@
 module ReceivedOnReports
   class Projection
-    def initialize(stream_names:, observed_at: Time.current)
-      @stream_names = stream_names.uniq
+    def initialize(stream_name:, observed_at: Time.current)
+      @stream_name = stream_name
       @observed_at = observed_at
     end
 
@@ -10,33 +10,26 @@ module ReceivedOnReports
     def dataset
       return @dataset if @dataset
 
-      total_received = 0
-      total_closed = 0
-
-      @stream_names.each do |stream_name|
-        scope = scope(stream_name)
-        total_received += scope.of_type(Configuration::OPENING_EVENTS).count
-        total_closed += scope.of_type(Configuration::CLOSING_EVENTS).count
-      end
+      total_received = scope.of_type(Configuration::OPENING_EVENTS).count
+      total_closed = scope.of_type(Configuration::CLOSING_EVENTS).count
 
       @dataset = { total_received:, total_closed: }
     end
 
     private
 
-    def scope(stream_name)
-      Rails.application.config.event_store.read.stream(stream_name)
+    def scope
+      Rails.application.config.event_store.read.stream(@stream_name)
            .older_than_or_equal(observed_at)
     end
 
     class << self
-      def for_dates(business_days, observed_at: nil)
-        stream_names = [*business_days].map { |day| business_day_stream_name(day) }
-        new(stream_names:, observed_at:)
-      end
+      def for_date(business_day, observed_at: nil)
+        stream_name = business_day.strftime(
+          ReceivedOnReports::Configuration::STREAM_NAME_FORMAT
+        )
 
-      def business_day_stream_name(business_day)
-        business_day.strftime(ReceivedOnReports::Configuration::STREAM_NAME_FORMAT)
+        new(stream_name:, observed_at:)
       end
     end
   end

--- a/app/views/reporting/snapshots/show.html.erb
+++ b/app/views/reporting/snapshots/show.html.erb
@@ -1,0 +1,37 @@
+<% title(@report.title) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-3">
+      <%= label_text(@report_type) %>
+    </h1>
+
+    <%= govuk_pagination(block_mode: true) do |p| %>
+      <%= p.with_previous_page text: 'Previous day', label_text: l(@report.previous_report.observed_at, format: :snapshot), href: reporting_snapshot_path(@report.previous_report.to_param)  %>
+
+      <% unless @report.current? %>
+        <% if @report.next_report.current? %>
+          <%= p.with_next_page text: 'Next day', label_text: l(@report.next_report.observed_at, format: :now), href: reporting_current_snapshot_path(@report_type)  %>
+        <% else %>
+          <%= p.with_next_page text: 'Next day', label_text: l(@report.next_report.observed_at, format: :snapshot), href: url_for(@report.next_report.to_param)  %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-m">
+      <%= l(@report.observed_at, format: :snapshot) %>
+    </h2>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <%= turbo_frame_tag @report_type, data: { turbo: 'true' } do %>
+      <%= render partial: @report_type, locals: { report: @report } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/reporting/user_reports/index.html.erb
+++ b/app/views/reporting/user_reports/index.html.erb
@@ -27,10 +27,20 @@
     <% end %>
 
     <h2 class='govuk-heading-m'>Latest snapshots<h2>
-    <% current_user.reports.each do |report_type| %>
+
+    <% @snapshot_report_types.each do |report_type| %>
       <h3 class='govuk-heading-s'>
-        <%= govuk_link_to label_text(report_type), reporting_user_report_path(report_type), { no_visited_state: true } %>
+        <%= govuk_link_to(
+              label_text(report_type),
+              reporting_current_snapshot_path(report_type),
+              { no_visited_state: true }
+            ) %>
       </h3>
+
     <% end %>
+
+    <h3 class='govuk-heading-s'>
+      <%= govuk_link_to label_text('processed_report'), reporting_user_report_path('processed_report'), { no_visited_state: true } %>
+    </h3>
   </div>
 </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,72 +1,15 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Remote Code Execution",
-      "warning_code": 24,
-      "fingerprint": "3bc47d1d64eee125a9ec3ee1ad06429eb12ca50addb0ad8aeb3fce7847fdd520",
-      "check_name": "UnsafeReflection",
-      "message": "Unsafe reflection method `const_get` called with parameter value",
-      "file": "app/controllers/reporting/user_reports_controller.rb",
-      "line": 13,
-      "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
-      "code": "Reporting.const_get(Types::Report[params.require(:report_type).presence_in(*Types::TemporalReportType)].camelize)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Reporting::UserReportsController",
-        "method": "show"
-      },
-      "user_input": "params.require(:report_type).presence_in(*Types::TemporalReportType)",
-      "confidence": "Medium",
-      "cwe_id": [
-        470
-      ],
-      "note": "Scoped by Type"
-    },
-    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "99f8c84c26b50119e57b780ab3f8bf9184d5037493022325ff69b9afdeb104b4",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/views/reporting/user_reports/show.html.erb",
-      "line": 14,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(partial => params.require(:report_type).presence_in(*Types::TemporalReportType), { :locals => ({ :report => Reporting.const_get(Types::Report[params.require(:report_type).presence_in(*Types::TemporalReportType)].camelize).new }) })",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Reporting::UserReportsController",
-          "method": "show",
-          "line": 14,
-          "file": "app/controllers/reporting/user_reports_controller.rb",
-          "rendered": {
-            "name": "reporting/user_reports/show",
-            "file": "app/views/reporting/user_reports/show.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "reporting/user_reports/show"
-      },
-      "user_input": "params.require(:report_type).presence_in(*Types::TemporalReportType)",
-      "confidence": "High",
-      "cwe_id": [
-        22
-      ],
-      "note": "Scoped by Type"
-    },
-    {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "9d21d6dd1eeda467dd7c9568006a3fb50229e8adb78658565f1fbc9cc7c50e66",
+      "fingerprint": "76f30c460c50dcd62a7d92d439de585ac7932e16bb188a7f82d41140dc16d40b",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/reporting/temporal_reports/show.html.erb",
       "line": 20,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(partial => params.require(:report_type).presence_in(*Types::TemporalReportType), { :locals => ({ :report => report_klass.from_param(:report_type => params.require(:report_type).presence_in(*Types::TemporalReportType), :period => params[:period]) }) })",
+      "code": "render(partial => params.require(:report_type).presence_in(*Types::SnapshotReportType), { :locals => ({ :report => report_klass.from_param(:report_type => params.require(:report_type).presence_in(*Types::SnapshotReportType), :period => params[:period]) }) })",
       "render_path": [
         {
           "type": "controller",
@@ -84,14 +27,105 @@
         "type": "template",
         "template": "reporting/temporal_reports/show"
       },
-      "user_input": "params.require(:report_type).presence_in(*Types::TemporalReportType)",
+      "user_input": "params.require(:report_type).presence_in(*Types::SnapshotReportType)",
       "confidence": "High",
       "cwe_id": [
         22
       ],
       "note": "Scoped by Type"
+    },
+    {
+      "warning_type": "Remote Code Execution",
+      "warning_code": 24,
+      "fingerprint": "820d5ff4010418a7a11637323f60a964ef46ff5f5b531f18bebcf7992a12ed8b",
+      "check_name": "UnsafeReflection",
+      "message": "Unsafe reflection method `const_get` called with parameter value",
+      "file": "app/controllers/reporting/user_reports_controller.rb",
+      "line": 14,
+      "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
+      "code": "Reporting.const_get(Types::Report[params.require(:report_type).presence_in(*Types::SnapshotReportType)].camelize)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Reporting::UserReportsController",
+        "method": "show"
+      },
+      "user_input": "params.require(:report_type).presence_in(*Types::SnapshotReportType)",
+      "confidence": "Medium",
+      "cwe_id": [
+        470
+      ],
+      "note": "Scoped by Type"
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "ad3817dddc2165af97b6dd13096b32f6d033deb6b3a8ad14eb51a6964d3541b6",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/reporting/user_reports/show.html.erb",
+      "line": 14,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(partial => params.require(:report_type).presence_in(*Types::SnapshotReportType), { :locals => ({ :report => Reporting.const_get(Types::Report[params.require(:report_type).presence_in(*Types::SnapshotReportType)].camelize).new }) })",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Reporting::UserReportsController",
+          "method": "show",
+          "line": 15,
+          "file": "app/controllers/reporting/user_reports_controller.rb",
+          "rendered": {
+            "name": "reporting/user_reports/show",
+            "file": "app/views/reporting/user_reports/show.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "reporting/user_reports/show"
+      },
+      "user_input": "params.require(:report_type).presence_in(*Types::SnapshotReportType)",
+      "confidence": "High",
+      "cwe_id": [
+        22
+      ],
+      "note": "Scoped by Type"
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "dd542b1ff01fcf89839000d8c094ba3d1d4a8894e76330f11b28469a1cc5c94c",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/reporting/snapshots/show.html.erb",
+      "line": 34,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(partial => params.require(:report_type).presence_in(*Types::SnapshotReportType), { :locals => ({ :report => Reporting::Snapshot.new(:report_type => params.require(:report_type).presence_in(*Types::SnapshotReportType)) }) })",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Reporting::SnapshotsController",
+          "method": "now",
+          "line": 17,
+          "file": "app/controllers/reporting/snapshots_controller.rb",
+          "rendered": {
+            "name": "reporting/snapshots/show",
+            "file": "app/views/reporting/snapshots/show.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "reporting/snapshots/show"
+      },
+      "user_input": "params.require(:report_type).presence_in(*Types::SnapshotReportType)",
+      "confidence": "High",
+      "cwe_id": [
+        22
+      ],
+      "note": ""
     }
   ],
-  "updated": "2023-10-05 12:41:33 +0100",
+  "updated": "2023-10-09 18:30:59 +0100",
   "brakeman_version": "6.0.1"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,8 @@ en:
       <<: *DATE_FORMATS
       datetime: '%-l:%M%P %-d %b %Y'  # 2:45pm 3 Jan 2019
       timestamp: '%A %-d %b %H:%M'  # Thursday 3 Jan 14:45
+      snapshot: '%A %-d %B %H:%M' 
+      now: '%A %-d %B'
 
   phase_banner:
     tag:

--- a/config/locales/en/reporting.yml
+++ b/config/locales/en/reporting.yml
@@ -9,6 +9,9 @@ en:
     daily_report:
       caseworker_report:
         title: "Caseworker daily: %{period_name}"
+    snapshot:
+      workload_report: 
+        title: "Workload report: %{observed_at}"
     user_reports:
       index:
         page_title: Reporting 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,8 @@ Rails.application.routes.draw do
     root to: 'user_reports#index'
     get ':report_type', to: 'user_reports#show', as: 'user_report'
     get ':report_type/:interval/:period', to: 'temporal_reports#show', as: :temporal_report
+    get ':report_type/:date/at/:time', to: 'snapshots#show', as: :snapshot
+    get ':report_type/now', to: 'snapshots#now', as: :current_snapshot
   end
 
   namespace :manage_users do

--- a/spec/models/reporting/snapshot_spec.rb
+++ b/spec/models/reporting/snapshot_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Reporting::Snapshot do
+  subject(:snapshot) do
+    described_class.new(report_type:, observed_at:)
+  end
+
+  let(:report_type) { Types::Report['workload_report'] }
+  let(:observed_at) { Time.zone.local(2023, 10, 9, 11, 11) }
+
+  let(:example_params) do
+    {
+      report_type: 'workload_report',
+      date: '2023-10-09',
+      time: '12:11'
+    }
+  end
+
+  describe '#to_param' do
+    subject(:to_param) { snapshot.to_param }
+
+    it 'is a hash of "report_type", "date", and "time"' do
+      expect(to_param).to eq example_params
+    end
+  end
+
+  describe '.from_param' do
+    let(:from_param) { described_class.from_param(**example_params) }
+
+    it 'initialize a snapshot based on the params' do
+      expect(from_param.to_param).to eq(example_params)
+    end
+
+    context 'with invalid date params' do
+      let(:example_params) { super().merge(date: '2023-13-10') }
+
+      it 'raises Reporting::ReportNotFound' do
+        expect { from_param }.to raise_error Reporting::ReportNotFound
+      end
+    end
+
+    context 'with an unsupported report_type' do
+      let(:example_params) { super().merge(report_type: Types::Report['caseworker_report']) }
+
+      it 'raises Reporting::ReportNotFound' do
+        expect { from_param }.to raise_error Reporting::ReportNotFound
+      end
+    end
+  end
+end

--- a/spec/read_models/received_on_reports/projection_spec.rb
+++ b/spec/read_models/received_on_reports/projection_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe ReceivedOnReports::Projection do
   let(:event_store) { Rails.configuration.event_store }
 
   describe 'instance' do
-    let(:stream_names) { ['ReceivedOn$2023-278', 'ReceivedOn$2023-279'] }
+    let(:stream_name) { ['ReceivedOn$2023-278'] }
     let(:split_time) { Time.zone.local(2023, 10, 5, 1, 21) }
     let(:observed_at) { Time.current }
 
     describe '#dataset' do
-      subject(:dataset) { described_class.new(stream_names:, observed_at:).dataset }
+      subject(:dataset) { described_class.new(stream_name:, observed_at:).dataset }
 
       before do
         # We use the "split_time" to test being able to observe the stream at a given time.
@@ -18,15 +18,15 @@ RSpec.describe ReceivedOnReports::Projection do
         events = [
           Reviewing::ApplicationReceived.new,
           Reviewing::ApplicationReceived.new,
-          Reviewing::SentBack.new
+          Reviewing::SentBack.new,
+          Reviewing::ApplicationReceived.new
         ]
 
-        event_store.publish(events, stream_name: stream_names.first)
-        event_store.publish(Reviewing::ApplicationReceived.new, stream_name: stream_names.last)
+        event_store.publish(events, stream_name:)
 
         travel_to split_time
 
-        event_store.publish(Reviewing::SentBack.new, stream_name: stream_names.first)
+        event_store.publish(Reviewing::SentBack.new, stream_name:)
 
         travel_back
       end
@@ -60,26 +60,15 @@ RSpec.describe ReceivedOnReports::Projection do
   describe '.for_dates' do
     before do
       allow(described_class).to receive(:new)
-      described_class.for_dates(business_days)
-    end
-
-    context 'when for more than one date' do
-      let(:business_days) { [Date.new(2023, 10, 5), Date.new(2023, 10, 4)] }
-
-      it 'initializes the projection with the stream names for the business days' do
-        expect(described_class).to have_received(:new).with(
-          stream_names: ['ReceivedOn$2023-278', 'ReceivedOn$2023-277'],
-          observed_at: nil
-        )
-      end
+      described_class.for_date(business_day)
     end
 
     context 'when for a single date' do
-      let(:business_days) { Date.new(2023, 10, 5) }
+      let(:business_day) { Date.new(2023, 10, 5) }
 
       it 'initializes the projection with the stream name for the business day' do
         expect(described_class).to have_received(:new).with(
-          stream_names: ['ReceivedOn$2023-278'],
+          stream_name: 'ReceivedOn$2023-278',
           observed_at: nil
         )
       end

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe 'Authorisation' do
       reporting_user_report
       reporting_root
       reporting_temporal_report
+      reporting_snapshot
+      reporting_current_snapshot
       search_application_searches
     ]
   end
@@ -215,6 +217,9 @@ RSpec.describe 'Authorisation' do
     report_type = 'processed_report'
     interval = 'monthly'
     period = '2023-August'
-    { id:, crime_application_id:, path:, report_type:, interval:, period: }.slice(*route.required_keys.dup)
+    date = '2023-05-01'
+    time = '23:59'
+    { id:, crime_application_id:, path:, report_type:, interval:, period:, date:,
+time: }.slice(*route.required_keys.dup)
   end
 end

--- a/spec/system/reporting/reports_page_spec.rb
+++ b/spec/system/reporting/reports_page_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe 'Reports' do
       end
 
       it 'is shown the caseworker report' do
-        click_on 'Caseworker report'
-        expect(page).to have_text('Caseworker report')
+        click_on 'Caseworker daily'
+        expect(page).to have_text('Caseworker daily')
       end
 
       it 'is shown the processed report' do
@@ -82,8 +82,8 @@ RSpec.describe 'Reports' do
     end
 
     it 'is shown the caseworker report' do
-      click_on 'Caseworker report'
-      expect(page).to have_text('Caseworker report')
+      click_on 'Caseworker daily'
+      expect(page).to have_text('Caseworker daily')
     end
 
     it 'is shown the processed report' do
@@ -110,8 +110,8 @@ RSpec.describe 'Reports' do
     end
 
     it 'is shown the caseworker report' do
-      click_on 'Caseworker report'
-      expect(page).to have_text('Caseworker report')
+      click_on 'Caseworker daily'
+      expect(page).to have_text('Caseworker daily')
     end
 
     it 'is shown the processed report' do

--- a/spec/system/reporting/snapshot_reports_spec.rb
+++ b/spec/system/reporting/snapshot_reports_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe 'Snapshot report' do
+  include_context 'with an existing application'
+
+  let(:current_user_role) { UserRole::DATA_ANALYST }
+  let(:report_type) { Types::SnapshotReportType['workload_report'] }
+  let(:previous_day) { 'Previous day' }
+  let(:next_day) { 'Next day' }
+  let(:yesterday) { Time.current.in_time_zone('London').to_date.yesterday }
+
+  context 'when viwing the current snaphshot for the worklaod report' do
+    before do
+      visit reporting_current_snapshot_path(report_type)
+    end
+
+    it 'has the heading "Workload report"' do
+      expect(page.find('h1')).to have_text 'Workload report'
+    end
+
+    it 'has the page title "Workload report"' do
+      expect(page.title).to have_text 'Workload report'
+    end
+
+    it 'shows the correct column headers' do
+      expected_headers = ['Business days since applications were received',
+                          'Applications received', 'Applications still open']
+
+      page.all('table thead tr th').each_with_index do |el, i|
+        expect(el).to have_content expected_headers[i]
+      end
+    end
+
+    it 'shows the correct row headers for day zero' do
+      within all('table tbody th')[0] do
+        expect(page).to have_content '0 days'
+      end
+    end
+
+    it 'shows the correct row header for one day' do
+      within all('table tbody th')[1] do
+        expect(page).to have_content '1 day'
+      end
+    end
+
+    it 'shows the correct row headers for two days' do
+      within all('table tbody th')[2] do
+        expect(page).to have_content '2 days'
+      end
+    end
+
+    it 'shows the correct row headers for three days' do
+      within all('table tbody th')[3] do
+        expect(page).to have_content '3 days'
+      end
+    end
+
+    it 'shows the correct row headers for the last row' do
+      within all('table tbody th')[4] do
+        expect(page).to have_content 'Between 4 and 9 days'
+      end
+    end
+
+    it 'can navigate to the end of the the previous day' do
+      expect { click_link(previous_day) }.to change { current_path }
+        .from('/reporting/workload_report/now')
+        .to("/reporting/workload_report/#{yesterday}/at/23:59")
+    end
+
+    it 'does not show a link to the next day' do
+      expect(page).not_to have_link(next_day)
+    end
+
+    context 'when the report_type is not supported' do
+      let(:report_type) { Types::TemporalReportType['caseworker_report'] }
+
+      it 'shows the page not found' do
+        expect(page).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  context 'when viewing a snapshot from the previous day at a specified time' do
+    before do
+      visit reporting_snapshot_path(report_type: report_type, date: yesterday, time: '12:00')
+    end
+
+    it 'can navigate to the end of the next day' do
+      expect { click_link(next_day) }.to change { current_path }.to('/reporting/workload_report/now')
+    end
+
+    it 'can navigate to the end of the previous day' do
+      expect { click_link(previous_day) }.to change { current_path }
+        .to("/reporting/workload_report/#{yesterday.yesterday}/at/23:59")
+    end
+
+    it 'shows the report at the specified time' do
+      expect(page).to have_text yesterday.strftime('%A %-d %B 12:00')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Add prototype processed report snapshot

## Link to relevant ticket
[CRIMAP-589](https://dsdmoj.atlassian.net/browse/CRIMAP-589)

## Notes for reviewer

Whilst the report can be viewed at any historical time, the UI has been kept simple to allow users to navigate to "Now" or the end of (23:59) any previous day. (The url can be altered to view the report at a different time.)

## Screenshots of changes (if applicable)

### Before changes:
<img width="679" alt="Screenshot 2023-10-09 at 18 38 02" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/9ab0d1ba-4acb-4418-8355-d0f406435e04">

### After changes:
<img width="690" alt="Screenshot 2023-10-09 at 18 36 52" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/4b076f23-51aa-4e09-8503-1ee6a2791aec">


<img width="746" alt="Screenshot 2023-10-09 at 18 37 01" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/cc6bc981-c6c5-464f-b097-2857f1d31ee2">

## How to manually test the feature


[CRIMAP-589]: https://dsdmoj.atlassian.net/browse/CRIMAP-589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ