### PR TITLE
 CRIMAP-651 Skip attack-sqli check on production

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -22,8 +22,9 @@ metadata:
       SecRequestBodyLimit 1048576
       SecRequestBodyNoFilesLimit 1048576
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
-      SecRuleUpdateTargetById 941100-941350 !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
-      SecRuleUpdateTargetById 942100 !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
+      SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
+      SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
+
       SecRule REQUEST_URI "@beginsWith /api/events" "id:555001, phase:1, pass, t:none, nolog, chain" \
         SecRule REQUEST_METHOD "@streq POST" "chain" \
           SecRule REQUEST_HEADERS:Content-Type "@rx [\s]*text/plain[\s]*" "ctl:ruleRemoveById=920420"


### PR DESCRIPTION
## Description of change
Prevent sql injection false positives on the rails session cookie PRODUCTION

## Link to relevant ticket
[CRIMAP-651](https://dsdmoj.atlassian.net/browse/CRIMAP-651)

## Notes for reviewer
False positives on the session cookie have been causing 403 errors. Here we use tags rather than id to prevent the offending rules being applied to the rails session cookie.  After testing on staging, this change will need to be applied to the production ingress.

This change has been on staging for a couple of days without any reported issues.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAP-651]: https://dsdmoj.atlassian.net/browse/CRIMAP-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ