### PR TITLE
[CRIMAP-675] Update schema gem to v1.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.3'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.5'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: b2f94b5b4e952477435358d23f5f14fb38c87b0a
-  tag: v1.0.3
+  revision: 1e08dfd8e71f956b06c1f8684af3fa465271f624
+  tag: v1.0.5
   specs:
-    laa-criminal-legal-aid-schemas (1.0.3)
+    laa-criminal-legal-aid-schemas (1.0.5)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 


### PR DESCRIPTION
## Description of change
Update Schema gem to 1.0.5 to allow optional Document.scan_status

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-675

## Notes for reviewer
Introduces new Document virus scan attributes ready for https://dsdmoj.atlassian.net/browse/CRIMAP-659

