### PR TITLE
CRIMAP-679 remove basic user role feature flag

### DIFF
--- a/app/models/concerns/user_role.rb
+++ b/app/models/concerns/user_role.rb
@@ -36,7 +36,7 @@ module UserRole
     return false if deactivated?
     return false if dormant?
 
-    FeatureFlags.basic_user_roles.enabled?
+    true
   end
 
   def service_user?

--- a/app/views/manage_users/history/_actions.html.erb
+++ b/app/views/manage_users/history/_actions.html.erb
@@ -38,16 +38,14 @@
             ) %>
       </li>
 
-      <% if FeatureFlags.basic_user_roles.enabled? %>
-        <li class="govuk-summary-list__actions-list-item">
-          <%= gov_link_to_unless_current_user(
-                user: user,
-                text: action_text(:change_role),
-                path: edit_manage_users_change_role_path(id: user),
-                html_options: { no_visited_state: true }
-              ) %>
-        </li>
-      <% end %>
+      <li class="govuk-summary-list__actions-list-item">
+        <%= gov_link_to_unless_current_user(
+              user: user,
+              text: action_text(:change_role),
+              path: edit_manage_users_change_role_path(id: user),
+              html_options: { no_visited_state: true }
+            ) %>
+      </li>
     <% end %>
   <% elsif user.pending_activation? %>
     <% if user.invitation_expired? %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,10 +7,6 @@ feature_flags:
     local: false
     staging: true
     production: false # user managers should not access the service in production
-  basic_user_roles:
-    local: true
-    staging: true
-    production: true
   evidence_upload:
     local: true
     staging: true

--- a/spec/models/concerns/user_role_spec.rb
+++ b/spec/models/concerns/user_role_spec.rb
@@ -198,19 +198,6 @@ RSpec.describe UserRole do
       end
     end
 
-    context 'when feature flag is disabled' do
-      before do
-        allow(FeatureFlags).to receive(:basic_user_roles) {
-          instance_double(FeatureFlags::EnabledFeature, enabled?: false)
-        }
-      end
-
-      it 'returns false' do
-        expect(user.activated?).to be true
-        expect(user.can_change_role?).to be false
-      end
-    end
-
     context 'when user is dormant' do
       before do
         user.last_auth_at = 100.days.ago

--- a/spec/system/manage_users/change_user_role_spec.rb
+++ b/spec/system/manage_users/change_user_role_spec.rb
@@ -110,30 +110,6 @@ RSpec.describe 'Change user role' do
     end
   end
 
-  describe 'when feature is disabled' do
-    before do
-      allow(FeatureFlags).to receive(:basic_user_roles) {
-        instance_double(FeatureFlags::EnabledFeature, enabled?: false)
-      }
-      active_user
-
-      visit '/manage_users/active_users'
-    end
-
-    it 'does not show Change role action' do
-      expect(page).not_to have_content 'Change role'
-    end
-
-    it 'denies role change if forced via URL' do
-      visit "/manage_users/change_roles/#{user.id}/edit"
-
-      expect(page).to have_notification_banner(
-        text: "Unable to change #{user.name}'s role",
-        details: []
-      )
-    end
-  end
-
   describe 'when admin manipulates the HTTP client' do
     context 'with their own user id' do
       before do


### PR DESCRIPTION
## Description of change

Remove basic user roles feature flag

## Link to relevant ticket
[CRIMAP-679](https://dsdmoj.atlassian.net/browse/CRIMAP-679)

## Notes for reviewer
This feature is now available in all environments.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAP-679]: https://dsdmoj.atlassian.net/browse/CRIMAP-679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ