### PR TITLE
CRIMAP-702 do not show flash messages on error pages

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,4 @@
 class ErrorsController < ApplicationController
-  layout 'external'
-
   before_action :set_response_format
 
   # The show action is configured as the Rails "exceptions_app" in /config/application.rb

--- a/app/views/layouts/errors.html.erb
+++ b/app/views/layouts/errors.html.erb
@@ -1,0 +1,11 @@
+<% content_for?(:page_title) ? yield(:page_title) : fallback_title %>
+
+<% content_for(:header) do %>
+  <%= govuk_header(service_name: t('service.name'), classes: ["app-banner-#{HostEnv.env_name}"]) %>
+<% end %>
+
+<% content_for(:content) do %>
+  <%= yield %>
+<% end %>
+
+<%= render template: 'layouts/govuk_template', layout: false %>

--- a/spec/system/authenticating/dev_auth_spec.rb
+++ b/spec/system/authenticating/dev_auth_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe 'Authenticating with the DevAuth strategy' do
         click_button 'Sign in'
       end
 
-      it 'redirects to the forbidden page' do
+      it 'shows the forbidden page' do
         expect(page).to have_content 'Access to this service is restricted'
       end
 
-      it 'shows the forbidden page' do
-        expect(page).to have_content 'Access to this service is restricted'
+      it 'uses the simplified error page' do
         expect(page).not_to have_css('nav.moj-primary-navigation')
+        expect(page).not_to have_css('.govuk-notification-banner')
       end
     end
 


### PR DESCRIPTION
## Description of change
Do not show flash messages on error pages.

## Link to relevant ticket
[CRIMAP-702](https://dsdmoj.atlassian.net/browse/CRIMAP-702)

## Notes for reviewer

To prevent information leakage flash messages should not be shown on error pages. This PR adds a dedicated errors layout and specs to make sure that flash messages are not included on error page errors.

## Screenshots of changes (if applicable)

### Before changes:
<img width="917" alt="Screenshot 2023-10-24 at 15 09 15" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/b50224cd-2bfa-4d0f-9c51-e50ea83b8487">


### After changes:

<img width="878" alt="Screenshot 2023-10-24 at 15 06 57" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/58e83c8d-d8e8-4d27-95a1-208bf789db7c">

## How to manually test the feature
Using the dev auth locally, select the "Not.Authorised@example.com"
Confirm that a flash notice is not shown on the resulting error page.


[CRIMAP-702]: https://dsdmoj.atlassian.net/browse/CRIMAP-702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ