### PR TITLE
Use rails failure app for devise errors.

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -3,15 +3,13 @@ module Users
     def azure_ad
       @user = UserAuthenticate.new(request.env['omniauth.auth']).authenticate
 
-      if @user
-        sign_in_and_redirect @user, event: :authentication
-      else
-        throw(:warden, recall: 'Errors#forbidden', message: :forbidden)
-      end
+      raise ApplicationController::ForbiddenError, 'User not authorised' unless @user
+
+      sign_in_and_redirect @user, event: :authentication
     end
 
     def failure
-      throw(:warden, recall: 'Errors#forbidden', message: :forbidden)
+      raise ApplicationController::ForbiddenError, 'Devise failure'
     end
 
     # Override the #passthru action. It is used when a GET request is made
@@ -19,7 +17,7 @@ module Users
     # The fix for this is in Devise but awaiting release:
     # https://github.com/heartcombo/devise/pull/5508
     def passthru
-      redirect_to unauthenticated_root_path
+      raise ActionController::RoutingError, 'Get requests should not be supported.'
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -75,6 +75,7 @@ module LaaReviewCriminalLegalAid
     config.exceptions_app = ->(env) {
       ErrorsController.action(:show).call(env)
     }
+
     config.action_dispatch.rescue_responses["Reporting::ReportNotFound"] = :not_found
     config.action_dispatch.rescue_responses["ApplicationController::ForbiddenError"] = :forbidden
   end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -192,11 +192,11 @@ RSpec.describe 'Authentication Session Initialisation' do
     end
   end
 
-  context 'when a get request is made to the user auth path' do
-    it 'redirects to sign in page' do
+  context 'when a GET request is made to the user auth path' do
+    it 'returns page not found' do
       get user_azure_ad_omniauth_authorize_path
 
-      expect(response).to redirect_to(unauthenticated_root_path)
+      expect(response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/system/authenticating/a_deactivated_user_spec.rb
+++ b/spec/system/authenticating/a_deactivated_user_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe 'Authenticating a deactivated user' do
+  before do
+    click_on 'Sign out'
+    current_user.update(deactivated_at: Time.current)
+    click_button 'Start now'
+    select current_user.email
+    click_button 'Sign in'
+  end
+
+  it 'the user is not signed in' do
+    expect(page).not_to have_content 'Your list'
+  end
+
+  it 'the user is informed that access to the service is restricted' do
+    expect(page).to have_content 'Access to this service is restricted'
+    expect(page).to have_http_status(:forbidden)
+  end
+end

--- a/spec/system/authenticating/dev_auth_spec.rb
+++ b/spec/system/authenticating/dev_auth_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'Authenticating with the DevAuth strategy' do
 
       it 'shows the forbidden page' do
         expect(page).to have_content 'Access to this service is restricted'
+        expect(page).to have_http_status(:forbidden)
       end
 
       it 'uses the simplified error page' do


### PR DESCRIPTION
## Description of change
Refactor devise controller to directly use the application failure app.

## Link to relevant ticket
[CRIMAP-702](https://dsdmoj.atlassian.net/browse/CRIMAP-702)

## Notes for reviewer
Whilst working on CRIMAP-702, I noticed that the devise errors had not been updated to use the application's failure app. This PR does that. It also adds a system spec for a deactivated user which was previously only tested in the model spec.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAP-702]: https://dsdmoj.atlassian.net/browse/CRIMAP-702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ