### PR TITLE
[CRIMAP-728] Revert back to always outputting first_court_hearing_name

### DIFF
--- a/app/presenters/case_details_presenter.rb
+++ b/app/presenters/case_details_presenter.rb
@@ -1,8 +1,6 @@
 require 'laa_crime_schemas'
 
 class CaseDetailsPresenter < BasePresenter
-  # first_court_hearing reflects any changes in the court location, not
-  # the actual first court hearing location.
   def first_court_hearing
     if legacy_application?
       t('values.not_asked')
@@ -27,10 +25,6 @@ class CaseDetailsPresenter < BasePresenter
 
   def no_hearing_yet?
     is_first_court_hearing == type_of('no_hearing_yet')
-  end
-
-  def first_court_hearing?
-    is_first_court_hearing == type_of('yes')
   end
 
   private

--- a/app/views/casework/crime_applications/_case_details.html.erb
+++ b/app/views/casework/crime_applications/_case_details.html.erb
@@ -41,16 +41,14 @@
   <% end%>
 
   <!-- Court hearing -->
-  <% unless case_details.first_court_hearing? %>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= label_text(:first_court_hearing) %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= case_details.first_court_hearing %>
-      </dd>
-    </div>
-  <% end %>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <%= label_text(:first_court_hearing) %>
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= case_details.first_court_hearing %>
+    </dd>
+  </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
       <%= label_text(:next_court_hearing) %>

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -397,16 +397,14 @@ RSpec.describe 'Viewing an application unassigned, open application' do
       let(:hearing_details) do
         {
           'hearing_court_name' => 'Westminster Magistrates Court',
+          'first_court_hearing_name' => 'Westminster Magistrates Court',
           'is_first_court_hearing' => 'yes',
         }
       end
 
-      it 'shows the court hearing the case name' do
+      it 'shows same next and first court hearing the case' do
         expect(next_court_hearing).to have_content('Westminster Magistrates Court')
-      end
-
-      it 'does not have a first court hearing the case' do
-        expect(page).not_to have_content('First court hearing the case')
+        expect(first_court_hearing).to have_content('Westminster Magistrates Court')
       end
     end
 
@@ -419,7 +417,7 @@ RSpec.describe 'Viewing an application unassigned, open application' do
         }
       end
 
-      it 'shows the next and first court hearing the case' do
+      it 'shows different next and first court hearing the case' do
         expect(next_court_hearing).to have_content('Southwark Crown Court')
         expect(first_court_hearing).to have_content('Westminster Magistrates Court')
       end


### PR DESCRIPTION
## Description of change
Always displays `first_court_hearing_name`, assumes `first_court_hearing_name` is always populated with a value by Datastore. 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-728

## Notes for reviewer
- Dependent on latest Datastore with [PR 79](https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/179)
## Screenshots of changes (if applicable)
#### 1. User enters court hearing name, selects "yes" for "Did this court also hear the first hearing?"
<img width="711" alt="01-data-entry" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/47113046/57fa5c92-7d6a-407d-a474-0cff681ab615">

#### 2. Apply DB entry shows `first_court_hearing_name` as NULL
<img width="782" alt="02-apply-db-entry" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/47113046/b659a355-532a-43cd-bd29-5bcf2923fb68">

#### 3. Caseworker still sees first/next court hearing names
<img width="690" alt="03-review-application" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/47113046/ec95e2c3-bcfc-41c9-a6b6-98cbf036f754">

#### 4. Datastore DB `crime_applications.submitted_application` has replicated `hearing_court_name` into `first_court_hearing_name`
<img width="626" alt="04-datastore-submitted-application" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/47113046/50729c37-f5b6-4122-b1b5-8ce3ad92a127">


## How to manually test the feature
1. Create a new application, in the court hearing section enter the hearing court name and select "Yes" for "Did this court also hear the first hearing". Submit application.
2. Log in to Review as caseworker and check the Case Details section
3. Try creating applications with "no hearing yet" and "no" as the answer to "Did this court also hear the first hearing". Try changing the court hearing details after they've been entered before submitting to ensure correct data is always output.