### PR TITLE
[CRIMAP-736] Remove restriction allowing only assigned users to download evidence

### DIFF
--- a/app/controllers/casework/documents_controller.rb
+++ b/app/controllers/casework/documents_controller.rb
@@ -1,7 +1,7 @@
 module Casework
   class DocumentsController < Casework::BaseController
     before_action :set_crime_application, :set_document
-    before_action :require_assigned_user
+    before_action :require_doc_part_of_app
 
     class CannotDownloadUnlessAssigned < StandardError; end
     class CannotDownloadDocNotPartOfApp < StandardError; end
@@ -34,13 +34,9 @@ module Casework
       @document = @crime_application.supporting_evidence.find { |evidence| evidence.s3_object_key == params[:id] }
     end
 
-    def require_assigned_user
+    def require_doc_part_of_app
       # To ensure users can only download documents that are part of the current application
       raise CannotDownloadDocNotPartOfApp if @document.blank?
-      raise CannotDownloadUnlessAssigned unless @crime_application.assigned_to?(current_user_id)
-    rescue CannotDownloadUnlessAssigned
-      set_flash(:cannot_download_unless_assigned, success: false)
-      redirect_to crime_application_path(params[:crime_application_id])
     rescue CannotDownloadDocNotPartOfApp
       set_flash(:cannot_download_doc_uploaded_to_another_app, success: false)
       redirect_to crime_application_path(params[:crime_application_id])

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -36,7 +36,6 @@ en:
       cannot_mark_as_ready_when_sent_back: This application was already sent back to the provider
       cannot_send_back_when_completed: This application was already marked as complete
       cannot_send_back_when_marked_as_ready: This application was already marked as ready for assessment
-      cannot_download_unless_assigned: You must assign this application to your list to download files
       cannot_download_doc_uploaded_to_another_app: File must be uploaded to current application to download
       cannot_download_try_again: "%{file_name} could not be downloaded – try again"
 

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -363,11 +363,6 @@ RSpec.describe 'Viewing an application unassigned, open application' do
                             //tr[contains(td[1], 'test.pdf')]")
       expect(evidence_row).to have_content('test.pdf Download file (pdf, 12 Bytes)')
     end
-
-    it 'raises an error if user attempts to download the file' do
-      click_on 'Download file (pdf, 12 Bytes)'
-      expect(page).to have_content('You must assign this application to your list to download files')
-    end
   end
 
   context 'with no supporting evidence' do


### PR DESCRIPTION
## Description of change
Following confirmation from product, the restriction limiting users from downloading evidence on review if they are not assigned to an application has been removed. This is with the aim of revisiting what measures we could put in place to make evidence download more secure without impacting user needs in the future. More information in the ticket linked.

## Link to relevant ticket
[CRIMAP-736](https://dsdmoj.atlassian.net/browse/CRIMAP-736)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/039edc88-44fc-426b-af5d-32bb6b23a02d

## How to manually test the feature
Submit an application in apply with supporting evidence. Go to the submitted application in review and download that evidence. You should be able to download the evidence regardless of whether you are assigned to the application or not.

[CRIMAP-736]: https://dsdmoj.atlassian.net/browse/CRIMAP-736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ