### PR TITLE
Update schema to v1.0.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.6'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.7'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 1f45f2cbc3c9d4c7defe81b0dc182f549550d46f
-  tag: v1.0.6
+  revision: a3064cefa57b95bc643ea110bd46cf62a7fc03dc
+  tag: v1.0.7
   specs:
-    laa-criminal-legal-aid-schemas (1.0.6)
+    laa-criminal-legal-aid-schemas (1.0.7)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)


### PR DESCRIPTION
## Description of change
Fixes sentry error: https://ministryofjustice.sentry.io/issues/4635857522/?alert_rule_id=14029744&alert_timestamp=1700049014274&alert_type=email&environment=staging&notification_uuid=4d3c22be-7e9b-462a-9766-52360ce25270&project=4504927032967168&referrer=alert_email

The work stream attribute was set to the case details level in the schema but as was being set to the crime application parent in the datastore. The schema was corrected to move the work stream attribute to the crime application struct 

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
