### PR TITLE
CRIMAPP-78 handle empty cell content

### DIFF
--- a/app/components/data_table/header_cell_component.rb
+++ b/app/components/data_table/header_cell_component.rb
@@ -43,7 +43,9 @@ module DataTable
     end
 
     def name
-      text || sanitize(I18n.t(colname, scope: 'table_headings'))
+      return text if text
+
+      sanitize(I18n.t(colname, scope: 'table_headings')) if colname.present?
     end
 
     def sortable?

--- a/app/views/reporting/base/_caseworker_report.html.erb
+++ b/app/views/reporting/base/_caseworker_report.html.erb
@@ -8,7 +8,7 @@
 
       table.with_sortable_head(sorting:) do |head| # rubocop:disable Metrics/BlockLength
         head.with_row(classes: 'colgroup-headers') do |row|
-          row.with_cell
+          row.with_cell(text: '')
           row.with_cell(
             colname: :colpsan_assigned_to_user, colspan: 3, scope: 'colgroup'
           )


### PR DESCRIPTION
## Description of change
Fix missing translation error for cell without content.

## Link to relevant ticket

## Notes for reviewer
This error only manifested in production env because translation errors render as strings in production env.

## Screenshots of changes (if applicable)

### Before changes:
<img width="1064" alt="Screenshot 2023-11-16 at 17 12 20" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/9c2503c7-b96e-4c00-8630-4d3ebb827210">

### After changes:

## How to manually test the feature
