### PR TITLE
CRIMAPP-195 Show benefit type if over 18

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -19,8 +19,8 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
     !means_passport.empty?
   end
 
-  def passporting_benefit?
-    means_passport.include?(Types::MeansPassportType['on_benefit_check'])
+  def means_passported_on_age?
+    means_passport.include?(Types::MeansPassportType['on_age_under18'])
   end
 
   def relevant_ioj_passport

--- a/app/views/casework/crime_applications/_overview.html.erb
+++ b/app/views/casework/crime_applications/_overview.html.erb
@@ -25,14 +25,13 @@
     </dd>
   </div>
 
-  <% if overview.passporting_benefit? %>
+  <% unless overview.means_passported_on_age? %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
         <%= label_text(:passporting_benefit) %>
       </dt>
       <dd class="govuk-summary-list__value">
         <%= t(overview.client_details.applicant.benefit_type.presence, scope: 'values') || t(:not_asked, scope: 'values') %>
-
       </dd>
     </div>
   <% end %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -135,6 +135,7 @@ en:
     jsa: Income-based Jobseeker's Allowance (JSA)
     esa: Income-related Employment and Support Allowance (ESA)
     income_support: Income Support
+    none: None
     no_home_address: Does not have a home address
     home_address: Same as home address
     provider_address: Same as provider address

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -102,21 +102,21 @@ RSpec.describe CrimeApplication do
     end
   end
 
-  describe '#passporting_benefit?' do
-    subject(:passporting_benefit?) { application.passporting_benefit? }
+  describe '#means_passported_on_age?' do
+    subject(:means_passported_on_age?) { application.means_passported_on_age? }
 
     let(:attributes) { super().merge({ 'means_passport' => means_passport }) }
 
     context 'when application is passported on benefits' do
       let(:means_passport) { [Types::MeansPassportType['on_benefit_check']] }
 
-      it { is_expected.to be true }
+      it { is_expected.to be false }
     end
 
     context 'when application is passported on age' do
       let(:means_passport) { [Types::MeansPassportType['on_age_under18']] }
 
-      it { is_expected.to be false }
+      it { is_expected.to be true }
     end
 
     context 'when application has no means passport' do


### PR DESCRIPTION
## Description of change
Conditional to show selected input for benefit type was on whether or not the applicant had a positive DWP result, rather than whether they had been (or historically would have been) shown this question. 

Potential outcomes as follows:

1. Selected a passporting benefit - shows benefit name
2. Selected 'None' - shows 'None'
3. Not shown question at time of application -  shows 'Not asked when this application was submitted'
4. Not shown question as applicant under 18 - line not shown on Review

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-195

## Notes for reviewer
Relevance of when to show an answer is whether or not the provider would have been presented with the question (or would have if it was in the MVP from the start) 
## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
