### PR TITLE
Add work stream tabs to the open/closed applications pages

### DIFF
--- a/app/aggregates/allocating.rb
+++ b/app/aggregates/allocating.rb
@@ -1,5 +1,6 @@
 module Allocating
   class CompetenciesSet < RailsEventStore::Event; end
+  class WorkStreamNotFound < StandardError; end
 
   class << self
     def user_competencies(user_id)

--- a/app/controllers/casework/base_controller.rb
+++ b/app/controllers/casework/base_controller.rb
@@ -5,8 +5,9 @@ module Casework
     before_action :authenticate_user!
     before_action :require_service_user!
     before_action :set_security_headers
+    before_action :set_current_work_stream
 
-    helper_method :assignments_count
+    helper_method :assignments_count, :current_work_stream
 
     rescue_from DatastoreApi::Errors::ApiError do |e|
       Rails.error.report(e, handled: true, severity: :error)
@@ -35,6 +36,22 @@ module Casework
       @assignments_count ||= CurrentAssignment.where(
         user_id: current_user_id
       ).count
+    end
+
+    def set_current_work_stream
+      session[:current_work_stream] =
+        Utils::CurrentWorkStreamCalculator.new(work_stream_param: params[:work_stream],
+                                               session_work_stream: session[:current_work_stream],
+                                               user_competencies: current_user.competencies).current_work_stream
+    end
+
+    def current_work_stream
+      # TODO: enable when viewing applications by work stream feature is live
+      if FeatureFlags.work_stream.enabled?
+        [session[:current_work_stream]]
+      else
+        Types::WORK_STREAM_TYPES
+      end
     end
   end
 end

--- a/app/controllers/casework/base_controller.rb
+++ b/app/controllers/casework/base_controller.rb
@@ -7,7 +7,7 @@ module Casework
     before_action :set_security_headers
     before_action :set_current_work_stream
 
-    helper_method :assignments_count, :current_work_stream
+    helper_method :assignments_count, :work_stream
 
     rescue_from DatastoreApi::Errors::ApiError do |e|
       Rails.error.report(e, handled: true, severity: :error)
@@ -45,7 +45,7 @@ module Casework
                                                user_competencies: current_user.competencies).current_work_stream
     end
 
-    def current_work_stream
+    def work_stream
       # TODO: enable when viewing applications by work stream feature is live
       if FeatureFlags.work_stream.enabled?
         [session[:current_work_stream]]

--- a/app/controllers/casework/crime_applications_controller.rb
+++ b/app/controllers/casework/crime_applications_controller.rb
@@ -6,7 +6,7 @@ module Casework
 
     def open
       set_search(
-        default_filter: { application_status: 'open' },
+        default_filter: { application_status: 'open', work_stream: current_work_stream },
         default_sorting: { sort_by: 'submitted_at', sort_direction: 'ascending' }
       )
 
@@ -17,7 +17,7 @@ module Casework
 
     def closed
       set_search(
-        default_filter: { application_status: 'closed' },
+        default_filter: { application_status: 'closed', work_stream: current_work_stream },
         default_sorting: { sort_by: 'reviewed_at', sort_direction: 'descending' }
       )
 

--- a/app/controllers/casework/crime_applications_controller.rb
+++ b/app/controllers/casework/crime_applications_controller.rb
@@ -6,7 +6,7 @@ module Casework
 
     def open
       set_search(
-        default_filter: { application_status: 'open', work_stream: current_work_stream },
+        default_filter: { application_status: 'open', work_stream: work_stream },
         default_sorting: { sort_by: 'submitted_at', sort_direction: 'ascending' }
       )
 
@@ -17,7 +17,7 @@ module Casework
 
     def closed
       set_search(
-        default_filter: { application_status: 'closed', work_stream: current_work_stream },
+        default_filter: { application_status: 'closed', work_stream: work_stream },
         default_sorting: { sort_by: 'reviewed_at', sort_direction: 'descending' }
       )
 

--- a/app/controllers/concerns/application_searchable.rb
+++ b/app/controllers/concerns/application_searchable.rb
@@ -7,6 +7,7 @@ module ApplicationSearchable
     params.permit(
       :page,
       :per_page,
+      :work_stream,
       filter: ApplicationSearchFilter.attribute_names,
       sorting: ApplicationSearchSorting.attribute_names
     )

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,7 +76,7 @@ module ApplicationHelper
     )
   end
 
-  def open_closed_route(action_name, work_stream)
+  def url_for_open_or_closed_page(action_name, work_stream)
     # TODO: enable when viewing applications by work stream feature is live
     if FeatureFlags.work_stream.enabled?
       action_name == 'open' ? open_work_stream_path(work_stream) : closed_work_stream_path(work_stream)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -75,4 +75,13 @@ module ApplicationHelper
       no_visited_state: true
     )
   end
+
+  def open_closed_route(action_name, work_stream)
+    # TODO: enable when viewing applications by work stream feature is live
+    if FeatureFlags.work_stream.enabled?
+      action_name == 'open' ? open_work_stream_path(work_stream) : closed_work_stream_path(work_stream)
+    else
+      action_name == 'open' ? open_crime_applications_path : closed_crime_applications_path
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -84,4 +84,8 @@ module ApplicationHelper
       action_name == 'open' ? open_crime_applications_path : closed_crime_applications_path
     end
   end
+
+  def closed_action?(action_name)
+    action_name == 'closed'
+  end
 end

--- a/app/models/reporting/workload_report.rb
+++ b/app/models/reporting/workload_report.rb
@@ -4,7 +4,7 @@ module Reporting
     # ago.
     #
     # If the "number_of_rows" limit is set to be less than the number of rows
-    # required to accomodate 1 business day per row, the remaining days are
+    # required to accommodate 1 business day per row, the remaining days are
     # combined into the final row. For example:
     #   "0 days", "1 day", "2 days", "Between 3 and 9 days"
     #

--- a/app/services/utils/current_work_stream_calculator.rb
+++ b/app/services/utils/current_work_stream_calculator.rb
@@ -9,12 +9,12 @@ module Utils
     end
 
     def current_work_stream
-      if @work_stream_param.present?
-        Types::WorkStreamType[@work_stream_param]
-      elsif @session_work_stream.present?
-        @session_work_stream
-      elsif @user_competencies
-        @user_competencies.first
+      if work_stream_param.present?
+        Types::WorkStreamType[work_stream_param]
+      elsif session_work_stream.present?
+        session_work_stream
+      elsif user_competencies.present?
+        user_competencies.first
       else
         Types::WorkStreamType.values.first
       end

--- a/app/services/utils/current_work_stream_calculator.rb
+++ b/app/services/utils/current_work_stream_calculator.rb
@@ -10,7 +10,7 @@ module Utils
 
     def current_work_stream
       if @work_stream_param.present?
-        @work_stream_param
+        Types::WorkStreamType[@work_stream_param]
       elsif @session_work_stream.present?
         @session_work_stream
       elsif @user_competencies
@@ -18,6 +18,8 @@ module Utils
       else
         Types::WorkStreamType.values.first
       end
+    rescue Dry::Types::ConstraintError
+      raise Allocating::WorkStreamNotFound
     end
   end
 end

--- a/app/services/utils/current_work_stream_calculator.rb
+++ b/app/services/utils/current_work_stream_calculator.rb
@@ -1,0 +1,23 @@
+module Utils
+  class CurrentWorkStreamCalculator
+    attr_reader :work_stream_param, :session_work_stream, :user_competencies
+
+    def initialize(work_stream_param:, session_work_stream:, user_competencies:)
+      @work_stream_param = work_stream_param
+      @session_work_stream = session_work_stream
+      @user_competencies = user_competencies
+    end
+
+    def current_work_stream
+      if @work_stream_param.present?
+        @work_stream_param
+      elsif @session_work_stream.present?
+        @session_work_stream
+      elsif @user_competencies
+        @user_competencies.first
+      else
+        Types::WorkStreamType.values.first
+      end
+    end
+  end
+end

--- a/app/views/casework/assigned_applications/index.html.erb
+++ b/app/views/casework/assigned_applications/index.html.erb
@@ -16,7 +16,7 @@
                      data: { module: 'govuk-button' } %>
 
         <%= link_to t('.open_applications'),
-                    url_for_open_or_closed_page('open', current_work_stream),
+                    url_for_open_or_closed_page('open', work_stream),
                     class: 'govuk-link--no-visited-state govuk-!-font-size-19' %>
       </div>
     <% end %>

--- a/app/views/casework/assigned_applications/index.html.erb
+++ b/app/views/casework/assigned_applications/index.html.erb
@@ -16,7 +16,7 @@
                      data: { module: 'govuk-button' } %>
 
         <%= link_to t('.open_applications'),
-                    open_crime_applications_path,
+                    open_closed_route('open', current_work_stream),
                     class: 'govuk-link--no-visited-state govuk-!-font-size-19' %>
       </div>
     <% end %>

--- a/app/views/casework/assigned_applications/index.html.erb
+++ b/app/views/casework/assigned_applications/index.html.erb
@@ -16,7 +16,7 @@
                      data: { module: 'govuk-button' } %>
 
         <%= link_to t('.open_applications'),
-                    open_closed_route('open', current_work_stream),
+                    url_for_open_or_closed_page('open', current_work_stream),
                     class: 'govuk-link--no-visited-state govuk-!-font-size-19' %>
       </div>
     <% end %>

--- a/app/views/casework/base/_primary_navigation.html.erb
+++ b/app/views/casework/base/_primary_navigation.html.erb
@@ -25,16 +25,16 @@
 
             <li class="moj-primary-navigation__item">
               <%= link_to t('primary_navigation.open_apps'),
-                          open_closed_route('open', current_work_stream),
+                          url_for_open_or_closed_page('open', current_work_stream),
                           class: 'moj-primary-navigation__link',
-                          aria: { current: current_page?(open_closed_route('open', current_work_stream)) ? 'page' : nil } %>
+                          aria: { current: current_page?(url_for_open_or_closed_page('open', current_work_stream)) ? 'page' : nil } %>
             </li>
 
             <li class="moj-primary-navigation__item">
               <%= link_to t('primary_navigation.closed_apps'),
-                          open_closed_route('closed', current_work_stream),
+                          url_for_open_or_closed_page('closed', current_work_stream),
                           class: 'moj-primary-navigation__link',
-                          aria: { current: current_page?(open_closed_route('closed', current_work_stream)) ? 'page' : nil } %>
+                          aria: { current: current_page?(url_for_open_or_closed_page('closed', current_work_stream)) ? 'page' : nil } %>
             </li>
           </ul>
         <% end %>

--- a/app/views/casework/base/_primary_navigation.html.erb
+++ b/app/views/casework/base/_primary_navigation.html.erb
@@ -25,16 +25,16 @@
 
             <li class="moj-primary-navigation__item">
               <%= link_to t('primary_navigation.open_apps'),
-                          open_crime_applications_path,
+                          open_closed_route('open', current_work_stream),
                           class: 'moj-primary-navigation__link',
-                          aria: { current: current_page?(open_crime_applications_path) ? 'page' : nil } %>
+                          aria: { current: current_page?(open_closed_route('open', current_work_stream)) ? 'page' : nil } %>
             </li>
 
             <li class="moj-primary-navigation__item">
               <%= link_to t('primary_navigation.closed_apps'),
-                          closed_crime_applications_path,
+                          open_closed_route('closed', current_work_stream),
                           class: 'moj-primary-navigation__link',
-                          aria: { current: current_page?(closed_crime_applications_path) ? 'page' : nil } %>
+                          aria: { current: current_page?(open_closed_route('closed', current_work_stream)) ? 'page' : nil } %>
             </li>
           </ul>
         <% end %>

--- a/app/views/casework/base/_primary_navigation.html.erb
+++ b/app/views/casework/base/_primary_navigation.html.erb
@@ -25,16 +25,16 @@
 
             <li class="moj-primary-navigation__item">
               <%= link_to t('primary_navigation.open_apps'),
-                          url_for_open_or_closed_page('open', current_work_stream),
+                          url_for_open_or_closed_page('open', work_stream),
                           class: 'moj-primary-navigation__link',
-                          aria: { current: current_page?(url_for_open_or_closed_page('open', current_work_stream)) ? 'page' : nil } %>
+                          aria: { current: current_page?(url_for_open_or_closed_page('open', work_stream)) ? 'page' : nil } %>
             </li>
 
             <li class="moj-primary-navigation__item">
               <%= link_to t('primary_navigation.closed_apps'),
-                          url_for_open_or_closed_page('closed', current_work_stream),
+                          url_for_open_or_closed_page('closed', work_stream),
                           class: 'moj-primary-navigation__link',
-                          aria: { current: current_page?(url_for_open_or_closed_page('closed', current_work_stream)) ? 'page' : nil } %>
+                          aria: { current: current_page?(url_for_open_or_closed_page('closed', work_stream)) ? 'page' : nil } %>
             </li>
           </ul>
         <% end %>

--- a/app/views/casework/crime_applications/_open_closed_applications.html.erb
+++ b/app/views/casework/crime_applications/_open_closed_applications.html.erb
@@ -9,7 +9,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <div class="govuk-body">
-      <% if action_name == "closed" %>
+      <% if closed_action?(action_name) %>
         <%= t('casework.crime_applications.index.closed_body') %>
       <% else %>
         <%= t('casework.crime_applications.index.total_open', count: search.total) %>
@@ -23,7 +23,7 @@
     <details class="govuk-details" data-module="govuk-details">
       <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
-          <% if action_name == "closed" %>
+          <% if closed_action?(action_name) %>
             <%= t 'calls_to_action.view_closed_on_count' %>
           <% else %>
             <%= t 'calls_to_action.view_daily_count' %>

--- a/app/views/casework/crime_applications/_open_closed_applications.html.erb
+++ b/app/views/casework/crime_applications/_open_closed_applications.html.erb
@@ -1,0 +1,57 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">
+      <%= t "casework.crime_applications.index.#{action_name}_heading" %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-body">
+      <% if action_name == "closed" %>
+        <%= t('casework.crime_applications.index.closed_body') %>
+      <% else %>
+        <%= t('casework.crime_applications.index.total_open', count: search.total) %>
+      <%end%>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          <% if action_name == "closed" %>
+            <%= t 'calls_to_action.view_closed_on_count' %>
+          <% else %>
+            <%= t 'calls_to_action.view_daily_count' %>
+          <%end%>
+        </span>
+      </summary>
+      <div class="govuk-details__text ">
+        <%= turbo_frame_tag report_type, src: reporting_user_report_path(report_type), data: { turbo: 'true' }, loading: :lazy %>
+      </div>
+    </details>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+  <table class="govuk-table app-dashboard-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <%= render "#{action_name}_crime_applications_table_headers", search: %>
+      </tr>
+    </thead>
+
+    <tbody class="govuk-table__body">
+      <%= render partial: "#{action_name}_crime_applications_table_body",
+                 collection: search.results,
+                 as: :app %>
+    </tbody>
+  </table>
+    <%= paginate search.pagination %>
+  </div>
+</div>

--- a/app/views/casework/crime_applications/index.html.erb
+++ b/app/views/casework/crime_applications/index.html.erb
@@ -1,59 +1,26 @@
 <% title t(".#{action_name}_title") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">
-      <%= t ".#{action_name}_heading" %>
-    </h1>
-  </div>
-</div>
+<% if FeatureFlags.work_stream.enabled? %>
+  <div class="govuk-tabs">
+    <ul class="govuk-tabs__list" role="tablist">
+      <% CaseworkerPresenter::CASEWORKER_COMPETENCIES.each_with_index do |competency| %>
+        <% css_class = %w[govuk-tabs__list-item govuk-tabs__list-item--selected] %>
+        <%= content_tag(:li, class: current_work_stream == [competency] ? css_class : css_class.first) do %>
+          <%= link_to(
+                label_tag(competency),
+                url_for(work_stream: competency),
+                class: 'govuk-tabs__tab'
+              ) %>
+        <% end %>
+      <% end %>
+    </ul>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <div class="govuk-body">
-      <% if action_name == "closed" %>
-        <%= t('.closed_body') %>
-      <% else %>
-        <%= t('.total_open', count: @search.total) %>
-      <%end%>
+    <div class=govuk-tabs__panel>
+      <%= render partial: 'open_closed_applications',
+                 locals: { action_name: action_name, search: @search, report_type: @report_type } %>
     </div>
   </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <details class="govuk-details" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          <% if action_name == "closed" %>
-            <%= t 'calls_to_action.view_closed_on_count' %>
-          <% else %>
-            <%= t 'calls_to_action.view_daily_count' %>
-          <%end%>
-        </span>
-      </summary>
-      <div class="govuk-details__text ">
-        <%= turbo_frame_tag @report_type, src: reporting_user_report_path(@report_type), data: { turbo: 'true' }, loading: :lazy %>
-      </div>
-    </details>
-  </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-  <table class="govuk-table app-dashboard-table">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <%= render "#{action_name}_crime_applications_table_headers", search: @search %>
-      </tr>
-    </thead>
-
-    <tbody class="govuk-table__body">
-      <%= render partial: "#{action_name}_crime_applications_table_body",
-                 collection: @search.results,
-                 as: :app %>
-    </tbody>
-  </table>
-    <%= paginate @search.pagination %>
-  </div>
-</div>
+<% else %>
+  <%= render partial: 'open_closed_applications',
+             locals: { action_name: action_name, search: @search, report_type: @report_type } %>
+<% end  %>

--- a/app/views/casework/crime_applications/index.html.erb
+++ b/app/views/casework/crime_applications/index.html.erb
@@ -5,12 +5,8 @@
     <ul class="govuk-tabs__list" role="tablist">
       <% CaseworkerPresenter::CASEWORKER_COMPETENCIES.each_with_index do |competency| %>
         <% css_class = %w[govuk-tabs__list-item govuk-tabs__list-item--selected] %>
-        <%= content_tag(:li, class: current_work_stream == [competency] ? css_class : css_class.first) do %>
-          <%= link_to(
-                label_tag(competency),
-                url_for(work_stream: competency),
-                class: 'govuk-tabs__tab'
-              ) %>
+        <%= content_tag(:li, class: work_stream == [competency] ? css_class : css_class.first) do %>
+          <%= link_to(label_tag(competency), url_for(work_stream: competency), class: 'govuk-tabs__tab') %>
         <% end %>
       <% end %>
     </ul>

--- a/app/views/reporting/temporal_reports/show.html.erb
+++ b/app/views/reporting/temporal_reports/show.html.erb
@@ -26,7 +26,7 @@
         <h2 class="govuk-heading-m"><%= @report.period_name %></h2>
 
         <% if @interval == 'weekly' %>
-          <h3 class="govuk-heading-s"><%= @report.period_text %></h2>
+          <h3 class="govuk-heading-s"><%= @report.period_text %></h3>
         <% end %>
 
         <%= turbo_frame_tag [@report_type, @report.to_param], data: { turbo: 'true' } do %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -76,7 +76,10 @@ module LaaReviewCriminalLegalAid
       ErrorsController.action(:show).call(env)
     }
 
-    config.action_dispatch.rescue_responses["Reporting::ReportNotFound"] = :not_found
-    config.action_dispatch.rescue_responses["ApplicationController::ForbiddenError"] = :forbidden
+    config.action_dispatch.rescue_responses.merge!(
+      'Reporting::ReportNotFound' => :not_found,
+      'Allocating::WorkStreamNotFound' => :not_found,
+      'ApplicationController::ForbiddenError' => :forbidden
+    )
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,9 @@ Rails.application.routes.draw do
       resource :return, only: [:new, :create]
     end
 
+    get 'applications/open/:work_stream', to: 'crime_applications#open', as: :open_work_stream
+    get 'applications/closed/:work_stream', to: 'crime_applications#closed', as: :closed_work_stream
+
     resource :application_searches, only: [:new] do
       get :search, on: :collection
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -97,11 +97,11 @@ RSpec.describe ApplicationHelper do
     end
   end
 
-  describe '#open_closed_route' do
+  describe '#url_for_open_or_closed_page' do
     context 'when work stream feature flag is enabled' do
       work_stream = Types::WorkStreamType.values.first
-      it { expect(helper.open_closed_route('open', work_stream)).to eq('/applications/open/extradition') }
-      it { expect(helper.open_closed_route('closed', work_stream)).to eq('/applications/closed/extradition') }
+      it { expect(helper.url_for_open_or_closed_page('open', work_stream)).to eq('/applications/open/extradition') }
+      it { expect(helper.url_for_open_or_closed_page('closed', work_stream)).to eq('/applications/closed/extradition') }
     end
 
     context 'when work stream feature flag in is not enabled' do
@@ -111,8 +111,11 @@ RSpec.describe ApplicationHelper do
         }
       end
 
-      it { expect(helper.open_closed_route('open', Types::WORK_STREAM_TYPES)).to eq('/applications/open') }
-      it { expect(helper.open_closed_route('closed', Types::WORK_STREAM_TYPES)).to eq('/applications/closed') }
+      it { expect(helper.url_for_open_or_closed_page('open', Types::WORK_STREAM_TYPES)).to eq('/applications/open') }
+
+      it {
+        expect(helper.url_for_open_or_closed_page('closed', Types::WORK_STREAM_TYPES)).to eq('/applications/closed')
+      }
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -96,4 +96,23 @@ RSpec.describe ApplicationHelper do
       end
     end
   end
+
+  describe '#open_closed_route' do
+    context 'when work stream feature flag is enabled' do
+      work_stream = Types::WorkStreamType.values.first
+      it { expect(helper.open_closed_route('open', work_stream)).to eq('/applications/open/extradition') }
+      it { expect(helper.open_closed_route('closed', work_stream)).to eq('/applications/closed/extradition') }
+    end
+
+    context 'when work stream feature flag in is not enabled' do
+      before do
+        allow(FeatureFlags).to receive(:work_stream) {
+          instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+        }
+      end
+
+      it { expect(helper.open_closed_route('open', Types::WORK_STREAM_TYPES)).to eq('/applications/open') }
+      it { expect(helper.open_closed_route('closed', Types::WORK_STREAM_TYPES)).to eq('/applications/closed') }
+    end
+  end
 end

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe 'Authorisation' do
       reporting_current_snapshot
       reporting_current_temporal_report
       search_application_searches
+      open_work_stream
+      closed_work_stream
     ]
   end
 
@@ -226,7 +228,8 @@ RSpec.describe 'Authorisation' do
     period = '2023-August'
     date = '2023-05-01'
     time = '23:59'
+    work_stream = 'criminal_applications_team'
     { id:, crime_application_id:, path:, report_type:, interval:, period:, date:,
-time: }.slice(*route.required_keys.dup)
+time:, work_stream: }.slice(*route.required_keys.dup)
   end
 end

--- a/spec/services/utils/current_work_stream_calculator_spec.rb
+++ b/spec/services/utils/current_work_stream_calculator_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe Utils::CurrentWorkStreamCalculator do
+  subject(:calculator) { described_class.new(work_stream_param:, session_work_stream:, user_competencies:) }
+
+  let(:work_stream_param) { 'criminal_applications_team' }
+  let(:session_work_stream) { nil }
+  let(:user_competencies) { nil }
+
+  describe 'Current work stream calculation' do
+    context 'when work stream param is set' do
+      it 'returns a criminal applications team work stream value' do
+        expect(calculator.current_work_stream).to eq Types::WorkStreamType['criminal_applications_team']
+      end
+    end
+
+    context 'when work stream session is set' do
+      let(:work_stream_param) { nil }
+      let(:session_work_stream) { 'extradition' }
+
+      it 'returns an extradition work stream value' do
+        expect(calculator.current_work_stream).to eq Types::WorkStreamType['extradition']
+      end
+    end
+
+    context 'when user competencies is set' do
+      let(:work_stream_param) { nil }
+      let(:user_competencies) { %w[criminal_applications_team extradition] }
+
+      it 'returns a criminal applications team work stream value' do
+        expect(calculator.current_work_stream).to eq Types::WorkStreamType['criminal_applications_team']
+      end
+    end
+
+    context 'when there is no param/session/competency data' do
+      let(:work_stream_param) { nil }
+
+      it 'returns an extradition work stream value' do
+        expect(calculator.current_work_stream).to eq Types::WorkStreamType['extradition']
+      end
+    end
+  end
+end

--- a/spec/services/utils/current_work_stream_calculator_spec.rb
+++ b/spec/services/utils/current_work_stream_calculator_spec.rb
@@ -32,10 +32,19 @@ describe Utils::CurrentWorkStreamCalculator do
       end
     end
 
+    context 'when user competencies is empty array' do
+      let(:work_stream_param) { nil }
+      let(:user_competencies) { [] }
+
+      it 'returns an extradition work stream value (default)' do
+        expect(calculator.current_work_stream).to eq Types::WorkStreamType['extradition']
+      end
+    end
+
     context 'when there is no param/session/competency data' do
       let(:work_stream_param) { nil }
 
-      it 'returns an extradition work stream value' do
+      it 'returns an extradition work stream value (default)' do
         expect(calculator.current_work_stream).to eq Types::WorkStreamType['extradition']
       end
     end

--- a/spec/services/utils/current_work_stream_calculator_spec.rb
+++ b/spec/services/utils/current_work_stream_calculator_spec.rb
@@ -39,5 +39,13 @@ describe Utils::CurrentWorkStreamCalculator do
         expect(calculator.current_work_stream).to eq Types::WorkStreamType['extradition']
       end
     end
+
+    context 'with invalid work stream param' do
+      let(:work_stream_param) { 'test' }
+
+      it 'raises Allocating::WorkStreamNotFound' do
+        expect { calculator.current_work_stream }.to raise_error Allocating::WorkStreamNotFound
+      end
+    end
   end
 end

--- a/spec/shared_contexts/with_stubbed_search.rb
+++ b/spec/shared_contexts/with_stubbed_search.rb
@@ -40,7 +40,7 @@ RSpec.shared_context 'with stubbed search', shared_context: :metadata do
     ).and_return(body: datastore_response.to_json)
   end
 
-  def expect_datastore_to_have_been_searched_with(*params, sorting: nil, pagination: Pagination.new)
+  def expect_datastore_to_have_been_searched_with(*params, sorting: nil, pagination: Pagination.new, number_of_times: 1)
     sorting ||= ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending')
     expect(WebMock).to have_requested(:post, "#{ENV.fetch('DATASTORE_API_ROOT')}/api/v1/searches").with(
       body: {
@@ -49,7 +49,7 @@ RSpec.shared_context 'with stubbed search', shared_context: :metadata do
         pagination: pagination.datastore_params
       },
       headers: { 'Content-Type' => 'application/json' }
-    )
+    ).times(number_of_times)
   end
 
   def expect_datastore_not_to_have_been_searched

--- a/spec/system/casework/assigning/viewing_your_assigned_applications_spec.rb
+++ b/spec/system/casework/assigning/viewing_your_assigned_applications_spec.rb
@@ -90,6 +90,21 @@ RSpec.describe 'Viewing your assigned application' do
 
     it 'proceeds to the correct page' do
       expect(page).to have_content 'All open applications'
+      expect(page).to have_current_path '/applications/open/extradition'
+    end
+
+    context 'when work stream feature flag in is not enabled' do
+      before do
+        allow(FeatureFlags).to receive(:work_stream) {
+          instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+        }
+        visit '/'
+      end
+
+      it 'takes you to all open applications path when you click "All open applications"' do
+        click_on('All open applications')
+        expect(page).to have_current_path '/applications/open'
+      end
     end
   end
 

--- a/spec/system/casework/closed_applications_dashboard_spec.rb
+++ b/spec/system/casework/closed_applications_dashboard_spec.rb
@@ -125,7 +125,8 @@ RSpec.describe 'Closed Applications Dashboard' do
         expect_datastore_to_have_been_searched_with(
           { review_status: Types::REVIEW_STATUS_GROUPS['closed'],
             work_stream: %w[extradition] },
-          sorting: ApplicationSearchSorting.new(sort_by: 'reviewed_at', sort_direction: 'descending')
+          sorting: ApplicationSearchSorting.new(sort_by: 'reviewed_at', sort_direction: 'descending'),
+          number_of_times: 2
         )
       end
 

--- a/spec/system/casework/closed_applications_dashboard_spec.rb
+++ b/spec/system/casework/closed_applications_dashboard_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe 'Closed Applications Dashboard' do
   let(:user_id) { current_user_id }
 
   before do
+    allow(FeatureFlags).to receive(:work_stream) {
+      instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+    }
+
     visit '/'
     click_on 'All open applications'
 
@@ -39,7 +43,8 @@ RSpec.describe 'Closed Applications Dashboard' do
 
   it 'shows only closed applications' do
     expect_datastore_to_have_been_searched_with(
-      { review_status: Types::REVIEW_STATUS_GROUPS['closed'] },
+      { review_status: Types::REVIEW_STATUS_GROUPS['closed'],
+                work_stream: %w[extradition national_crime_team criminal_applications_team] },
       sorting: ApplicationSearchSorting.new(sort_by: 'reviewed_at', sort_direction: 'descending')
     )
   end
@@ -85,5 +90,62 @@ RSpec.describe 'Closed Applications Dashboard' do
     let(:active_sort_headers) { ['Date closed'] }
     let(:active_sort_direction) { 'descending' }
     let(:inactive_sort_headers) { ['Applicant\'s name', 'Date received'] }
+  end
+
+  context 'when work stream feature flag in is enabled' do
+    before do
+      allow(FeatureFlags).to receive(:work_stream) {
+        instance_double(FeatureFlags::EnabledFeature, enabled?: true)
+      }
+      visit '/'
+      click_on 'Closed applications'
+    end
+
+    it 'shows only extradition closed applications' do
+      # Extradition is currently the default
+      expect_datastore_to_have_been_searched_with(
+        { review_status: Types::REVIEW_STATUS_GROUPS['closed'],
+          work_stream: %w[extradition] },
+        sorting: ApplicationSearchSorting.new(sort_by: 'reviewed_at', sort_direction: 'descending')
+      )
+      expect(page).to have_current_path('/applications/closed/extradition')
+    end
+
+    it 'includes tabs for work streams' do
+      tabs = find(:xpath, "//div[@class='govuk-tabs']")
+
+      expect(tabs).to have_content 'Extradition National crime team Criminal applications team'
+    end
+
+    context 'when viewing closed applications by work stream' do
+      it 'searches for extradition closed applications' do
+        click_on 'Extradition'
+        expect(page).to have_current_path('/applications/closed/extradition')
+
+        expect_datastore_to_have_been_searched_with(
+          { review_status: Types::REVIEW_STATUS_GROUPS['closed'],
+            work_stream: %w[extradition] },
+          sorting: ApplicationSearchSorting.new(sort_by: 'reviewed_at', sort_direction: 'descending')
+        )
+      end
+
+      it 'searches for national crime team closed applications' do
+        click_on 'National crime team'
+        expect_datastore_to_have_been_searched_with(
+          { review_status: Types::REVIEW_STATUS_GROUPS['closed'],
+            work_stream: %w[national_crime_team] },
+          sorting: ApplicationSearchSorting.new(sort_by: 'reviewed_at', sort_direction: 'descending')
+        )
+      end
+
+      it 'searches for criminal applications team closed applications' do
+        click_on 'Criminal applications team'
+        expect_datastore_to_have_been_searched_with(
+          { review_status: Types::REVIEW_STATUS_GROUPS['closed'],
+            work_stream: %w[criminal_applications_team] },
+          sorting: ApplicationSearchSorting.new(sort_by: 'reviewed_at', sort_direction: 'descending')
+        )
+      end
+    end
   end
 end

--- a/spec/system/casework/open_applications_dashboard_spec.rb
+++ b/spec/system/casework/open_applications_dashboard_spec.rb
@@ -4,8 +4,19 @@ RSpec.describe 'Open Applications Dashboard' do
   include_context 'with stubbed search'
 
   before do
+    allow(FeatureFlags).to receive(:work_stream) {
+      instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+    }
     visit '/'
     click_on 'All open applications'
+  end
+
+  it 'shows only open applications' do
+    expect_datastore_to_have_been_searched_with(
+      { review_status: Types::REVIEW_STATUS_GROUPS['open'],
+        work_stream: %w[extradition national_crime_team criminal_applications_team] },
+      sorting: ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending')
+    )
   end
 
   it 'includes the page title' do
@@ -54,5 +65,57 @@ RSpec.describe 'Open Applications Dashboard' do
     let(:active_sort_headers) { ['Date received', 'Business days since application was received'] }
     let(:active_sort_direction) { 'ascending' }
     let(:inactive_sort_headers) { ['Applicant\'s name'] }
+  end
+
+  context 'when work stream feature flag in is enabled' do
+    before do
+      allow(FeatureFlags).to receive(:work_stream) {
+        instance_double(FeatureFlags::EnabledFeature, enabled?: true)
+      }
+      click_on 'All open applications'
+    end
+
+    it 'shows only extradition open applications' do
+      expect_datastore_to_have_been_searched_with(
+        { review_status: Types::REVIEW_STATUS_GROUPS['open'],
+          work_stream: %w[extradition] },
+        sorting: ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending')
+      )
+    end
+
+    it 'includes tabs for work streams' do
+      tabs = find(:xpath, "//div[@class='govuk-tabs']")
+
+      expect(tabs).to have_content 'Extradition National crime team Criminal applications team'
+    end
+
+    context 'when viewing closed applications by work stream' do
+      it 'searches for extradition closed applications' do
+        click_on 'Extradition'
+        expect_datastore_to_have_been_searched_with(
+          { review_status: Types::REVIEW_STATUS_GROUPS['open'],
+            work_stream: %w[extradition] },
+          sorting: ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending')
+        )
+      end
+
+      it 'searches for national crime team closed applications' do
+        click_on 'National crime team'
+        expect_datastore_to_have_been_searched_with(
+          { review_status: Types::REVIEW_STATUS_GROUPS['open'],
+            work_stream: %w[national_crime_team] },
+          sorting: ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending')
+        )
+      end
+
+      it 'searches for criminal applications team closed applications' do
+        click_on 'Criminal applications team'
+        expect_datastore_to_have_been_searched_with(
+          { review_status: Types::REVIEW_STATUS_GROUPS['open'],
+            work_stream: %w[criminal_applications_team] },
+          sorting: ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending')
+        )
+      end
+    end
   end
 end

--- a/spec/system/casework/open_applications_dashboard_spec.rb
+++ b/spec/system/casework/open_applications_dashboard_spec.rb
@@ -95,7 +95,8 @@ RSpec.describe 'Open Applications Dashboard' do
         expect_datastore_to_have_been_searched_with(
           { review_status: Types::REVIEW_STATUS_GROUPS['open'],
             work_stream: %w[extradition] },
-          sorting: ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending')
+          sorting: ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending'),
+          number_of_times: 2
         )
       end
 

--- a/spec/system/casework/primary_nav_spec.rb
+++ b/spec/system/casework/primary_nav_spec.rb
@@ -69,12 +69,12 @@ RSpec.describe 'Primary navigation' do
       visit '/'
     end
 
-    it 'takes you to all open applications path when you click "All open applications"' do
+    it 'takes you to the open applications path when you click "All open applications"' do
       click_on('All open applications')
       expect(page).to have_current_path '/applications/open'
     end
 
-    it 'takes you to all open applications path when you click "Closed applications"' do
+    it 'takes you to the closed applications path when you click "Closed applications"' do
       click_on('Closed applications')
       expect(page).to have_current_path '/applications/closed'
     end

--- a/spec/system/casework/primary_nav_spec.rb
+++ b/spec/system/casework/primary_nav_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe 'Primary navigation' do
 
     heading_text = page.first('.govuk-heading-xl').text
     expect(heading_text).to eq('All open applications')
+    expect(page).to have_current_path '/applications/open/extradition'
   end
 
   it 'takes you to closed applications when you click "Closed applications"' do
@@ -57,5 +58,25 @@ RSpec.describe 'Primary navigation' do
 
     heading_text = page.first('.govuk-heading-xl').text
     expect(heading_text).to eq('Closed applications')
+    expect(page).to have_current_path '/applications/closed/extradition'
+  end
+
+  context 'when work stream feature flag in is not enabled' do
+    before do
+      allow(FeatureFlags).to receive(:work_stream) {
+        instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+      }
+      visit '/'
+    end
+
+    it 'takes you to all open applications path when you click "All open applications"' do
+      click_on('All open applications')
+      expect(page).to have_current_path '/applications/open'
+    end
+
+    it 'takes you to all open applications path when you click "Closed applications"' do
+      click_on('Closed applications')
+      expect(page).to have_current_path '/applications/closed'
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Adds tabs to the open/closed for each work stream and show the number of applications received / still open or closed for each work stream

As part of this work, two new routes are added `applications/open/:work_stream` and `applications/closed/:work_stream`. The current routes `applications/open` and `applications/closed` are still available whilst this feature is in development. 

The work stream that a user selects is saved in the users session so that they can navigate to the last work stream they were looking at across the open and closed applications pages.

## Link to relevant ticket
[CRIMAPP-229](https://dsdmoj.atlassian.net/browse/CRIMAPP-229)
[CRIMAPP-230](https://dsdmoj.atlassian.net/browse/CRIMAPP-230)

## Notes for reviewer
Note this does not change the data in the `Check when applications were received` mini report on the open/closed application pages, just the table of search results. The mini report will be changed as part of the changes to the [volume report](https://dsdmoj.atlassian.net/browse/CRIMAPP-232) 

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
**Displaying open applications by users work stream. Tab defaults to users competency** 

<img width="1391" alt="Screenshot 2023-11-22 at 14 21 25" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/8233af32-eb93-499c-ad52-e815b456d296">
<img width="1371" alt="Screenshot 2023-11-22 at 14 20 23" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/8bf29bed-a462-438f-8766-f4b3716fa686">

---------------------------

**Defaults to the first competency in list if user has multiple competencies**

<img width="1391" alt="Screenshot 2023-11-22 at 14 21 37" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/20cfa604-4e33-42f1-9f86-34729fa5db9c">
<img width="1391" alt="Screenshot 2023-11-22 at 14 21 47" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/697f8884-92d2-4d65-9edb-80def47957f4">

---------------------

**The last tab selected is remembered when switching between tabs**

<img width="1391" alt="Screenshot 2023-11-22 at 14 20 54" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/85de1791-865a-4fd6-9103-2d3661ef8d1b">
<img width="1391" alt="Screenshot 2023-11-22 at 14 20 47" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/6df49fb6-2f11-4ad2-8a01-a260097a2f95">


## How to manually test the feature

Quite a bit to test in this pr you have been warned! 

**Requires:**

- One supervisor user and one caseworker user
- An extradition case to have been submitted to review

**Note: you may need to sign in and out whilst testing to reset the session work stream value**

Test the following scenarios. In all cases, you should check the number of applications listed in the table is what you expect to see

- As a caseworker with a competency set, when you navigate to the open or closed applications page, you should be taken to the tab of the competency that you are assigned.
- As a caseworker with multiple competencies, when you navigate to the open or closed applications page, one of the competencies you are assigned to will be shown first 
- As a caseworker with no competencies set, when you navigate to the open or closed applications page, you should see the extradition tab by default.
- As a supervisor, when you navigate to the open or closed applications page, you should see the extradition tab by default

Other tests: 

- When the `work_stream` feature flag is set to false, you see the all applications in the open/closed applications page (i.e. the current view)
- Test the `Check all open applications` link in the your list page, navigates to the open applications page and displays the right view depending on whether you have competencies or whether the feature flag is set etc.. 
- Check that an invalid work stream param e.g. `applications/open/test` displays a page not found error screen 


[CRIMAPP-229]: https://dsdmoj.atlassian.net/browse/CRIMAPP-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-230]: https://dsdmoj.atlassian.net/browse/CRIMAPP-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ