### PR TITLE
CRIMAP-89 add prototype return reasons report

### DIFF
--- a/app/components/data_table/header_cell_component.rb
+++ b/app/components/data_table/header_cell_component.rb
@@ -15,15 +15,17 @@ module DataTable
 
     def call
       tag.th(**html_attributes) do
-        if sortable?
-          button_to(name, nil, params: sorting_params, method: :get)
-        else
-          name
-        end
+        cell_content
       end
     end
 
     private
+
+    def cell_content
+      return name unless sortable?
+
+      button_to(name, nil, params: sorting_params, method: :get)
+    end
 
     def default_classes
       class_names(
@@ -49,13 +51,13 @@ module DataTable
     end
 
     def sortable?
-      sorting.class::SORTABLE_COLUMNS.include?(colname.to_s)
+      sorting.class.sortable_columns.include?(colname.to_s)
     end
 
     def sorting_params
       {
         sorting: {
-          sort_by: colname,
+          sort_by: colname.to_s,
           sort_direction: sorting.reverse_direction
         }
       }
@@ -67,8 +69,13 @@ module DataTable
     #
     def sort_state
       return nil unless sortable?
+      return 'none' unless active?
 
-      colname.to_s == sorting.sort_by ? sorting.sort_direction : 'none'
+      sorting.sort_direction
+    end
+
+    def active?
+      colname.to_s == sorting.sort_by
     end
   end
 end

--- a/app/controllers/reporting/temporal_reports_controller.rb
+++ b/app/controllers/reporting/temporal_reports_controller.rb
@@ -11,7 +11,7 @@ module Reporting
         interval: @interval
       )
 
-      @sorting = @report.sorting_klass.new(permitted_params[:sorting])
+      @sorting = report_sorting
     end
 
     def now
@@ -19,7 +19,7 @@ module Reporting
         interval: @interval, report_type: @report_type
       )
 
-      @sorting = @report.sorting_klass.new(permitted_params[:sorting])
+      @sorting = report_sorting
 
       render :show
     end
@@ -30,6 +30,7 @@ module Reporting
       params.permit(
         :report_type,
         :interval,
+        :period,
         sorting: [:sort_by, :sort_direction]
       )
     end
@@ -41,6 +42,12 @@ module Reporting
     def set_interval
       @intervals = Types::TemporalInterval
       @interval = permitted_params.require(:interval).presence_in(*@intervals)
+    end
+
+    def report_sorting
+      @report.sorting_klass.new_or_default(
+        permitted_params[:sorting]
+      )
     end
   end
 end

--- a/app/controllers/reporting/user_reports_controller.rb
+++ b/app/controllers/reporting/user_reports_controller.rb
@@ -27,11 +27,8 @@ module Reporting
     def latest_temporal_reports
       interval = Types::TemporalInterval['daily']
 
-      klass = Reporting::TemporalReport.klass_for_interval(interval)
-      date = klass.latest_complete_report_date
-
       temporal_report_types.map do |report_type|
-        klass.new(report_type:, date:)
+        Reporting::TemporalReport.current(report_type:, interval:)
       end
     end
 

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -53,10 +53,18 @@ module Types
     details: String
   )
 
-  Report = String.enum('caseworker_report', 'volumes_report', 'processed_report', 'workload_report')
+  Report = String.enum(*%w[
+                         caseworker_report
+                         volumes_report
+                         processed_report
+                         workload_report
+                         return_reasons_report
+                       ])
 
   SnapshotReportType = String.enum(Report['workload_report'])
-  TemporalReportType = String.enum(Report['caseworker_report'], Report['volumes_report'])
+  TemporalReportType = String.enum(Report['caseworker_report'], Report['volumes_report'],
+                                   Report['return_reasons_report'])
+
   TemporalInterval = String.enum('daily', 'weekly', 'monthly')
 
   USER_ROLE_REPORTS = {
@@ -65,7 +73,7 @@ module Types
     UserRole[SUPERVISOR_ROLE] => Report.values
   }.freeze
 
-  SortDirection = String.default('ascending'.freeze).enum('descending', 'ascending')
+  SortDirection = String.enum('descending', 'ascending')
 
   SORTABLE_COLUMNS = %w[
     submitted_at

--- a/app/models/application_search_filter.rb
+++ b/app/models/application_search_filter.rb
@@ -1,7 +1,14 @@
-class ApplicationSearchFilter < ApplicationStruct
+class ApplicationSearchFilter < ApplicationStruct # rubocop:disable Metrics/ClassLength
   REVIEW_FILTERS = %i[assigned_status age_in_business_days].freeze
   DATASTORE_FILTERS = %i[
-    applicant_date_of_birth application_id_in application_status search_text submitted_after submitted_before
+    applicant_date_of_birth
+    application_id_in
+    application_status
+    reviewed_after
+    reviewed_before
+    search_text
+    submitted_after
+    submitted_before
     work_stream
   ].freeze
 
@@ -12,6 +19,8 @@ class ApplicationSearchFilter < ApplicationStruct
   attribute? :search_text, Types::Params::Nil | Types::Params::String
   attribute? :submitted_after, Types::Params::Nil | Types::Params::Date
   attribute? :submitted_before, Types::Params::Nil | Types::Params::Date
+  attribute? :reviewed_after, Types::Params::Nil | Types::Params::Date
+  attribute? :reviewed_before, Types::Params::Nil | Types::Params::Date
   attribute? :work_stream, Types::Array.of(Types::WorkStreamType)
 
   # Options for the assigned status filter
@@ -97,6 +106,14 @@ class ApplicationSearchFilter < ApplicationStruct
 
   def application_status_datastore_param
     { review_status: Types::REVIEW_STATUS_GROUPS.fetch(application_status) }
+  end
+
+  def reviewed_after_datastore_param
+    { reviewed_after: reviewed_after&.in_time_zone('London') }
+  end
+
+  def reviewed_before_datastore_param
+    { reviewed_before: reviewed_before&.in_time_zone('London') }
   end
 
   def submitted_after_datastore_param

--- a/app/models/application_search_sorting.rb
+++ b/app/models/application_search_sorting.rb
@@ -1,4 +1,4 @@
-class ApplicationSearchSorting < Sorting
+class ApplicationSearchSorting < ApplicationStruct
   SORTABLE_COLUMNS = %w[
     submitted_at
     time_passed
@@ -6,5 +6,8 @@ class ApplicationSearchSorting < Sorting
     applicant_name
   ].freeze
 
-  attribute? :sort_by, Types::String.enum(*SORTABLE_COLUMNS)
+  DEFAULT_SORT_BY = 'submitted_at'.freeze
+  DEFAULT_SORT_DIRECTION = Types::SortDirection['ascending']
+
+  include SortableStruct
 end

--- a/app/models/concerns/sortable_struct.rb
+++ b/app/models/concerns/sortable_struct.rb
@@ -1,0 +1,36 @@
+module SortableStruct
+  extend ActiveSupport::Concern
+
+  included do
+    attribute :sort_direction, Types::SortDirection
+    attribute :sort_by, Types::String.default(default_sort_by).enum(*sortable_columns)
+  end
+
+  class_methods do
+    def sortable_columns
+      self::SORTABLE_COLUMNS
+    end
+
+    def default_sort_by
+      self::DEFAULT_SORT_BY
+    end
+
+    def default_sort_direction
+      self::DEFAULT_SORT_DIRECTION
+    end
+
+    def new_or_default(params = nil)
+      params ||= {
+        sort_by: default_sort_by,
+        sort_direction: default_sort_direction
+      }
+      new(**params)
+    end
+  end
+
+  def reverse_direction
+    return 'ascending' if sort_direction == 'descending'
+
+    'descending'
+  end
+end

--- a/app/models/reporting/caseworker_report.rb
+++ b/app/models/reporting/caseworker_report.rb
@@ -4,7 +4,7 @@ module Reporting
       @dataset = dataset
     end
 
-    def rows(sorting: CaseworkerReportSorting.default)
+    def rows(sorting: sorting_klass.new_or_default)
       sorted_rows = dataset.values.sort_by do |r|
         v = r.public_send(sorting.sort_by)
         v.respond_to?(:upcase) ? v.upcase : v
@@ -15,13 +15,20 @@ module Reporting
       sorted_rows.reverse
     end
 
+    def sorting_klass
+      CaseworkerReportSorting
+    end
+
     private
 
     attr_reader :dataset
 
     class << self
-      def for_temporal_period(date:, interval:)
-        stream_name = CaseworkerReports.stream_name(date:, interval:)
+      def for_time_period(time_period:)
+        stream_name = CaseworkerReports.stream_name(
+          date: time_period.starts_on,
+          interval: time_period.interval
+        )
 
         projection = CaseworkerReports::Projection.new(stream_name:)
         new(dataset: projection.dataset)

--- a/app/models/reporting/caseworker_report_sorting.rb
+++ b/app/models/reporting/caseworker_report_sorting.rb
@@ -1,5 +1,5 @@
 module Reporting
-  class CaseworkerReportSorting < Sorting
+  class CaseworkerReportSorting < ApplicationStruct
     SORTABLE_COLUMNS = %w[
       user_name
       total_assigned_to_user
@@ -10,14 +10,8 @@ module Reporting
     ].freeze
 
     DEFAULT_SORT_BY = 'user_name'.freeze
+    DEFAULT_SORT_DIRECTION = Types::SortDirection['ascending']
 
-    attribute :sort_direction, Types::SortDirection
-    attribute :sort_by, Types::String.default(DEFAULT_SORT_BY).enum(*SORTABLE_COLUMNS)
-
-    class << self
-      def default
-        new(sort_by: DEFAULT_SORT_BY)
-      end
-    end
+    include SortableStruct
   end
 end

--- a/app/models/reporting/daily_report.rb
+++ b/app/models/reporting/daily_report.rb
@@ -7,23 +7,5 @@ module Reporting
     def period_text
       '00:00—23:59'
     end
-
-    def period_starts_on
-      date
-    end
-
-    def period_ends_on
-      date
-    end
-
-    class << self
-      def next_date(date)
-        date + 1
-      end
-
-      def previous_date(date)
-        date - 1
-      end
-    end
   end
 end

--- a/app/models/reporting/monthly_report.rb
+++ b/app/models/reporting/monthly_report.rb
@@ -5,26 +5,7 @@ module Reporting
     PERIOD_NAME_FORMAT = '%B, %Y'.freeze
 
     def period_text
-      period_starts_on.strftime('%A %-d — ') +
-        period_ends_on.strftime('%A %-d %B %Y')
-    end
-
-    def period_starts_on
-      date.beginning_of_month
-    end
-
-    def period_ends_on
-      date.end_of_month
-    end
-
-    class << self
-      def next_date(date)
-        date >> 1
-      end
-
-      def previous_date(date)
-        date << 1
-      end
+      time_period.starts_on.strftime('%A %-d — ') + time_period.ends_on.strftime('%A %-d %B %Y')
     end
   end
 end

--- a/app/models/reporting/return_reasons_report.rb
+++ b/app/models/reporting/return_reasons_report.rb
@@ -1,0 +1,48 @@
+module Reporting
+  class ReturnReasonsReport
+    attr_reader :time_period
+
+    def initialize(time_period:)
+      @time_period = time_period
+    end
+
+    def rows(sorting:)
+      dataset(sorting:).map do |row|
+        ReturnReasonsReportRow.new(row)
+      end
+    end
+
+    private
+
+    def pagination
+      Pagination.new(limit_value: 100)
+    end
+
+    def filter
+      ApplicationSearchFilter.new(
+        application_status: 'sent_back',
+        reviewed_before: time_period.ends_before,
+        reviewed_after: time_period.starts_on
+      )
+    end
+
+    def dataset(sorting:)
+      datastore_params = {
+        search: filter.datastore_params,
+        pagination: pagination.datastore_params,
+        sorting: sorting.to_h
+      }
+
+      paginated_response(http_client.post('/searches', datastore_params))
+    end
+
+    include DatastoreApi::Traits::ApiRequest
+    include DatastoreApi::Traits::PaginatedResponse
+
+    class << self
+      def for_time_period(time_period:)
+        new(time_period:)
+      end
+    end
+  end
+end

--- a/app/models/reporting/return_reasons_report_row.rb
+++ b/app/models/reporting/return_reasons_report_row.rb
@@ -1,0 +1,24 @@
+module Reporting
+  class ReturnReasonsReportRow < ApplicationStruct
+    attribute :office_code, Types::String
+    attribute :provider_name, Types::String
+    attribute :reference, Types::Integer
+    attribute :resource_id, Types::Uuid
+    attribute :return_details, Types::String
+    attribute :return_reason, Types::ReturnReason
+    attribute :reviewed_at, Types::DateTime
+
+    def reviewer_id
+      @reviewer_id ||= Review.reviewer_id_for(resource_id)
+    end
+
+    def closed_by
+      User.name_for(reviewer_id)
+    end
+
+    # TODO: make dynamic when other means_types are understood
+    def means_type
+      'passported'
+    end
+  end
+end

--- a/app/models/reporting/return_reasons_report_sorting.rb
+++ b/app/models/reporting/return_reasons_report_sorting.rb
@@ -1,0 +1,16 @@
+module Reporting
+  class ReturnReasonsReportSorting < ApplicationStruct
+    SORTABLE_COLUMNS = %w[
+      applicant_name
+      reviewed_at
+      return_reason
+      reference
+      office_code
+    ].freeze
+
+    DEFAULT_SORT_BY = 'reviewed_at'.freeze
+    DEFAULT_SORT_DIRECTION = Types::SortDirection['ascending']
+
+    include SortableStruct
+  end
+end

--- a/app/models/reporting/time_period.rb
+++ b/app/models/reporting/time_period.rb
@@ -1,0 +1,80 @@
+module Reporting
+  class TimePeriod
+    attr_reader :interval
+
+    def initialize(interval:, date: Time.current)
+      @date = date.in_time_zone('London').to_date
+      @interval = Types::TemporalInterval[interval]
+    end
+
+    # The date of an interval need not be the same for it to be considdered
+    # equivalent to another. Only the range and the interval string.
+    def ==(other)
+      interval == other.interval && range == other.range
+    end
+
+    def range
+      starts_on..ends_on
+    end
+
+    def starts_on
+      case interval
+      when 'weekly'
+        date.beginning_of_week
+      when 'daily'
+        date
+      when 'monthly'
+        date.beginning_of_month
+      end
+    end
+
+    def ends_on
+      case interval
+      when 'weekly'
+        date.end_of_week
+      when 'daily'
+        date
+      when 'monthly'
+        date.end_of_month
+      end
+    end
+
+    def ends_before
+      ends_on + 1
+    end
+
+    def next
+      self.class.new(interval: interval, date: next_date)
+    end
+
+    def previous
+      self.class.new(interval: interval, date: previous_date)
+    end
+
+    private
+
+    def previous_date
+      case interval
+      when 'weekly'
+        date - 7
+      when 'daily'
+        date - 1
+      when 'monthly'
+        date << 1
+      end
+    end
+
+    def next_date
+      case interval
+      when 'weekly'
+        date + 7
+      when 'daily'
+        date + 1
+      when 'monthly'
+        date >> 1
+      end
+    end
+
+    attr_reader :date
+  end
+end

--- a/app/models/reporting/weekly_report.rb
+++ b/app/models/reporting/weekly_report.rb
@@ -6,27 +6,9 @@ module Reporting
 
     def period_text
       [
-        I18n.l(period_starts_on, format: :reporting_long),
-        I18n.l(period_ends_on, format: :reporting_long)
+        I18n.l(time_period.starts_on, format: :reporting_long),
+        I18n.l(time_period.ends_on, format: :reporting_long)
       ].join(' — ')
-    end
-
-    def period_starts_on
-      date.beginning_of_week
-    end
-
-    def period_ends_on
-      date.end_of_week
-    end
-
-    class << self
-      def next_date(date)
-        date + 7
-      end
-
-      def previous_date(date)
-        date - 7
-      end
     end
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -23,5 +23,9 @@ class Review < ApplicationRecord
     def reviewed_by_ids(user_id:)
       where(reviewer_id: user_id).pluck(:application_id)
     end
+
+    def reviewer_id_for(application_id)
+      Review.where(application_id:).pick(:reviewer_id)
+    end
   end
 end

--- a/app/models/sorting.rb
+++ b/app/models/sorting.rb
@@ -1,9 +1,0 @@
-class Sorting < ApplicationStruct
-  attribute? :sort_direction, Types::SortDirection
-
-  def reverse_direction
-    return 'ascending' if sort_direction == 'descending'
-
-    'descending'
-  end
-end

--- a/app/read_models/caseworker_reports/row.rb
+++ b/app/read_models/caseworker_reports/row.rb
@@ -1,7 +1,12 @@
 module CaseworkerReports
   class Row
     COUNTERS = %w[
-      assigned_to_user reassigned_to_user reassigned_from_user unassigned_from_user completed_by_user sent_back_by_user
+      assigned_to_user
+      reassigned_to_user
+      reassigned_from_user
+      unassigned_from_user
+      completed_by_user
+      sent_back_by_user
     ].freeze
 
     def initialize(user_id)

--- a/app/views/reporting/base/_return_reasons_report.html.erb
+++ b/app/views/reporting/base/_return_reasons_report.html.erb
@@ -1,0 +1,31 @@
+<%= render DataTableComponent.new(classes: ['app-table']) do |table| # rubocop:disable Metrics/BlockLength
+      table.with_sortable_head(sorting:) do |head|
+        head.with_row do |row|
+          row.with_cell(text: 'Means')
+          row.with_cell(colname: :closed_by)
+          row.with_cell(colname: :reviewed_at, text: 'Date returned')
+          row.with_cell(colname: :return_reason, text: 'Return reason')
+          row.with_cell(text: 'Return details')
+          row.with_cell(colname: :reference)
+          row.with_cell(colname: :office_code)
+          row.with_cell(colname: :provider_name)
+        end
+      end
+
+      table.with_body do |body|
+        report.rows(sorting:).each do |row|
+          body.with_row do |r|
+            r.with_cell(text: row.means_type)
+            r.with_cell(text: row.closed_by)
+            r.with_cell(text: l(row.reviewed_at))
+            r.with_cell(text: row.return_reason.humanize(capitalize: false))
+            r.with_cell(
+              text: simple_format(row.return_details, {}, wrapper_tag: 'div')
+            )
+            r.with_cell(text: row.reference)
+            r.with_cell(text: row.office_code)
+            r.with_cell(text: row.provider_name)
+          end
+        end
+      end
+    end %>

--- a/app/views/reporting/temporal_reports/show.html.erb
+++ b/app/views/reporting/temporal_reports/show.html.erb
@@ -26,10 +26,10 @@
         <h2 class="govuk-heading-m"><%= @report.period_name %></h2>
 
         <% if @interval == 'weekly' %>
-          <h3 class="govuk-heading-s"><%= @report.period_text %></h2>
+          <h3 class="govuk-heading-s"><%= @report.period_text %></h3>
         <% end %>
 
-        <%= turbo_frame_tag [@report_type, @report.to_param], data: { turbo: 'true' } do %>
+        <%= turbo_frame_tag @report.id, data: { turbo: 'true' } do %>
           <%= render partial: @report_type, locals: { report: @report, sorting: @sorting } %>
         <% end %>
       </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "2be5c59acdbe339a40ada3fde511ca6d0bb128e90a91ffca5ae6c28dda842c3f",
+      "fingerprint": "640098948ddce901a04f77412dcd33f3a532714060a2fea65086f75263d3ce3e",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/reporting/temporal_reports/show.html.erb",
       "line": 33,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(partial => params.require(:report_type).presence_in(*Types::SnapshotReportType), { :locals => ({ :report => Reporting::TemporalReport.current(:interval => permitted_params.require(:interval).presence_in(*Types::TemporalInterval), :report_type => params.require(:report_type).presence_in(*Types::SnapshotReportType)), :sorting => Reporting::TemporalReport.current(:interval => permitted_params.require(:interval).presence_in(*Types::TemporalInterval), :report_type => params.require(:report_type).presence_in(*Types::SnapshotReportType)).sorting_klass.new(permitted_params[:sorting]) }) })",
+      "code": "render(partial => params.require(:report_type).presence_in(*Types::SnapshotReportType), { :locals => ({ :report => Reporting::TemporalReport.current(:interval => permitted_params.require(:interval).presence_in(*Types::TemporalInterval), :report_type => params.require(:report_type).presence_in(*Types::SnapshotReportType)), :sorting => report_sorting }) })",
       "render_path": [
         {
           "type": "controller",
@@ -32,7 +32,7 @@
       "cwe_id": [
         22
       ],
-      "note": "scoped by type"
+      "note": "Scoped by Type"
     },
     {
       "warning_type": "Remote Code Execution",
@@ -126,6 +126,6 @@
       "note": "scoped by type"
     }
   ],
-  "updated": "2023-11-15 23:29:29 +0000",
+  "updated": "2023-11-23 13:04:11 +0000",
   "brakeman_version": "6.0.1"
 }

--- a/config/locales/en/reporting.yml
+++ b/config/locales/en/reporting.yml
@@ -3,16 +3,22 @@ en:
     monthly_report:
       caseworker_report:
         title: "Caseworker monthly: %{period_name}"
+      return_reasons_report:
+        title: "Return reasons monthly: %{period_name}"
       volumes_report:
         title: "Volumes monthly: %{period_name}"
     weekly_report:
       caseworker_report:
         title: "Caseworker weekly: %{period_name}"
+      return_reasons_report:
+        title: "Return reasons weekly: %{period_name}"
       volumes_report:
         title: "Daily volumes: %{period_name}"
     daily_report:
       caseworker_report:
         title: "Caseworker daily: %{period_name}"
+      return_reasons_report:
+        title: "Return reasons daily: %{period_name}"
       volumes_report:
         title: "Daily volumes: %{period_name}"
     snapshot:
@@ -23,6 +29,7 @@ en:
         page_title: Reporting 
         heading: Reports
   labels:
+    return_reasons_report: Return reasons report
     workload_report: Workload report
     processed_report: Processed report
     caseworker_report: Caseworker report
@@ -31,35 +38,35 @@ en:
     weekly: Weekly 
     daily: Daily 
   table_headings:
+    application_type: Type
     applications_closed: Number of closed applications
     applications_received: Applications received
+    assigned_to_user: "from<br>list"
     closed: Closed
-    received: Received
-    days_passed: Business days since applications were received
-    open_applications_by_age: "Applications still\xA0open"
-    processed_on: When applications were closed
-    received_applications_by_age: Applications received
-
     colpsan_assigned_to_user: "Assigned"
-    colspan_unassigned_from_user: Unassigned
     colspan_closed_by_user: Closed
     colspan_percentage_of_assigned: Percentage
-    assigned_to_user: "from<br>list"
-    reassigned_to_user: "from<br>another"
-    total_assigned_to_user: total
-    unassigned_from_user: "from<br>self"
-    reassigned_from_user: "by<br>another"
-    total_unassigned_from_user: total
+    colspan_unassigned_from_user: Unassigned
     completed_by_user: completed
-    sent_back_by_user: "sent<br>back"
-    total_closed_by_user: total
-    percentage_unassigned_from_user: "unassigned"
+    days_passed: Business days since applications were received
+    office_code: Office code 
+    open_applications_by_age: "Applications still\xA0open"
     percentage_closed_by_user: "closed"
-
-    application_type: Type
-    what: What 
+    percentage_unassigned_from_user: "unassigned"
+    processed_on: When applications were closed
+    provider_name: Legal representative 
+    reassigned_from_user: "by<br>another"
+    reassigned_to_user: "from<br>another"
+    received: Received
+    received_applications_by_age: Applications received
+    return_reason: Reason
+    sent_back_by_user: "sent<br>back"
+    total_assigned_to_user: total
+    total_closed_by_user: total
+    total_unassigned_from_user: total
+    unassigned_from_user: "from<br>self"
     user_name: "&nbsp;"
-
+    what: What 
   caseworker_report:
     caption:  Number of times applications were assigned to, unassigned from, and closed by a given caseworker
   warnings:

--- a/spec/models/concerns/user_role_spec.rb
+++ b/spec/models/concerns/user_role_spec.rb
@@ -225,10 +225,20 @@ RSpec.describe UserRole do
   describe '#reports' do
     subject(:reports) { user.reports }
 
+    let(:expected_user_reports) do
+      %w[
+        caseworker_report
+        volumes_report
+        processed_report
+        workload_report
+        return_reasons_report
+      ]
+    end
+
     context 'when user is supervisor' do
       before { user.role = Types::SUPERVISOR_ROLE }
 
-      it { is_expected.to eq %w[caseworker_report volumes_report processed_report workload_report] }
+      it { is_expected.to eq expected_user_reports }
     end
 
     context 'when user is caseworker' do
@@ -240,7 +250,7 @@ RSpec.describe UserRole do
     context 'when user is data_analyst' do
       before { user.role = Types::DATA_ANALYST_ROLE }
 
-      it { is_expected.to eq %w[caseworker_report volumes_report processed_report workload_report] }
+      it { is_expected.to eq expected_user_reports }
     end
 
     context 'when user is user manager' do
@@ -255,7 +265,7 @@ RSpec.describe UserRole do
           }
         end
 
-        it { is_expected.to eq %w[caseworker_report volumes_report processed_report workload_report] }
+        it { is_expected.to eq expected_user_reports }
       end
     end
   end

--- a/spec/models/reporting/caseworker_report_spec.rb
+++ b/spec/models/reporting/caseworker_report_spec.rb
@@ -7,10 +7,10 @@ describe Reporting::CaseworkerReport do
     described_class.new(dataset:)
   end
 
-  describe '.for_temporal_report_period' do
-    let(:report) do
-      described_class.for_temporal_period(date: '2023-10-15', interval: :weekly)
-    end
+  describe '.for_time_period' do
+    let(:report) { described_class.for_time_period(time_period:) }
+
+    let(:time_period) { Reporting::TimePeriod.new(interval: 'weekly', date: '2023-10-15') }
 
     before do
       allow(CaseworkerReports::Projection).to receive(:new) do

--- a/spec/models/reporting/daily_report_spec.rb
+++ b/spec/models/reporting/daily_report_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 describe Reporting::DailyReport do
-  subject(:report) { described_class.new(date:, report_type:) }
+  subject(:report) { described_class.new(time_period:, report_type:) }
+
+  let(:time_period) { Reporting::TimePeriod.new(interval: 'daily', date: date) }
 
   let(:date) { Date.new(2023, 8, 1) }
   let(:report_type) { 'caseworker_report' }
@@ -11,6 +13,7 @@ describe Reporting::DailyReport do
     let(:expected_period_text) { '00:00—23:59' }
     let(:expected_title) { 'Caseworker daily: Tuesday 1 August 2023' }
     let(:expected_to_param) { { interval: 'daily', period: '2023-08-01', report_type: 'caseworker_report' } }
+    let(:expected_id) { 'caseworker_report_daily_2023-08-01' }
     let(:expected_period_name) { 'Tuesday 1 August 2023' }
     let(:expected_next_report_date) { date + 1 }
     let(:expected_previous_report_date) { date - 1 }

--- a/spec/models/reporting/monthly_report_spec.rb
+++ b/spec/models/reporting/monthly_report_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 describe Reporting::MonthlyReport do
-  subject(:report) { described_class.new(date:, report_type:) }
+  subject(:report) { described_class.new(time_period:, report_type:) }
 
+  let(:time_period) { Reporting::TimePeriod.new(interval: 'monthly', date: date) }
   let(:date) { Date.new(2023, 8, 1) }
   let(:report_type) { 'caseworker_report' }
 
@@ -11,6 +12,7 @@ describe Reporting::MonthlyReport do
     let(:expected_stream_name) { 'MonthlyCaseworker$2023-08' }
     let(:expected_period_text) { 'Tuesday 1 — Thursday 31 August 2023' }
     let(:expected_title) { 'Caseworker monthly: August, 2023' }
+    let(:expected_id) { 'caseworker_report_monthly_2023-August' }
     let(:expected_to_param) { { interval: 'monthly', period: '2023-August', report_type: 'caseworker_report' } }
     let(:expected_period_name) { 'August, 2023' }
     let(:expected_next_report_date) { Date.new(2023, 9, 1) }

--- a/spec/models/reporting/weekly_report_spec.rb
+++ b/spec/models/reporting/weekly_report_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 describe Reporting::WeeklyReport do
-  subject(:report) { described_class.new(date:, report_type:) }
+  subject(:report) { described_class.new(time_period:, report_type:) }
+
+  let(:time_period) { Reporting::TimePeriod.new(interval: 'weekly', date: date) }
 
   let(:date) { Date.new(2023, 8, 1) }
   let(:report_type) { 'caseworker_report' }
@@ -11,6 +13,7 @@ describe Reporting::WeeklyReport do
     let(:expected_stream_name) { 'WeeklyCaseworker$2023-31' }
     let(:expected_period_text) { 'Monday 31 July 2023 — Sunday 6 August 2023' }
     let(:expected_title) { 'Caseworker weekly: Week 31, 2023' }
+    let(:expected_id) { 'caseworker_report_weekly_2023-31' }
     let(:expected_to_param) { { interval: 'weekly', period: '2023-31', report_type: report_type } }
     let(:expected_period_name) { 'August, 2023' }
     let(:expected_next_report_date) { Date.new(2023, 8, 8) }

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,7 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe Review do
+  let(:application_id) { SecureRandom.uuid }
+  let(:reviewer_id) { SecureRandom.uuid }
+
   it 'is a read only model' do
     expect(described_class.new).to be_readonly
+  end
+
+  describe '.reviewer_id_for' do
+    before do
+      described_class.insert({ reviewer_id:, application_id: }) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    it 'returns the reviewer id for a given application_id' do
+      expect(described_class.reviewer_id_for(application_id)).to eq(reviewer_id)
+    end
   end
 end

--- a/spec/shared_examples/temporal_report_shared_example.rb
+++ b/spec/shared_examples/temporal_report_shared_example.rb
@@ -13,6 +13,12 @@ RSpec.shared_examples 'a temporal report' do
     it { is_expected.to eq expected_to_param }
   end
 
+  describe '#id' do
+    subject(:id) { report.id }
+
+    it { is_expected.to eq expected_id }
+  end
+
   describe '#period_text' do
     subject(:period_text) { report.period_text }
 
@@ -23,7 +29,11 @@ RSpec.shared_examples 'a temporal report' do
     subject(:next_report) { report.next_report }
 
     it 'returns the next report' do
-      expect(next_report.date).to eq(expected_next_report_date)
+      expected_time_period = Reporting::TimePeriod.new(
+        interval: time_period.interval,
+        date: expected_next_report_date
+      )
+      expect(next_report.time_period).to eq(expected_time_period)
     end
   end
 
@@ -31,7 +41,11 @@ RSpec.shared_examples 'a temporal report' do
     subject(:previous_report) { report.previous_report }
 
     it 'returns the previous report' do
-      expect(previous_report.date).to eq(expected_previous_report_date)
+      expected_time_period = Reporting::TimePeriod.new(
+        interval: time_period.interval,
+        date: expected_previous_report_date
+      )
+      expect(previous_report.time_period).to eq(expected_time_period)
     end
   end
 

--- a/spec/system/reporting/return_reasons_report_spec.rb
+++ b/spec/system/reporting/return_reasons_report_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+RSpec.describe 'Return Reasons Report' do
+  before do
+    caseworker_id = SecureRandom.uuid
+    allow(Review).to receive(:reviewer_id_for).with(resource_id) { caseworker_id }
+    allow(User).to receive(:name_for).with(caseworker_id).and_return('Joe Case')
+  end
+
+  include_context 'when viewing a temporal report'
+
+  let(:report_type) { Types::TemporalReportType['return_reasons_report'] }
+  let(:interval) { Types::TemporalInterval['weekly'] }
+  let(:period) { '2023-1' }
+  let(:resource_id) { SecureRandom.uuid }
+
+  let(:stubbed_search_results) do
+    [
+      {
+        resource_id: resource_id,
+        reviewed_at: Time.new(2023, 1, 5, 9, 0).utc,
+        appplicant_name: 'Jo Bloggs',
+        reference: 12_345_678,
+        return_reason: 'clarification_required',
+        return_details: 'More information please.',
+        office_code: '1A2BC3D',
+        provider_name: 'Andy Others'
+      }
+    ]
+  end
+
+  it 'shows the report\'s title' do
+    heading_text = page.first('h1').text
+    expect(heading_text).to eq('Return reasons report')
+  end
+
+  it 'shows the report\'s period name' do
+    heading_text = page.first('h2').text
+    expect(heading_text).to eq('Week 1, 2023')
+  end
+
+  it 'shows the report\'s period range' do
+    heading_text = page.first('h2 + h3').text
+    expect(heading_text).to eq('Monday 2 January 2023 — Sunday 8 January 2023')
+  end
+
+  it 'shows the correct column headers' do # rubocop:disable RSpec/ExampleLength
+    expected_headers = [
+      'Means',
+      'Closed by',
+      'Date returned',
+      'Return reason',
+      'Return details',
+      'Reference number',
+      'Office code',
+      'Legal representative'
+    ]
+
+    page.all('table thead tr th').each_with_index do |el, i|
+      expect(el).to have_content expected_headers[i]
+    end
+  end
+
+  it 'includes the expected data' do # rubocop:disable RSpec/ExampleLength
+    expected_data = [
+      'passported',
+      'Joe Case',
+      '5 Jan 2023',
+      'clarification required',
+      'More information please',
+      '12345678',
+      '1A2BC3D',
+      'Andy Others'
+    ]
+
+    within first('tbody tr') do
+      all('td').each_with_index do |cell, i|
+        expect(cell).to have_content expected_data[i]
+      end
+    end
+  end
+
+  it_behaves_like 'a table with sortable headers' do
+    let(:active_sort_headers) { ['Date returned'] }
+    let(:active_sort_direction) { 'ascending' }
+    let(:inactive_sort_headers) { ['Return reason', 'Reference number', 'Office code'] }
+  end
+
+  it 'can navigate to the monthly view' do
+    expect { click_link('Monthly') }.to change { current_path }
+      .from('/reporting/return_reasons_report/weekly/2023-1')
+      .to('/reporting/return_reasons_report/monthly/now')
+
+    expect(page).to have_http_status :ok
+  end
+
+  it 'can navigate to the weekly view' do
+    expect { click_link('Weekly') }.to change { current_path }
+      .from('/reporting/return_reasons_report/weekly/2023-1')
+      .to('/reporting/return_reasons_report/weekly/now')
+
+    expect(page).to have_http_status :ok
+  end
+end


### PR DESCRIPTION
## Description of change
Adds prototype return reasons report.
Refactor temporal reports to use a TimePeriod value object.
Refactor sorting by extracting sortable_struct methods.

## Link to relevant ticket
[CRIMAPP-89](https://dsdmoj.atlassian.net/browse/CRIMAPP-89)

## Notes for reviewer
Requires the following datastore changes and must not be merged until they have been deployed:
https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/185

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="855" alt="Screenshot 2023-11-24 at 10 12 15" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/1832cbb2-a567-4fd0-92ef-3eb84113a452">
<img width="1003" alt="Screenshot 2023-11-24 at 10 12 04" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/142ae70f-a809-4e6f-af58-9cf9d39c9a34">


## How to manually test the feature

Pull this version of the datastore: https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/185 .
Log in as a supervisor and click on the "Return reasons report" from the reports dashboard.

[CRIMAPP-89]: https://dsdmoj.atlassian.net/browse/CRIMAPP-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ