### PR TITLE
 [CRIMAP-129] Use latest schema 1.0.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.7'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.10'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: a3064cefa57b95bc643ea110bd46cf62a7fc03dc
-  tag: v1.0.7
+  revision: 36557b0a9c3973c41a8bb450285516f278606c3b
+  tag: v1.0.10
   specs:
-    laa-criminal-legal-aid-schemas (1.0.7)
+    laa-criminal-legal-aid-schemas (1.0.10)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)


### PR DESCRIPTION
## Description of change
Updates to latest schema to allow usage of `means_details` going forward

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-105

## Notes for reviewer
N/A

