### PR TITLE
Bump schema gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.10'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.11'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 36557b0a9c3973c41a8bb450285516f278606c3b
-  tag: v1.0.10
+  revision: cdbca6d1ff657a19df9f667192763d99c4d3c302
+  tag: v1.0.11
   specs:
-    laa-criminal-legal-aid-schemas (1.0.10)
+    laa-criminal-legal-aid-schemas (1.0.11)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)


### PR DESCRIPTION
## Description of change

Bump schema version to 1.0.11 to fix issue reading structs with empty income_details.

## Link to relevant ticket
https://ministryofjustice.sentry.io/issues/4635857522/?environment=staging&query=start%3D2023-11-20T11%3A52%3A32%26end%3D2023-11-27T11%3A52%3A32%26groupStatsPeriod%3Dauto&referrer=alerts-related-issues-issue-stream#:~:text=REVIEW%2DCRIMINAL%2DLEGAL%2DAID%2D14

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Navigate to an application's details and confirm the page loads as expected.
