### PR TITLE
[PATCH] Set work streams ff to false on prod

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,4 +14,4 @@ feature_flags:
   work_stream:
     local: true
     staging: true
-    production: true
+    production: false


### PR DESCRIPTION
## Description of change
Sets work stream ff to false after it was accidentally enabled

## Link to relevant ticket
https://github.com/ministryofjustice/laa-review-criminal-legal-aid/pull/461

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
