### PR TITLE
Re enable work stream ff on staging

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,5 +13,5 @@ feature_flags:
     production: false
   work_stream:
     local: true
-    staging: false
+    staging: true
     production: false


### PR DESCRIPTION
## Description of change

Re-enables work stream feature flag that was [previously disabled](https://github.com/ministryofjustice/laa-review-criminal-legal-aid/pull/481) on staging for regression testing.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
