### PR TITLE
Handle sorting by integer when nil

### DIFF
--- a/app/models/reporting/caseworker_report.rb
+++ b/app/models/reporting/caseworker_report.rb
@@ -7,7 +7,8 @@ module Reporting
     def rows(sorting: sorting_klass.new_or_default)
       sorted_rows = dataset.values.sort_by do |r|
         v = r.public_send(sorting.sort_by)
-        v.respond_to?(:upcase) ? v.upcase : v
+        v = v.upcase if v.respond_to?(:upcase)
+        v.nil? ? -1 : v
       end
 
       return sorted_rows unless sorting.sort_direction == 'descending'

--- a/spec/models/reporting/caseworker_report_spec.rb
+++ b/spec/models/reporting/caseworker_report_spec.rb
@@ -64,6 +64,21 @@ describe Reporting::CaseworkerReport do
           expect(rows.map(&:user_name)).to eq(['An Brown', 'Al Hart', 'Bo Brown'])
         end
       end
+
+      context 'when sorted values include nil' do
+        let(:dataset) do
+          {
+            a: instance_double(CaseworkerReports::Row, user_name: 'Al', percentage_closed_by_user: 0),
+            b: instance_double(CaseworkerReports::Row, user_name: 'Bo', percentage_closed_by_user: 99),
+            c: instance_double(CaseworkerReports::Row, user_name: 'Ad', percentage_closed_by_user: nil)
+          }
+        end
+        let(:sort_by) { 'percentage_closed_by_user' }
+
+        it 'reverses the order' do
+          expect(rows.map(&:user_name)).to eq(%w[Bo Al Ad])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Handle sorting by integer when nil

## Description of change

## Link to relevant ticket
https://ministryofjustice.sentry.io/issues/4729005239/?environment=staging&query=&referrer=issue-stream&statsPeriod=7d&stream_index=1

## Notes for reviewer

nil values are assigned -1 for sorting which means they are differentiated from 0%

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Attempt to sort the Caseworker report on Review when one of the percentages has a nil value.