### PR TITLE
[CRIMAPP-87] Allow Data Analyst casework read access

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,12 +4,12 @@ class ApplicationController < ActionController::Base
   class ForbiddenError < StandardError; end
 
   def landing_page_for(user)
-    if user.service_user?
+    if user.data_analyst?
+      new_application_searches_path
+    elsif user.service_user?
       assigned_applications_path
     elsif user.user_manager?
       manage_users_root_path
-    elsif user.reporting_user?
-      reporting_root_path
     end
   end
 
@@ -24,9 +24,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(user)
-    url = landing_page_for(user)
-
-    url.presence || super
+    stored_location_for(user) || landing_page_for(user) || super(user)
   end
 
   # Sets the full flash message based on the message key.

--- a/app/models/concerns/user_competence.rb
+++ b/app/models/concerns/user_competence.rb
@@ -9,6 +9,7 @@ module UserCompetence
 
   def competencies
     return Types::CompetencyType.values if supervisor?
+    return [] if data_analyst?
     return Types::CompetencyType.values unless FeatureFlags.work_stream.enabled?
 
     @competencies ||= Allocating.user_competencies(id)

--- a/app/models/concerns/user_role.rb
+++ b/app/models/concerns/user_role.rb
@@ -42,7 +42,7 @@ module UserRole
   def service_user?
     return true if can_manage_others? && FeatureFlags.allow_user_managers_service_access.enabled?
 
-    [CASEWORKER, SUPERVISOR].include?(role) && !can_manage_others?
+    [CASEWORKER, SUPERVISOR, DATA_ANALYST].include?(role) && !can_manage_others?
   end
 
   def reporting_user?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,11 +19,8 @@ class User < ApplicationRecord
 
   before_create :set_invitation_expires_at
 
-  # Allow data_analyst users to be deleted because they cannot
-  # be assigned another 'lesser' role - see AddDataAnalystRoleEnum
-  # migration which destroys data_analysts if DB is rolled back
   before_destroy do
-    raise CannotDestroyIfActive if activated? && !data_analyst?
+    raise CannotDestroyIfActive if activated?
   end
 
   attr_readonly :email, :can_manage_others

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,7 +1,8 @@
 <%= govuk_header(service_name: t('service.name'), classes: ["app-banner-#{HostEnv.env_name}"]) do |header| %>
-  <%= header.with_navigation_item(text: current_user.name) %>
-  <%= header.with_navigation_item(text: t('.manage_users'), href: manage_users_root_path) if current_user.can_manage_others? %>
   <%= header.with_navigation_item(text: t('.reports'), href: reporting_root_path) if current_user.can_access_reporting_dashboard? %>
+  <%= header.with_navigation_item(text: t('.manage_users'), href: manage_users_root_path) if current_user.can_manage_others? %>
   <%= header.with_navigation_item(text: t('.manage_competencies'), href: manage_competencies_root_path) if current_user.can_write_application? %>
+
+  <%= header.with_navigation_item(text: current_user.name) %>
   <%= header.with_navigation_item(text: t('calls_to_action.sign_out'), href: destroy_user_session_path) %>
 <% end %>

--- a/spec/models/concerns/user_competence_spec.rb
+++ b/spec/models/concerns/user_competence_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe UserCompetence do
         end
       end
 
+      context 'when user is a data analyst' do
+        let(:user) { User.new(role: 'data_analyst') }
+
+        it 'returns no competencies' do
+          expect(competencies).to be_empty
+        end
+      end
+
       context 'when work stream feature flag is disabled' do
         before do
           allow(FeatureFlags).to receive(:work_stream) {

--- a/spec/models/concerns/user_role_spec.rb
+++ b/spec/models/concerns/user_role_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe UserRole do
         user.can_manage_others = false
         user.role = UserRole::DATA_ANALYST
 
-        expect(user.service_user?).to be false
+        expect(user.service_user?).to be true
       end
     end
 

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -138,6 +138,7 @@ RSpec.describe 'Authentication Session Initialisation' do
 
         it 'redirects to "Manage Users"' do
           auth_callback
+
           expect(response).to redirect_to(manage_users_root_path)
         end
       end
@@ -171,7 +172,7 @@ RSpec.describe 'Authentication Session Initialisation' do
 
         it 'redirects to "Your list"' do
           auth_callback
-          expect(response).to redirect_to(reporting_root_path)
+          expect(response).to redirect_to(new_application_searches_path)
         end
       end
     end

--- a/spec/system/header_nav_spec.rb
+++ b/spec/system/header_nav_spec.rb
@@ -126,10 +126,10 @@ RSpec.describe 'Header navigation' do
       visit '/'
     end
 
-    it 'they are redirected to the reports dashboard by default' do
-      expect { click_link('Reports') }.not_to change {
+    it 'they are redirected to application search by default' do
+      expect { click_link('Reports') }.to change {
         page.first('.govuk-heading-xl').text
-      }.from('Reports')
+      }.from('Search for an application').to('Reports')
     end
 
     it 'does not have a link to manage users' do


### PR DESCRIPTION
## Description of change
This pull request enables DataAnalysts to access the caseworker section of the service.

## Link to relevant ticket
https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMAPP/boards/1375/backlog?selectedIssue=CRIMAPP-87

## Notes for reviewer

Previously, DataAnalysts didn't have access to the casework section. However, in practice, they require access to the search function and application details and history. Due to restrictions, DataAnalysts were included as Supervisors. Changes in competencies now permit users to access the caseworker section, but without specific caseworker competencies, they can't review applications.

This PR grants DataAnalysts access to the caseworker area, allowing them to view applications and conduct searches but preventing them from reviewing applications.

We do not have Data Analysts enrolled on production so this change can be deployed following regression testing.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

Sign in as a data analyst. 
Confirm you are redirected to the application search. 
Confirm you cannot assign / review an application. 
Confirm you can access the reporting dashboard.
When on a report, allow the session to time out, confirm you are redirected to the report and not search when you re-authenticate.
