### PR TITLE
Renable work stream ff on staging for qa

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,5 +13,5 @@ feature_flags:
     production: true
   work_stream:
     local: true
-    staging: false
+    staging: true
     production: false


### PR DESCRIPTION
## Description of change
Work steams ff was previously disabled for regression testing on staging. This PR re-enables it

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
