### PR TITLE
[CRIMAPP-279] Ensure assigned applications are displayed for users with no competencies

### DIFF
--- a/app/controllers/casework/assigned_applications_controller.rb
+++ b/app/controllers/casework/assigned_applications_controller.rb
@@ -11,10 +11,7 @@ module Casework
     def index
       return unless assignments_count.positive?
 
-      set_search(
-        default_filter: { assigned_status: current_user_id },
-        default_sorting: { sort_by: 'submitted_at', sort_direction: 'ascending' }
-      )
+      set_search_filters
     end
 
     def create
@@ -66,7 +63,16 @@ module Casework
       return unless current_user.work_streams.empty?
 
       set_flash(:no_work_streams_to_assign_from, success: false)
+      set_search_filters
+
       render :index
+    end
+
+    def set_search_filters
+      set_search(
+        default_filter: { assigned_status: current_user_id },
+        default_sorting: { sort_by: 'submitted_at', sort_direction: 'ascending' }
+      )
     end
   end
 end

--- a/app/controllers/casework/assigned_applications_controller.rb
+++ b/app/controllers/casework/assigned_applications_controller.rb
@@ -11,7 +11,10 @@ module Casework
     def index
       return unless assignments_count.positive?
 
-      set_search_filters
+      set_search(
+        default_filter: { assigned_status: current_user_id },
+        default_sorting: { sort_by: 'submitted_at', sort_direction: 'ascending' }
+      )
     end
 
     def create
@@ -63,16 +66,8 @@ module Casework
       return unless current_user.work_streams.empty?
 
       set_flash(:no_work_streams_to_assign_from, success: false)
-      set_search_filters
 
       redirect_to assigned_applications_path
-    end
-
-    def set_search_filters
-      set_search(
-        default_filter: { assigned_status: current_user_id },
-        default_sorting: { sort_by: 'submitted_at', sort_direction: 'ascending' }
-      )
     end
   end
 end

--- a/app/controllers/casework/assigned_applications_controller.rb
+++ b/app/controllers/casework/assigned_applications_controller.rb
@@ -65,7 +65,7 @@ module Casework
       set_flash(:no_work_streams_to_assign_from, success: false)
       set_search_filters
 
-      render :index
+      redirect_to assigned_applications_path
     end
 
     def set_search_filters

--- a/app/views/casework/application_searches/_search_results_table_body.html.erb
+++ b/app/views/casework/application_searches/_search_results_table_body.html.erb
@@ -8,9 +8,6 @@
     <%= result.reference %>
   </td>
   <td class="govuk-table__cell">
-    <%= result.application_type.humanize %>
-  </td>
-  <td class="govuk-table__cell">
     <%= result.case_type.humanize %>
   </td>
   <td class="govuk-table__cell">

--- a/app/views/casework/application_searches/search.html.erb
+++ b/app/views/casework/application_searches/search.html.erb
@@ -25,7 +25,6 @@
               head.with_row do |row|
                 row.with_cell(colname: :applicant_name)
                 row.with_cell(colname: :reference)
-                row.with_cell(colname: :application_type)
                 row.with_cell(colname: :case_type)
                 row.with_cell(colname: :submitted_at)
                 row.with_cell(colname: :reviewed_at)

--- a/spec/system/casework/no_competencies_spec.rb
+++ b/spec/system/casework/no_competencies_spec.rb
@@ -40,6 +40,30 @@ RSpec.describe 'No competencies' do
       expect(page).to have_notification_banner(text: 'You must be allocated to a work queue to review applications',
                                                details: details, success: false)
     end
+
+    context 'when previously assigned an application' do
+      before do
+        Assigning::AssignToUser.new(
+          user_id: current_user.id,
+          to_whom_id: current_user.id,
+          assignment_id: crime_application_id
+        ).call
+
+        visit '/'
+      end
+
+      context 'when you are not allocated to a work stream' do
+        it 'displays a notification banner' do
+          click_on 'Review next application'
+          expect(page).to have_notification_banner(text: 'You must be allocated to a work queue to review applications',
+                                                   details: details, success: false)
+        end
+
+        it 'displays any previously assigned applications' do
+          expect(page).to have_content '1 application is assigned to you for review'
+        end
+      end
+    end
   end
 
   context 'when assigning an application to your list' do

--- a/spec/system/casework/searching/search_filters_and_results_spec.rb
+++ b/spec/system/casework/searching/search_filters_and_results_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Search Page' do
     column_headings = page.all('.app-dashboard-table thead tr th.govuk-table__header').map(&:text)
 
     expect(column_headings).to eq(
-      ["Applicant's name", 'Reference number', 'Type', 'Case type', 'Date received', 'Date closed', 'Closed by',
+      ["Applicant's name", 'Reference number', 'Case type', 'Date received', 'Date closed', 'Closed by',
        'Status']
     )
   end
@@ -30,7 +30,7 @@ RSpec.describe 'Search Page' do
   it 'shows the correct results' do
     first_row_text = page.first('.app-dashboard-table tbody tr').text
 
-    expect(first_row_text).to eq('Kit Pound 120398120 Initial Summary only 27 Oct 2022 Open')
+    expect(first_row_text).to eq('Kit Pound 120398120 Summary only 27 Oct 2022 Open')
   end
 
   it 'has the correct search results count' do


### PR DESCRIPTION
## Description of change
Discovered a bug in qa where when caseworkers with no competencies click to retrieve the next application, there is an error shown. This is because the search and sort filters were not being set when the page is being rendered with a flash message so the assigned applications table couldn't be populated. In future, assigned applications may be unassigned from caseworkers when their competencies are removed but this hasn't been agreed yet 

Also removes the application type column from following qa, as it was decided that this should be displayed once change in financial circumstances applications are coming through. Currently, every application is 'initial' so the column is not helpful 

## Link to relevant ticket
[CRIMAPP-279](https://dsdmoj.atlassian.net/browse/CRIMAPP-279)
[CRIMAPP-282](https://dsdmoj.atlassian.net/browse/CRIMAPP-282)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1435" alt="Screenshot 2023-12-19 at 12 50 09" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/8116ce20-a6f1-4903-abae-883f074c8d7d">


### After changes:
<img width="1249" alt="Screenshot 2023-12-20 at 12 47 51" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/e2f927e6-2e51-43de-b577-30aaf07de89c">
<img width="1249" alt="Screenshot 2023-12-20 at 12 48 00" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/749929c8-f6ce-4cae-804e-9b436247ce71">

## How to manually test the feature
Sign in as a caseworker with a CAT 1 competency 
Assign an application to yourself
Sign out and sign in as a supervisor 
Change the competency of that caseworker to no competencies
Sign out and sign in as that caseworker
Go to the assigned applications page click review next application 
You should get a banner saying you cannot review applications without a work queue and you should still see your assigned application 


For the search results table change, you can log in as any user, make a search and verify that you can no longer see the application type column 

[CRIMAPP-279]: https://dsdmoj.atlassian.net/browse/CRIMAPP-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-282]: https://dsdmoj.atlassian.net/browse/CRIMAPP-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ