### PR TITLE
[CRIMAPP-283] Add income section to app details

### DIFF
--- a/app/views/casework/crime_applications/_income.html.erb
+++ b/app/views/casework/crime_applications/_income.html.erb
@@ -1,0 +1,40 @@
+<% if income_details.present? %>
+  <h2 class="govuk-heading-m">
+    <%= label_text(:income) %>
+  </h2>
+
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:income_more_than) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= t(income_details.income_above_threshold, scope: 'values') %>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:has_frozen_income_or_assets) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= t(income_details.has_frozen_income_or_assets, scope: 'values') %>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:client_owns_property) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= t(income_details.client_owns_property, scope: 'values') %>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:has_savings) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= t(income_details.has_savings, scope: 'values') %>
+      </dd>
+    </div>
+  </dl>
+<% end %>

--- a/app/views/casework/crime_applications/show.html.erb
+++ b/app/views/casework/crime_applications/show.html.erb
@@ -19,7 +19,6 @@
       <%= render partial: 'supporting_evidence', locals: { crime_application: @crime_application } %>
     <% end %>
     <% if FeatureFlags.means_journey.enabled? %>
-      <%#= render partial: 'income', locals: { crime_application: @crime_application } %>
       <%= render partial: 'income', locals: { income_details: @crime_application.means_details.income_details } %>
   <% end %>
     <%= render partial: 'provider_details', object: @crime_application.provider_details %>

--- a/app/views/casework/crime_applications/show.html.erb
+++ b/app/views/casework/crime_applications/show.html.erb
@@ -18,6 +18,10 @@
     <% if FeatureFlags.evidence_upload.enabled? %>
       <%= render partial: 'supporting_evidence', locals: { crime_application: @crime_application } %>
     <% end %>
+    <% if FeatureFlags.means_journey.enabled? %>
+      <%#= render partial: 'income', locals: { object: @crime_application.means_details } %>
+      <%= render partial: 'income', locals: { income_details: @crime_application.means_details.income_details } %>
+  <% end %>
     <%= render partial: 'provider_details', object: @crime_application.provider_details %>
   </div>
 </div>

--- a/app/views/casework/crime_applications/show.html.erb
+++ b/app/views/casework/crime_applications/show.html.erb
@@ -19,7 +19,7 @@
       <%= render partial: 'supporting_evidence', locals: { crime_application: @crime_application } %>
     <% end %>
     <% if FeatureFlags.means_journey.enabled? %>
-      <%#= render partial: 'income', locals: { object: @crime_application.means_details } %>
+      <%#= render partial: 'income', locals: { crime_application: @crime_application } %>
       <%= render partial: 'income', locals: { income_details: @crime_application.means_details.income_details } %>
   <% end %>
     <%= render partial: 'provider_details', object: @crime_application.provider_details %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -71,6 +71,7 @@ en:
     case_type: Case type
     caseworker: Caseworker
     client_details: Client details
+    client_owns_property: Has land or property?
     closed_by: 'Closed by:'
     codefendants: Co-defendants
     correspondence_address: Correspondence address
@@ -88,8 +89,12 @@ en:
     financial_change_details: Changes in the client’s financial circumstances
     first_name: First name
     first_court_hearing: First court hearing the case
+    has_frozen_income_or_assets: Has income, savings or assets under a restraint or freezing order?
+    has_savings: Has savings or investments?
     hearing_date: Date of next hearing
     home_address: Home address
+    income: Income
+    income_more_than: Income more than £12,475?
     interests_of_justice: Interest of Justice
     interests_of_justice_type: Criteria
     justification: Justification
@@ -142,6 +147,8 @@ en:
   values: &VALUES
     "true": "Yes"
     "false": "No"
+    "yes": "Yes"
+    "no": "No"
     not_provided: Not provided
     not_asked: Not asked when this application was submitted
     deleted_user_name: '[deleted]'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,3 +15,7 @@ feature_flags:
     local: true
     staging: true
     production: true
+  means_journey:
+    local: true
+    staging: true
+    production: false

--- a/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Viewing the income details of an application' do
 
   context 'with no income details' do
     let(:application_data) do
-      super().deep_merge('means_details' => { 'income_details' => nil })
+      super().deep_merge('means_details' => nil)
     end
 
     it 'does not show income section' do

--- a/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing the income details of an application' do
+  include_context 'with stubbed application'
+
+  before do
+    visit crime_application_path(application_id)
+  end
+
+  context 'with income details' do
+    it 'shows income above threshold' do
+      expect(page).to have_content('Income more than £12,475? No')
+    end
+
+    it 'shows has income savings assets' do
+      expect(page).to have_content('Has income, savings or assets under a restraint or freezing order? No')
+    end
+
+    it 'shows land or property' do
+      expect(page).to have_content('Has land or property? No')
+    end
+
+    it 'shows savings or investments' do
+      expect(page).to have_content('Has savings or investments? No')
+    end
+  end
+
+  context 'with no income details' do
+    let(:application_data) do
+      super().deep_merge('means_details' => { 'income_details' => nil })
+    end
+
+    it 'does not show income section' do
+      expect(page).not_to have_content('Income')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Adds means journey feature flag 
Displays income details on application details page if present
If an application has not gone through the income details section, nothing is displayed

## Link to relevant ticket
[CRIMAPP-283](https://dsdmoj.atlassian.net/browse/CRIMAPP-283)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1234" alt="Screenshot 2023-12-22 at 09 28 52" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/0d54ca5e-546e-4b14-a34f-c176b1945c23">

## How to manually test the feature
Submit an application in apply with income details 
Go to review and view the application verify you can see the income details with the correct answers
Also verify an application with no income details does not display the section

[CRIMAPP-283]: https://dsdmoj.atlassian.net/browse/CRIMAPP-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ