### PR TITLE
CRIMAPP-87 data analyst can download return reasons

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -37,6 +37,11 @@ html {
 }
 
 .app-table {
+  thead {
+    position: sticky;
+    top: 0;
+    background-color: white;
+  }
   tr.colgroup-headers {
     th {
       border-bottom: none;

--- a/app/controllers/manage_competencies/base_controller.rb
+++ b/app/controllers/manage_competencies/base_controller.rb
@@ -3,8 +3,8 @@ module ManageCompetencies
     layout 'manage_competencies'
 
     before_action :authenticate_user!
-    before_action :set_security_headers
     before_action :require_supervisor!
+    before_action :set_security_headers
 
     # Scope for I18n locale, used by _text helpers.
     def text_namespace

--- a/app/controllers/manage_competencies/base_controller.rb
+++ b/app/controllers/manage_competencies/base_controller.rb
@@ -3,8 +3,8 @@ module ManageCompetencies
     layout 'manage_competencies'
 
     before_action :authenticate_user!
-    before_action :require_supervisor!
     before_action :set_security_headers
+    before_action :require_supervisor!
 
     # Scope for I18n locale, used by _text helpers.
     def text_namespace

--- a/app/controllers/manage_users/base_controller.rb
+++ b/app/controllers/manage_users/base_controller.rb
@@ -16,8 +16,7 @@ module ManageUsers
     def require_user_manager!
       return if current_user.can_manage_others?
 
-      render status: :not_found, template: 'errors/not_found', layout: 'external'
-      false
+      raise ForbiddenError, 'Must be a user manager'
     end
   end
 end

--- a/app/controllers/reporting/base_controller.rb
+++ b/app/controllers/reporting/base_controller.rb
@@ -13,7 +13,7 @@ module Reporting
       raise ForbiddenError, 'Must be a reporting user'
     end
 
-    def require_report_downloader!
+    def require_download_access!
       return if current_user.can_download_reports?
 
       raise ForbiddenError, 'Cannot download reports'

--- a/app/controllers/reporting/base_controller.rb
+++ b/app/controllers/reporting/base_controller.rb
@@ -13,8 +13,16 @@ module Reporting
       raise ForbiddenError, 'Must be a reporting user'
     end
 
+    def require_report_downloader!
+      return if current_user.can_download_reports?
+
+      raise ForbiddenError, 'Cannot download reports'
+    end
+
     def require_report_access!
-      raise Reporting::ReportNotFound unless current_user.reports.include?(@report_type)
+      return if current_user.reports.include?(@report_type)
+
+      raise ForbiddenError, 'Cannot access this report type'
     end
   end
 end

--- a/app/controllers/reporting/temporal_reports_controller.rb
+++ b/app/controllers/reporting/temporal_reports_controller.rb
@@ -10,27 +10,24 @@ module Reporting
       @sorting = @report.sorting
     end
 
-    def now
-      @report = Reporting::TemporalReport.current(
-        interval: @interval,
-        report_type: @report_type,
-        sorting: permitted_params[:sorting],
-        page: permitted_params[:page]
-      )
-
-      @sorting = @report.sorting
-
-      render :show
-    end
-
     def download
-      file = permitted_params[:file]
+      file = permitted_params[:file] || 1
       send_data(
-        @report.source_csv(file:),
+        @report.csv(file:),
         file_name: '@report.id',
-        filename: @report.source_csv_filename(file:),
+        filename: @report.csv_filename(file:),
         type: 'text/csv; charset=utf-8; header=present'
       )
+    end
+
+    def latest_complete
+      report = Reporting::TemporalReport.current(
+        interval: @interval,
+        report_type: @report_type,
+        sorting: permitted_params[:sorting]
+      ).previous_report
+
+      redirect_to reporting_temporal_report_path(report.to_param)
     end
 
     private

--- a/app/controllers/reporting/temporal_reports_controller.rb
+++ b/app/controllers/reporting/temporal_reports_controller.rb
@@ -2,7 +2,7 @@ module Reporting
   class TemporalReportsController < Reporting::BaseController
     before_action :set_report_type
     before_action :set_interval
-    before_action :require_report_downloader!, only: [:download]
+    before_action :require_download_access!, only: [:download]
     before_action :require_report_access!
     before_action :set_report, only: [:show, :download]
 

--- a/app/controllers/reporting/temporal_reports_controller.rb
+++ b/app/controllers/reporting/temporal_reports_controller.rb
@@ -2,26 +2,35 @@ module Reporting
   class TemporalReportsController < Reporting::BaseController
     before_action :set_report_type
     before_action :set_interval
+    before_action :require_report_downloader!, only: [:download]
     before_action :require_report_access!
+    before_action :set_report, only: [:show, :download]
 
     def show
-      @report = Reporting::TemporalReport.from_param(
-        report_type: @report_type,
-        period: params[:period],
-        interval: @interval
-      )
-
-      @sorting = report_sorting
+      @sorting = @report.sorting
     end
 
     def now
       @report = Reporting::TemporalReport.current(
-        interval: @interval, report_type: @report_type
+        interval: @interval,
+        report_type: @report_type,
+        sorting: permitted_params[:sorting],
+        page: permitted_params[:page]
       )
 
-      @sorting = report_sorting
+      @sorting = @report.sorting
 
       render :show
+    end
+
+    def download
+      file = permitted_params[:file]
+      send_data(
+        @report.source_csv(file:),
+        file_name: '@report.id',
+        filename: @report.source_csv_filename(file:),
+        type: 'text/csv; charset=utf-8; header=present'
+      )
     end
 
     private
@@ -31,6 +40,8 @@ module Reporting
         :report_type,
         :interval,
         :period,
+        :page,
+        :file,
         sorting: [:sort_by, :sort_direction]
       )
     end
@@ -39,15 +50,19 @@ module Reporting
       @report_type = permitted_params.require(:report_type).presence_in(*Types::TemporalReportType)
     end
 
+    def set_report
+      @report = Reporting::TemporalReport.from_param(
+        report_type: @report_type,
+        period: permitted_params[:period],
+        interval: @interval,
+        sorting: permitted_params[:sorting],
+        page: permitted_params[:page]
+      )
+    end
+
     def set_interval
       @intervals = Types::TemporalInterval
       @interval = permitted_params.require(:interval).presence_in(*@intervals)
-    end
-
-    def report_sorting
-      @report.sorting_klass.new_or_default(
-        permitted_params[:sorting]
-      )
     end
   end
 end

--- a/app/controllers/reporting/user_reports_controller.rb
+++ b/app/controllers/reporting/user_reports_controller.rb
@@ -39,10 +39,14 @@ module Reporting
     # NOTE: this code is temporary and used here to provide a list of temporal
     # reports for protyping purposes only.
     def latest_temporal_reports
-      interval = Types::TemporalInterval['daily']
+      interval = if current_user.data_analyst?
+                   Types::TemporalInterval['monthly']
+                 else
+                   Types::TemporalInterval['daily']
+                 end
 
       temporal_report_types.map do |report_type|
-        Reporting::TemporalReport.current(report_type:, interval:)
+        Reporting::TemporalReport.current(report_type:, interval:).previous_report
       end
     end
 

--- a/app/models/application_search_result.rb
+++ b/app/models/application_search_result.rb
@@ -5,8 +5,8 @@ class ApplicationSearchResult < ApplicationStruct
   attribute :resource_id, Types::Uuid
   attribute :status, Types::String
   attribute :work_stream, Types::WorkStreamType
-  attribute :application_type, Types::ApplicationType
-  attribute :case_type, Types::CaseType
+  attribute? :application_type, Types::ApplicationType
+  attribute? :case_type, Types::CaseType
   attribute? :parent_id, Types::Uuid.optional
 
   include Assignable

--- a/app/models/application_search_sorting.rb
+++ b/app/models/application_search_sorting.rb
@@ -8,7 +8,7 @@ class ApplicationSearchSorting < ApplicationStruct
   ].freeze
 
   DEFAULT_SORT_BY = 'submitted_at'.freeze
-  DEFAULT_SORT_DIRECTION = Types::SortDirection['ascending']
+  DEFAULT_SORT_DIRECTION = Types::SortDirection['ascending'].freeze
 
   include SortableStruct
 end

--- a/app/models/concerns/downloadable.rb
+++ b/app/models/concerns/downloadable.rb
@@ -1,0 +1,36 @@
+module Downloadable
+  extend ActiveSupport::Concern
+
+  def source_csv_file_count
+    Rational(total_count, source_csv_limit).ceil
+  end
+
+  def source_csv_limit
+    self.class::SOURCE_CSV_LIMIT
+  end
+
+  def source_csv_pagination(file: 1)
+    { page: file, per_page: source_csv_limit }
+  end
+
+  def source_dataset(file: 1)
+    paginated_response(http_client.post(
+                         '/searches',
+                         search: filter.datastore_params,
+                         pagination: source_csv_pagination(file:)
+                       ))
+  end
+
+  def source_csv(file: 1)
+    ds = source_dataset(file:)
+    @total_count ||= ds.pagination['total_count']
+
+    CSV.generate do |csv|
+      csv << ds.first.keys
+
+      ds.each do |d|
+        csv << d.values
+      end
+    end
+  end
+end

--- a/app/models/concerns/downloadable.rb
+++ b/app/models/concerns/downloadable.rb
@@ -1,28 +1,28 @@
 module Downloadable
   extend ActiveSupport::Concern
 
-  def source_csv_file_count
-    Rational(total_count, source_csv_limit).ceil
+  def csv_limit
+    self.class::CSV_LIMIT
   end
 
-  def source_csv_limit
-    self.class::SOURCE_CSV_LIMIT
+  def csv_pagination(file: 1)
+    { page: file, per_page: csv_limit }
   end
 
-  def source_csv_pagination(file: 1)
-    { page: file, per_page: source_csv_limit }
+  def csv_file_count
+    Rational(total_count, csv_limit).ceil
   end
 
-  def source_dataset(file: 1)
+  def csv_dataset(file: 1)
     paginated_response(http_client.post(
                          '/searches',
                          search: filter.datastore_params,
-                         pagination: source_csv_pagination(file:)
+                         pagination: csv_pagination(file:)
                        ))
   end
 
-  def source_csv(file: 1)
-    ds = source_dataset(file:)
+  def csv(file: 1)
+    ds = csv_dataset(file:)
     @total_count ||= ds.pagination['total_count']
 
     CSV.generate do |csv|

--- a/app/models/concerns/sortable_struct.rb
+++ b/app/models/concerns/sortable_struct.rb
@@ -2,8 +2,8 @@ module SortableStruct
   extend ActiveSupport::Concern
 
   included do
-    attribute :sort_direction, Types::SortDirection
-    attribute :sort_by, Types::String.default(default_sort_by).enum(*sortable_columns)
+    attribute? :sort_direction, Types::String.default(default_sort_direction).enum(*Types::SortDirection.values)
+    attribute? :sort_by, Types::String.default(default_sort_by).enum(*sortable_columns)
   end
 
   class_methods do

--- a/app/models/concerns/user_role.rb
+++ b/app/models/concerns/user_role.rb
@@ -30,6 +30,10 @@ module UserRole
     false
   end
 
+  def can_download_reports?
+    role == DATA_ANALYST
+  end
+
   # TODO: Any reason to not allow supervisor to be 'downgraded' to caseworker?
   def can_change_role?
     return false unless activated?

--- a/app/models/reporting/caseworker_report_sorting.rb
+++ b/app/models/reporting/caseworker_report_sorting.rb
@@ -11,7 +11,7 @@ module Reporting
     ].freeze
 
     DEFAULT_SORT_BY = 'user_name'.freeze
-    DEFAULT_SORT_DIRECTION = Types::SortDirection['ascending']
+    DEFAULT_SORT_DIRECTION = Types::SortDirection['ascending'].freeze
 
     include SortableStruct
   end

--- a/app/models/reporting/return_reasons_report.rb
+++ b/app/models/reporting/return_reasons_report.rb
@@ -2,7 +2,7 @@ module Reporting
   require 'csv'
 
   class ReturnReasonsReport
-    SOURCE_CSV_LIMIT = 1_000
+    CSV_LIMIT = 1_000
 
     include Downloadable
 

--- a/app/models/reporting/return_reasons_report.rb
+++ b/app/models/reporting/return_reasons_report.rb
@@ -1,22 +1,34 @@
 module Reporting
-  class ReturnReasonsReport
-    attr_reader :time_period
+  require 'csv'
 
-    def initialize(time_period:)
+  class ReturnReasonsReport
+    SOURCE_CSV_LIMIT = 1_000
+
+    include Downloadable
+
+    attr_reader :time_period, :sorting
+
+    def initialize(time_period:, sorting:, page:)
       @time_period = time_period
+      @sorting = ReturnReasonsReportSorting.new_or_default(sorting)
+      @page = page
     end
 
-    def rows(sorting:)
-      dataset(sorting:).map do |row|
+    def rows
+      dataset.map do |row|
         ReturnReasonsReportRow.new(row)
       end
     end
 
-    private
+    def total_count
+      @total_count ||= pagination.total_count
+    end
 
     def pagination
-      Pagination.new(limit_value: 100)
+      Pagination.new(dataset.pagination) if @dataset
     end
+
+    private
 
     def filter
       ApplicationSearchFilter.new(
@@ -26,22 +38,24 @@ module Reporting
       )
     end
 
-    def dataset(sorting:)
+    def dataset
+      return @dataset if @dataset
+
       datastore_params = {
         search: filter.datastore_params,
-        pagination: pagination.datastore_params,
+        pagination: Pagination.new(current_page: @page).datastore_params,
         sorting: sorting.to_h
       }
 
-      paginated_response(http_client.post('/searches', datastore_params))
+      @dataset = paginated_response(http_client.post('/searches', datastore_params))
     end
 
     include DatastoreApi::Traits::ApiRequest
     include DatastoreApi::Traits::PaginatedResponse
 
     class << self
-      def for_time_period(time_period:)
-        new(time_period:)
+      def for_time_period(time_period:, sorting:, page:)
+        new(time_period:, sorting:, page:)
       end
     end
   end

--- a/app/models/reporting/return_reasons_report_sorting.rb
+++ b/app/models/reporting/return_reasons_report_sorting.rb
@@ -9,7 +9,7 @@ module Reporting
     ].freeze
 
     DEFAULT_SORT_BY = 'reviewed_at'.freeze
-    DEFAULT_SORT_DIRECTION = Types::SortDirection['ascending']
+    DEFAULT_SORT_DIRECTION = Types::SortDirection['ascending'].freeze
 
     include SortableStruct
   end

--- a/app/models/reporting/temporal_report.rb
+++ b/app/models/reporting/temporal_report.rb
@@ -49,12 +49,12 @@ module Reporting
 
     delegate :total_count, :pagination, :downloadable?, to: :report
 
-    def source_csv(file: 1)
-      @source_csv ||= report.source_csv(file:)
+    def csv(file: 1)
+      @csv ||= report.csv(file:)
     end
 
-    def source_csv_filename(file: 1)
-      "#{id}_#{file}_of_#{report.source_csv_file_count}.csv"
+    def csv_filename(file: 1)
+      "#{id}_#{file}_of_#{report.csv_file_count}.csv"
     end
 
     # returns true if the report includes the current day

--- a/app/views/casework/application_searches/_search_results_table_body.html.erb
+++ b/app/views/casework/application_searches/_search_results_table_body.html.erb
@@ -8,7 +8,7 @@
     <%= result.reference %>
   </td>
   <td class="govuk-table__cell">
-    <%= result.case_type.humanize %>
+    <%= result.case_type&.humanize %>
   </td>
   <td class="govuk-table__cell">
     <%= l(result.submitted_at) %>

--- a/app/views/casework/application_searches/_search_results_table_body.html.erb
+++ b/app/views/casework/application_searches/_search_results_table_body.html.erb
@@ -8,7 +8,7 @@
     <%= result.reference %>
   </td>
   <td class="govuk-table__cell">
-    <%= result.case_type&.humanize %>
+    <%= result.case_type.humanize %>
   </td>
   <td class="govuk-table__cell">
     <%= l(result.submitted_at) %>

--- a/app/views/casework/application_searches/search.html.erb
+++ b/app/views/casework/application_searches/search.html.erb
@@ -20,7 +20,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <table class="govuk-table app-dashboard-table" data-module="moj-sortable-table">
+      <table class="govuk-table app-table">
         <%= render DataTable::HeadComponent.new(sorting: @search.sorting, filter: @search.filter) do |head|
               head.with_row do |row|
                 row.with_cell(colname: :applicant_name)

--- a/app/views/casework/crime_applications/_open_closed_applications.html.erb
+++ b/app/views/casework/crime_applications/_open_closed_applications.html.erb
@@ -31,7 +31,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-  <table class="govuk-table app-dashboard-table">
+  <table class="govuk-table app-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <%= render "#{action_name}_crime_applications_table_headers", search: %>

--- a/app/views/reporting/base/_caseworker_report.html.erb
+++ b/app/views/reporting/base/_caseworker_report.html.erb
@@ -42,7 +42,7 @@
       end
 
       table.with_body do |body| # rubocop:disable Metrics/BlockLength
-        report.rows(sorting:).each do |data_row| # rubocop:disable Metrics/BlockLength
+        report.rows.each do |data_row| # rubocop:disable Metrics/BlockLength
           body.with_row do |row| # rubocop:disable Metrics/BlockLength
             row.with_cell(
               text: link_to_search_by_caseworker(data_row.user_name, data_row.user_id)

--- a/app/views/reporting/temporal_reports/_download_links.html.erb
+++ b/app/views/reporting/temporal_reports/_download_links.html.erb
@@ -1,7 +1,7 @@
-<% Array.new(report.report.source_csv_file_count) do |i| %>
+<% Array.new(report.report.csv_file_count) do |i| %>
   <p>
     <%= govuk_link_to(
-          "Download source data (CSV) #{i + 1} of #{report.report.source_csv_file_count}",
+          "Download source data (CSV) #{i + 1} of #{report.report.csv_file_count}",
           reporting_download_temporal_report_path(file: i + 1, **report.to_param),
           data: { turbo: false }
         ) %>

--- a/app/views/reporting/temporal_reports/_download_links.html.erb
+++ b/app/views/reporting/temporal_reports/_download_links.html.erb
@@ -1,0 +1,9 @@
+<% Array.new(report.report.source_csv_file_count) do |i| %>
+  <p>
+    <%= govuk_link_to(
+          "Download source data (CSV) #{i + 1} of #{report.report.source_csv_file_count}",
+          reporting_download_temporal_report_path(file: i + 1, **report.to_param),
+          data: { turbo: false }
+        ) %>
+  </p>
+<% end %>

--- a/app/views/reporting/temporal_reports/_return_reasons_report.en.html.erb
+++ b/app/views/reporting/temporal_reports/_return_reasons_report.en.html.erb
@@ -22,11 +22,11 @@
       table.with_body do |body|
         report.rows.each do |row|
           body.with_row do |r|
-            r.with_cell(text: row.means_type)
+            r.with_cell(text: row.means_type.humanize)
             r.with_cell(text: row.closed_by)
             r.with_cell(text: l(row.reviewed_at))
             r.with_cell(text: govuk_link_to(
-              row.return_reason.humanize(capitalize: false),
+              row.return_reason.humanize,
               history_crime_application_path(row.resource_id),
               data: { turbo: false },
               no_visited_state: true

--- a/app/views/reporting/temporal_reports/_return_reasons_report.en.html.erb
+++ b/app/views/reporting/temporal_reports/_return_reasons_report.en.html.erb
@@ -1,3 +1,11 @@
+<% if report.rows.size > 0 && !report.current? %>
+  <p>
+    <%= pluralize(report.total_count, 'applications') %>
+    were sent back to providers this
+    <%= label_text [:period, report.time_period.interval].join('.') %>
+  </p>
+<% end %>
+
 <%= render DataTableComponent.new(classes: ['app-table']) do |table| # rubocop:disable Metrics/BlockLength
       table.with_sortable_head(sorting:) do |head|
         head.with_row do |row|
@@ -5,7 +13,6 @@
           row.with_cell(colname: :closed_by)
           row.with_cell(colname: :reviewed_at, text: 'Date returned')
           row.with_cell(colname: :return_reason, text: 'Return reason')
-          row.with_cell(text: 'Return details')
           row.with_cell(colname: :reference)
           row.with_cell(colname: :office_code)
           row.with_cell(colname: :provider_name)
@@ -13,15 +20,17 @@
       end
 
       table.with_body do |body|
-        report.rows(sorting:).each do |row|
+        report.rows.each do |row|
           body.with_row do |r|
             r.with_cell(text: row.means_type)
             r.with_cell(text: row.closed_by)
             r.with_cell(text: l(row.reviewed_at))
-            r.with_cell(text: row.return_reason.humanize(capitalize: false))
-            r.with_cell(
-              text: simple_format(row.return_details, {}, wrapper_tag: 'div')
-            )
+            r.with_cell(text: govuk_link_to(
+              row.return_reason.humanize(capitalize: false),
+              history_crime_application_path(row.resource_id),
+              data: { turbo: false },
+              no_visited_state: true
+            ))
             r.with_cell(text: row.reference)
             r.with_cell(text: row.office_code)
             r.with_cell(text: row.provider_name)
@@ -29,3 +38,6 @@
         end
       end
     end %>
+
+<%= paginate report.report.pagination %>
+<%= render(partial: 'download_links', locals: { report: }) if current_user.can_download_reports? %>

--- a/app/views/reporting/temporal_reports/show.html.erb
+++ b/app/views/reporting/temporal_reports/show.html.erb
@@ -13,7 +13,7 @@
           <%= content_tag(:li, class: @interval == interval ? css_class : css_class.first) do %>
             <%= link_to(
                   label_tag(interval),
-                  reporting_current_temporal_report_path(interval: interval, report_type: @report_type),
+                  reporting_latest_complete_temporal_report_path(interval: interval, report_type: @report_type),
                   class: 'govuk-tabs__tab'
                 ) %>
           <% end %>

--- a/app/views/reporting/user_reports/index.html.erb
+++ b/app/views/reporting/user_reports/index.html.erb
@@ -15,7 +15,7 @@
       <h3 class='govuk-heading-s'>
         <%= govuk_link_to(
               label_text(report.report_type),
-              reporting_current_temporal_report_path(report.to_param),
+              reporting_temporal_report_path(report.to_param),
               { no_visited_state: true }
             )%>
       </h3>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,40 +1,6 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "27fb733251b6982f2fc628934a553ae30a06f74d205e6937d9ef90e1cf5b6fd0",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/views/reporting/temporal_reports/show.html.erb",
-      "line": 33,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(partial => params.require(:report_type).presence_in(*Types::SnapshotReportType), { :locals => ({ :report => Reporting::TemporalReport.current(:interval => permitted_params.require(:interval).presence_in(*Types::TemporalInterval), :report_type => params.require(:report_type).presence_in(*Types::SnapshotReportType), :sorting => permitted_params[:sorting], :page => permitted_params[:page]), :sorting => Reporting::TemporalReport.current(:interval => permitted_params.require(:interval).presence_in(*Types::TemporalInterval), :report_type => params.require(:report_type).presence_in(*Types::SnapshotReportType), :sorting => permitted_params[:sorting], :page => permitted_params[:page]).sorting }) })",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Reporting::TemporalReportsController",
-          "method": "now",
-          "line": 23,
-          "file": "app/controllers/reporting/temporal_reports_controller.rb",
-          "rendered": {
-            "name": "reporting/temporal_reports/show",
-            "file": "app/views/reporting/temporal_reports/show.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "reporting/temporal_reports/show"
-      },
-      "user_input": "params.require(:report_type).presence_in(*Types::SnapshotReportType)",
-      "confidence": "High",
-      "cwe_id": [
-        22
-      ],
-      "note": "Scoped by Type"
-    },
-    {
       "warning_type": "Remote Code Execution",
       "warning_code": 24,
       "fingerprint": "820d5ff4010418a7a11637323f60a964ef46ff5f5b531f18bebcf7992a12ed8b",
@@ -56,6 +22,40 @@
         470
       ],
       "note": "scoped by type"
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "bad0ca2953d36189bf2b5a7466758aae1efadf12c43b44a44d051c6b0e3f152c",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/reporting/temporal_reports/show.html.erb",
+      "line": 33,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(partial => params.require(:report_type).presence_in(*Types::SnapshotReportType), { :locals => ({ :report => Reporting::TemporalReport.from_param(:report_type => params.require(:report_type).presence_in(*Types::SnapshotReportType), :period => permitted_params[:period], :interval => permitted_params.require(:interval).presence_in(*Types::TemporalInterval), :sorting => permitted_params[:sorting], :page => permitted_params[:page]), :sorting => Reporting::TemporalReport.from_param(:report_type => params.require(:report_type).presence_in(*Types::SnapshotReportType), :period => permitted_params[:period], :interval => permitted_params.require(:interval).presence_in(*Types::TemporalInterval), :sorting => permitted_params[:sorting], :page => permitted_params[:page]).sorting }) })",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Reporting::TemporalReportsController",
+          "method": "show",
+          "line": 11,
+          "file": "app/controllers/reporting/temporal_reports_controller.rb",
+          "rendered": {
+            "name": "reporting/temporal_reports/show",
+            "file": "app/views/reporting/temporal_reports/show.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "reporting/temporal_reports/show"
+      },
+      "user_input": "params.require(:report_type).presence_in(*Types::SnapshotReportType)",
+      "confidence": "High",
+      "cwe_id": [
+        22
+      ],
+      "note": "Scoped by Types"
     },
     {
       "warning_type": "Dynamic Render Path",
@@ -126,6 +126,6 @@
       "note": "Scoped by Type"
     }
   ],
-  "updated": "2023-12-27 13:28:17 +0000",
+  "updated": "2024-01-02 13:26:44 +0000",
   "brakeman_version": "6.1.0"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,19 +3,19 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "640098948ddce901a04f77412dcd33f3a532714060a2fea65086f75263d3ce3e",
+      "fingerprint": "27fb733251b6982f2fc628934a553ae30a06f74d205e6937d9ef90e1cf5b6fd0",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/reporting/temporal_reports/show.html.erb",
       "line": 33,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(partial => params.require(:report_type).presence_in(*Types::SnapshotReportType), { :locals => ({ :report => Reporting::TemporalReport.current(:interval => permitted_params.require(:interval).presence_in(*Types::TemporalInterval), :report_type => params.require(:report_type).presence_in(*Types::SnapshotReportType)), :sorting => report_sorting }) })",
+      "code": "render(partial => params.require(:report_type).presence_in(*Types::SnapshotReportType), { :locals => ({ :report => Reporting::TemporalReport.current(:interval => permitted_params.require(:interval).presence_in(*Types::TemporalInterval), :report_type => params.require(:report_type).presence_in(*Types::SnapshotReportType), :sorting => permitted_params[:sorting], :page => permitted_params[:page]), :sorting => Reporting::TemporalReport.current(:interval => permitted_params.require(:interval).presence_in(*Types::TemporalInterval), :report_type => params.require(:report_type).presence_in(*Types::SnapshotReportType), :sorting => permitted_params[:sorting], :page => permitted_params[:page]).sorting }) })",
       "render_path": [
         {
           "type": "controller",
           "class": "Reporting::TemporalReportsController",
           "method": "now",
-          "line": 24,
+          "line": 23,
           "file": "app/controllers/reporting/temporal_reports_controller.rb",
           "rendered": {
             "name": "reporting/temporal_reports/show",
@@ -126,6 +126,6 @@
       "note": "Scoped by Type"
     }
   ],
-  "updated": "2023-12-19 13:30:46 +0000",
+  "updated": "2023-12-27 13:28:17 +0000",
   "brakeman_version": "6.1.0"
 }

--- a/config/locales/en/reporting.yml
+++ b/config/locales/en/reporting.yml
@@ -31,6 +31,10 @@ en:
     monthly: Monthly 
     weekly: Weekly 
     daily: Daily 
+    period:
+      monthly: month 
+      weekly: week 
+      daily: day 
   table_headings:
     application_type: Type
     applications_closed: Number of closed applications

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,7 +58,7 @@ Rails.application.routes.draw do
     root to: 'user_reports#index'
     get ':report_type', to: 'user_reports#show', as: 'user_report'
 
-    get ':report_type/:interval/now', to: 'temporal_reports#now', as: :current_temporal_report
+    get ':report_type/:interval/latest_complete', to: 'temporal_reports#latest_complete', as: :latest_complete_temporal_report
     get ':report_type/:interval/:period', to: 'temporal_reports#show', as: :temporal_report
     get ':report_type/:interval/:period/download', to: 'temporal_reports#download', as: :download_temporal_report
     get ':report_type/:date/at/:time', to: 'snapshots#show', as: :snapshot

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
 
     get ':report_type/:interval/now', to: 'temporal_reports#now', as: :current_temporal_report
     get ':report_type/:interval/:period', to: 'temporal_reports#show', as: :temporal_report
+    get ':report_type/:interval/:period/download', to: 'temporal_reports#download', as: :download_temporal_report
     get ':report_type/:date/at/:time', to: 'snapshots#show', as: :snapshot
     get ':report_type/now', to: 'snapshots#now', as: :current_snapshot
   end

--- a/spec/models/reporting/caseworker_report_spec.rb
+++ b/spec/models/reporting/caseworker_report_spec.rb
@@ -46,7 +46,9 @@ describe Reporting::CaseworkerReport do
     end
 
     context 'when sorting is specified' do
-      subject(:rows) { report.rows(sorting: Reporting::CaseworkerReportSorting.new(sort_by:, sort_direction:)) }
+      let(:report) do
+        described_class.new(dataset: dataset, sorting: { sort_by:, sort_direction: })
+      end
 
       let(:sort_by) { 'user_name' }
       let(:sort_direction) { 'descending' }

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe 'Authorisation' do
       reporting_user_report
       reporting_root
       reporting_temporal_report
+      reporting_latest_complete_temporal_report
       reporting_snapshot
       reporting_current_snapshot
       reporting_current_temporal_report

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -1,11 +1,17 @@
 require 'rails_helper'
+# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe 'Authorisation' do
-  include Devise::Test::IntegrationHelpers
-
-  before do
-    allow(FeatureFlags).to receive(:work_stream) {
-      instance_double(FeatureFlags::EnabledFeature, enabled?: false)
-    }
+  let(:current_user) do
+    User.create(
+      email: 'Joe.EXAMPLE@justice.gov.uk',
+      first_name: 'Joe',
+      last_name: 'EXAMPLE',
+      auth_subject_id: SecureRandom.uuid,
+      first_auth_at: 1.month.ago,
+      last_auth_at: 1.hour.ago,
+      can_manage_others: current_user_can_manage_others,
+      role: current_user_role
+    )
   end
 
   let(:service_user_routes) do
@@ -87,6 +93,22 @@ RSpec.describe 'Authorisation' do
     ]
   end
 
+  let(:data_analyst_routes) do
+    %w[reporting_download_temporal_report]
+  end
+
+  let(:current_user_can_manage_others) { false }
+
+  let(:current_user_role) { UserRole::CASEWORKER }
+
+  include Devise::Test::IntegrationHelpers
+
+  before do
+    allow(FeatureFlags).to receive(:work_stream) {
+      instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+    }
+  end
+
   def expected_status(route_name)
     case route_name
     when 'users_auth_failure', 'forbidden'
@@ -124,9 +146,9 @@ RSpec.describe 'Authorisation' do
 
   describe 'an authenticated service user (caseworker)' do
     include_context 'with stubbed search'
+
     before do
-      user = User.create(email: 'Ben.EXAMPLE@example.com')
-      sign_in user
+      sign_in current_user
     end
 
     it 'can access the service' do
@@ -135,24 +157,27 @@ RSpec.describe 'Authorisation' do
       expect(response).to have_http_status :ok
     end
 
-    it 'returns "Not found" for all user manager and supervisor routes' do
+    it 'returns "Forbidden" for all user manager and supervisor routes' do
       configured_routes.each do |route|
-        next unless (user_manager_routes & supervisor_routes).include?(route.name)
+        next unless (user_manager_routes | supervisor_routes | data_analyst_routes).include?(route.name)
+
+        sign_in current_user
 
         visit_configured_route(route)
 
-        expect(response).to have_http_status :not_found
-        expect(response.body).to include('Page not found')
+        expect(response).to have_http_status(:forbidden), response.status.to_s + route.name
+        expect(response.body).to include('Access to this service is restricted')
       end
     end
   end
 
   describe 'an authenticated user manager' do
+    let(:current_user_can_manage_others) { true }
+
     include_context 'with stubbed search'
 
     before do
-      user = User.create(email: 'Ben.EXAMPLE@example.com', can_manage_others: true)
-      sign_in user
+      sign_in current_user
     end
 
     it 'can access admin manage users' do
@@ -160,13 +185,14 @@ RSpec.describe 'Authorisation' do
       expect(response).to have_http_status :ok
     end
 
-    it 'is redirected to "admin manage users root" for all service and supervisor routes' do
+    it 'returns "Forbidden" for all service, data analysts and supervisor routes' do
       configured_routes.each do |route|
-        next unless (service_user_routes & supervisor_routes).include?(route.name)
+        sign_in current_user
+        next unless (service_user_routes | supervisor_routes | data_analyst_routes).include?(route.name)
 
         visit_configured_route(route)
 
-        expect(response).to redirect_to(manage_users_root_path)
+        expect(response).to have_http_status(:forbidden)
       end
     end
 
@@ -192,7 +218,8 @@ RSpec.describe 'Authorisation' do
 
   it 'all configured routes are tested' do
     configured_routes.each do |route|
-      tested_routes = user_manager_routes + service_user_routes + unauthenticated_routes + supervisor_routes
+      tested_routes = user_manager_routes | service_user_routes | unauthenticated_routes |
+                      supervisor_routes | data_analyst_routes
 
       expect(tested_routes.include?(route.name)).to be(true), "\"#{route.name}\" is not tested"
     end
@@ -239,3 +266,5 @@ RSpec.describe 'Authorisation' do
 time:, work_stream: }.slice(*route.required_keys.dup)
   end
 end
+
+# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/shared_examples/temporal_report_shared_example.rb
+++ b/spec/shared_examples/temporal_report_shared_example.rb
@@ -61,16 +61,4 @@ RSpec.shared_examples 'a temporal report' do
       expect(report.previous_report.current?).to be false
     end
   end
-
-  describe '#rows' do
-    it 'fetches the rows from the report_type\'s read model using the correct temporal stream name' do
-      read_model = instance_double(Reporting::CaseworkerReport, rows: :read_model_rows)
-
-      allow(Reporting::CaseworkerReport).to receive(:new).with(dataset: {}) {
-        read_model
-      }
-
-      expect(report.rows).to eq :read_model_rows
-    end
-  end
 end

--- a/spec/system/casework/closed_applications_dashboard_spec.rb
+++ b/spec/system/casework/closed_applications_dashboard_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Closed Applications Dashboard' do
+RSpec.describe 'Closed Applications' do
   include_context 'with stubbed search'
 
   let(:application_id) { '47a93336-7da6-48ac-b139-808ddd555a41' }
@@ -68,7 +68,7 @@ RSpec.describe 'Closed Applications Dashboard' do
   end
 
   it 'shows the correct information' do
-    first_row_text = page.first('.app-dashboard-table tbody tr').text
+    first_row_text = page.first('.app-table tbody tr').text
     reviewed_at = I18n.l(Time.current.in_time_zone('London'))
     expect(first_row_text).to eq("John Potter 6000002 27 Sep 2022 #{reviewed_at} Joe EXAMPLE Sent back to provider")
   end
@@ -82,7 +82,7 @@ RSpec.describe 'Closed Applications Dashboard' do
   end
 
   it 'includes the correct headings' do # rubocop:disable RSpec/ExampleLength
-    column_headings = page.all('.app-dashboard-table thead tr th.govuk-table__header').map(&:text)
+    column_headings = page.all('.app-table thead tr th.govuk-table__header').map(&:text)
 
     expected_headings = [
       "Applicant's name",

--- a/spec/system/casework/open_applications_dashboard_spec.rb
+++ b/spec/system/casework/open_applications_dashboard_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Open Applications Dashboard' do
+RSpec.describe 'Open Applications' do
   include_context 'with stubbed search'
   let(:work_stream_flag_enabled) { true }
   let(:report_turbo_link_work_stream_params) do
@@ -35,15 +35,15 @@ RSpec.describe 'Open Applications Dashboard' do
   end
 
   it 'includes the correct headings' do
-    column_headings = page.first('.app-dashboard-table thead tr').text.squish
+    column_headings = page.first('.app-table thead tr').text.squish
 
-    # rubocop:disable Layout/LineLength
-    expect(column_headings).to eq("Applicant's name Reference number Date received Business days since application was received Caseworker")
-    # rubocop:enable Layout/LineLength
+    expect(column_headings).to eq(
+      "Applicant's name Reference number Date received Business days since application was received Caseworker"
+    )
   end
 
   it 'shows the correct information' do
-    first_row_text = page.first('.app-dashboard-table tbody tr').text
+    first_row_text = page.first('.app-table tbody tr').text
 
     days_ago = Calendar.new.business_days_between(
       Date.parse('2022-10-27'), Time.current.in_time_zone('London')

--- a/spec/system/casework/searching/search_filters_and_results_spec.rb
+++ b/spec/system/casework/searching/search_filters_and_results_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Search Page' do
   end
 
   it 'includes the correct results table headings' do
-    column_headings = page.all('.app-dashboard-table thead tr th.govuk-table__header').map(&:text)
+    column_headings = page.all('.app-table thead tr th.govuk-table__header').map(&:text)
 
     expect(column_headings).to eq(
       ["Applicant's name", 'Reference number', 'Case type', 'Date received', 'Date closed', 'Closed by',
@@ -28,7 +28,7 @@ RSpec.describe 'Search Page' do
   end
 
   it 'shows the correct results' do
-    first_row_text = page.first('.app-dashboard-table tbody tr').text
+    first_row_text = page.first('.app-table tbody tr').text
 
     expect(first_row_text).to eq('Kit Pound 120398120 Summary only 27 Oct 2022 Open')
   end

--- a/spec/system/errors_spec.rb
+++ b/spec/system/errors_spec.rb
@@ -144,12 +144,11 @@ RSpec.describe 'Error pages' do
     context 'when visiting an admin page to manage a user' do
       include_context 'with an existing user'
 
-      it 'shows "Page not found" even if the user exists' do
-        expected_content = 'Page not found'
+      it 'shows forbidden even if the user exists' do
         visit "/manage_users/history/#{user.id}"
-        expect(page).to have_content expected_content
+        expect(page).to have_http_status :forbidden
         visit '/manage_users/history/n0tan1d'
-        expect(page).to have_content expected_content
+        expect(page).to have_http_status :forbidden
       end
 
       it 'uses the errors layout' do

--- a/spec/system/manage_users/viewing_spec.rb
+++ b/spec/system/manage_users/viewing_spec.rb
@@ -6,9 +6,8 @@ RSpec.describe 'Manage Users Dashboard' do
       visit manage_users_root_path
     end
 
-    it 'redirects to "Page not" found' do
-      heading_text = page.first('.govuk-heading-xl').text
-      expect(heading_text).to eq('Page not found')
+    it 'shows the forbidden page' do
+      expect(page).to have_http_status(:forbidden)
     end
   end
 

--- a/spec/system/reporting/missing_report_spec.rb
+++ b/spec/system/reporting/missing_report_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Missing Report' do
     visit '/'
     visit reporting_user_report_path(:not_a_report)
 
-    expect(page).to have_http_status(:not_found)
+    expect(page).to have_http_status(:forbidden)
   end
 
   describe 'missing temporal report interval' do

--- a/spec/system/reporting/reports_page_spec.rb
+++ b/spec/system/reporting/reports_page_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Reports' do
+  before do
+    travel_to Time.zone.local(2023, 11, 28, 12)
+  end
+
   describe 'when logged in as a user manager' do
     include_context 'when logged in user is admin'
 
@@ -10,10 +14,10 @@ RSpec.describe 'Reports' do
       expect_forbidden
     end
 
-    it 'is shown not found for report pages', :aggregate_failures do
+    it 'is shown forbidden for report pages', :aggregate_failures do
       %w[processed_report caseworker_report workload_report].each do |report|
         visit reporting_user_report_path(report)
-        expect(page).to have_http_status(:not_found)
+        expect(page).to have_http_status(:forbidden)
       end
     end
 
@@ -30,10 +34,10 @@ RSpec.describe 'Reports' do
         expect(heading_text).to eq('Reports')
       end
 
-      it 'is shown the caseworker report' do
+      it 'shows the latest complete caseworker daily report' do
         expect { click_link('Caseworker report') }.to change { current_path }
           .from('/reporting')
-          .to('/reporting/caseworker_report/daily/now')
+          .to('/reporting/caseworker_report/daily/2023-11-27')
 
         expect(page).to have_http_status :ok
       end
@@ -63,7 +67,7 @@ RSpec.describe 'Reports' do
 
     it 'cannot access the caseworker report' do
       visit reporting_user_report_path('caseworker_report')
-      expect(page).to have_http_status(:not_found)
+      expect(page).to have_http_status(:forbidden)
     end
 
     it 'can access the processed report' do
@@ -91,10 +95,10 @@ RSpec.describe 'Reports' do
       expect(heading_text).to eq('Reports')
     end
 
-    it 'is shown the caseworker report' do
+    it 'shows the latest complete caseworker daily report' do
       expect { click_link('Caseworker report') }.to change { current_path }
         .from('/reporting')
-        .to('/reporting/caseworker_report/daily/now')
+        .to('/reporting/caseworker_report/daily/2023-11-27')
 
       expect(page).to have_http_status :ok
     end
@@ -127,10 +131,10 @@ RSpec.describe 'Reports' do
       expect(heading_text).to eq('Reports')
     end
 
-    it 'is shown the caseworker report' do
+    it 'shows the latest complete caseworker monthly report' do
       expect { click_link('Caseworker report') }.to change { current_path }
         .from('/reporting')
-        .to('/reporting/caseworker_report/daily/now')
+        .to('/reporting/caseworker_report/monthly/2023-October')
 
       expect(page).to have_http_status :ok
     end
@@ -161,7 +165,7 @@ RSpec.describe 'Reports' do
 
     it 'shows page not found' do
       expect(current_user.reports.include?('not_supported_report')).to be true # confirm stub
-      expect(page).to have_text('Page not found')
+      expect(page).to have_http_status :forbidden
     end
   end
 end

--- a/spec/system/reporting/return_reasons_report_spec.rb
+++ b/spec/system/reporting/return_reasons_report_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'Return Reasons Report' do
   it 'can navigate to the monthly view' do
     expect { click_link('Monthly') }.to change { current_path }
       .from('/reporting/return_reasons_report/weekly/2023-1')
-      .to('/reporting/return_reasons_report/monthly/now')
+      .to('/reporting/return_reasons_report/monthly/2022-December')
 
     expect(page).to have_http_status :ok
   end
@@ -97,7 +97,7 @@ RSpec.describe 'Return Reasons Report' do
   it 'can navigate to the weekly view' do
     expect { click_link('Weekly') }.to change { current_path }
       .from('/reporting/return_reasons_report/weekly/2023-1')
-      .to('/reporting/return_reasons_report/weekly/now')
+      .to('/reporting/return_reasons_report/weekly/2022-52')
 
     expect(page).to have_http_status :ok
   end
@@ -126,7 +126,14 @@ RSpec.describe 'Return Reasons Report' do
 
       it 'has the correct file name' do
         expect(page.driver.response.headers['Content-Disposition']).to match(
-          'return_reasons_report_monthly_2023-January_1_of_1.csv'
+          'return_reasons_report_monthly_2022-December_1_of_1.csv'
+        )
+      end
+
+      it 'can visit the download link to get the report' do
+        visit('/reporting/return_reasons_report/monthly/2023-November/download')
+        expect(page.driver.response.headers['Content-Disposition']).to match(
+          'return_reasons_report_monthly_2023-November_1_of_1.csv'
         )
       end
     end
@@ -136,6 +143,11 @@ RSpec.describe 'Return Reasons Report' do
 
       it 'does not show the download link' do
         expect(page).not_to have_content('Download')
+      end
+
+      it 'cannot visit the download link to get the report' do
+        visit('/reporting/return_reasons_report/monthly/2023-November/download')
+        expect(page).to have_http_status :forbidden
       end
     end
   end

--- a/spec/system/reporting/return_reasons_report_spec.rb
+++ b/spec/system/reporting/return_reasons_report_spec.rb
@@ -64,10 +64,10 @@ RSpec.describe 'Return Reasons Report' do
 
   it 'includes the expected data' do # rubocop:disable RSpec/ExampleLength
     expected_data = [
-      'passported',
+      'Passported',
       'Joe Case',
       '5 Jan 2023',
-      'clarification required',
+      'Clarification required',
       '12345678',
       '1A2BC3D',
       'Andy Others'

--- a/spec/system/reporting/snapshot_reports_spec.rb
+++ b/spec/system/reporting/snapshot_reports_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Snapshot report' do
       let(:report_type) { Types::TemporalReportType['caseworker_report'] }
 
       it 'shows the page not found' do
-        expect(page).to have_http_status(:not_found)
+        expect(page).to have_http_status(:forbidden)
       end
     end
   end


### PR DESCRIPTION
## Description of change

- allow data analysts only to download the source data for the return reasons report
- make table headers sticky
- standardise authorisation failure response for authenticated users
- data analysts are shown monthly reports by default
- reporting dashboard links to the latest complete report (rather than the current report)
- paginate temporal reports
- show total number of returns in reporting period

## Link to relevant ticket
[CRIMAPP-87](https://dsdmoj.atlassian.net/browse/CRIMAPP-87)

## Notes for reviewer
See discussion in ticket
requires: https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/194
## Screenshots of changes (if applicable)

### Before changes:
<img width="788" alt="Screenshot 2023-12-28 at 11 21 54" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/2e30f9c2-9030-4aca-96ee-5d81fc34d4aa">

### After changes:
<img width="1026" alt="Screenshot 2023-12-28 at 11 18 12" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/f96f0093-9a6b-4c5a-abbb-93a6c3c90070">

<img width="1134" alt="Screenshot 2023-12-28 at 11 17 36" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/57e4de5d-bc7d-4140-a8e1-d722c5659fb4">

<img width="1288" alt="Screenshot 2023-12-28 at 11 16 00" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/655527ee-c23b-4464-aa8a-2813c8b2766e">

## How to manually test the feature
Log in as a supervisor, confirm you cannot download the return reasons report
Log in as a data analyst, confirm you can download the return reasons report


[CRIMAPP-87]: https://dsdmoj.atlassian.net/browse/CRIMAPP-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ