### PR TITLE
[CRIMAPP-286] Add dependants section to app details

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.20'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.23'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: ec72e9c9cc930a3c6eee3873fac717d855e7ab2a
-  tag: v1.0.20
+  revision: 0e3a390af6311054d94720d3300178db898b6ae4
+  tag: v1.0.23
   specs:
-    laa-criminal-legal-aid-schemas (1.0.20)
+    laa-criminal-legal-aid-schemas (1.0.23)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -114,4 +114,8 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
   def applicant
     @applicant ||= ApplicantPresenter.present(self[:client_details][:applicant])
   end
+
+  def dependants
+    @dependants ||= DependantsPresenter.present(self[:means_details].income_details&.dependants)
+  end
 end

--- a/app/presenters/dependants_presenter.rb
+++ b/app/presenters/dependants_presenter.rb
@@ -15,28 +15,33 @@ class DependantsPresenter < BasePresenter
 
   # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
   def dependants_by_age_range
-    sorted_dependants = Hash.new(0)
+    grouped_dependants = Hash.new(0)
 
-    @dependants.each do |dependant|
+    sorted_dependants.each do |dependant|
       case dependant[:age]
       when 0, 1
-        sorted_dependants['0 to 1'] += 1
+        grouped_dependants['0 to 1'] += 1
       when 2, 3, 4
-        sorted_dependants['2 to 4'] += 1
+        grouped_dependants['2 to 4'] += 1
       when 5, 6, 7
-        sorted_dependants['5 to 7'] += 1
+        grouped_dependants['5 to 7'] += 1
       when 8, 9, 10
-        sorted_dependants['8 to 10'] += 1
+        grouped_dependants['8 to 10'] += 1
       when 11, 12
-        sorted_dependants['11 to 12'] += 1
+        grouped_dependants['11 to 12'] += 1
       when 13, 14, 15
-        sorted_dependants['13 to 15'] += 1
+        grouped_dependants['13 to 15'] += 1
       else
-        sorted_dependants['16 to 18'] += 1
+        grouped_dependants['16 to 18'] += 1
       end
     end
 
-    sorted_dependants
+    grouped_dependants
   end
   # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
+
+  def sorted_dependants
+    # Sorts ages so the ranking is ordered
+    @dependants.sort_by { |d| d[:age] }
+  end
 end

--- a/app/presenters/dependants_presenter.rb
+++ b/app/presenters/dependants_presenter.rb
@@ -1,0 +1,42 @@
+class DependantsPresenter < BasePresenter
+  def initialize(dependants)
+    super(
+      @dependants = dependants
+    )
+  end
+
+  def formatted_dependants
+    return unless @dependants
+
+    dependants_by_age_range
+  end
+
+  private
+
+  # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+  def dependants_by_age_range
+    sorted_dependants = Hash.new(0)
+
+    @dependants.each do |dependant|
+      case dependant[:age]
+      when 0, 1
+        sorted_dependants['0 to 1'] += 1
+      when 2, 3, 4
+        sorted_dependants['2 to 4'] += 1
+      when 5, 6, 7
+        sorted_dependants['5 to 7'] += 1
+      when 8, 9, 10
+        sorted_dependants['8 to 10'] += 1
+      when 11, 12
+        sorted_dependants['11 to 12'] += 1
+      when 13, 14, 15
+        sorted_dependants['13 to 15'] += 1
+      else
+        sorted_dependants['16 to 18'] += 1
+      end
+    end
+
+    sorted_dependants
+  end
+  # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
+end

--- a/app/views/casework/crime_applications/_dependants.html.erb
+++ b/app/views/casework/crime_applications/_dependants.html.erb
@@ -1,0 +1,30 @@
+<% if dependants %>
+  <h2 class="govuk-heading-m">
+    <%= label_text(:dependants) %>
+  </h2>
+  <% if dependants.any? %>
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <% dependants.each do |age_range, count| %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            <%= label_text(:number_of_dependants, age_range:) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= count %>
+          </dd>
+        </div>
+      <%end%>
+    </dl>
+  <% else %>
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:has_dependants) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(false, scope: 'values') %>
+        </dd>
+      </div>
+    </dl>
+  <% end %>
+<% end %>

--- a/app/views/casework/crime_applications/_income.html.erb
+++ b/app/views/casework/crime_applications/_income.html.erb
@@ -9,32 +9,38 @@
         <%= label_text(:income_more_than) %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= t((income_details.income_above_threshold || :no), scope: 'values') %>
+        <%= t(income_details.income_above_threshold, scope: 'values') %>
       </dd>
     </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= label_text(:has_frozen_income_or_assets) %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= t((income_details.has_frozen_income_or_assets || :no), scope: 'values') %>
-      </dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= label_text(:client_owns_property) %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= t((income_details.client_owns_property || :no), scope: 'values') %>
-      </dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= label_text(:has_savings) %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= t((income_details.has_savings || :no), scope: 'values') %>
-      </dd>
-    </div>
+    <% unless income_details.has_frozen_income_or_assets.nil? %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:has_frozen_income_or_assets) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(income_details.has_frozen_income_or_assets, scope: 'values') %>
+        </dd>
+      </div>
+    <% end %>
+    <% unless income_details.client_owns_property.nil? %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:client_owns_property) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(income_details.client_owns_property, scope: 'values') %>
+        </dd>
+      </div>
+    <% end %>
+    <% unless income_details.has_savings.nil? %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:has_savings) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(income_details.has_savings, scope: 'values') %>
+        </dd>
+      </div>
+    <% end %>
   </dl>
 <% end %>

--- a/app/views/casework/crime_applications/_income.html.erb
+++ b/app/views/casework/crime_applications/_income.html.erb
@@ -9,7 +9,7 @@
         <%= label_text(:income_more_than) %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= t(income_details.income_above_threshold, scope: 'values') %>
+        <%= t((income_details.income_above_threshold || :no), scope: 'values') %>
       </dd>
     </div>
     <div class="govuk-summary-list__row">
@@ -17,7 +17,7 @@
         <%= label_text(:has_frozen_income_or_assets) %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= t(income_details.has_frozen_income_or_assets, scope: 'values') %>
+        <%= t((income_details.has_frozen_income_or_assets || :no), scope: 'values') %>
       </dd>
     </div>
     <div class="govuk-summary-list__row">
@@ -25,7 +25,7 @@
         <%= label_text(:client_owns_property) %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= t(income_details.client_owns_property, scope: 'values') %>
+        <%= t((income_details.client_owns_property || :no), scope: 'values') %>
       </dd>
     </div>
     <div class="govuk-summary-list__row">
@@ -33,7 +33,7 @@
         <%= label_text(:has_savings) %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= t(income_details.has_savings, scope: 'values') %>
+        <%= t((income_details.has_savings || :no), scope: 'values') %>
       </dd>
     </div>
   </dl>

--- a/app/views/casework/crime_applications/_other_income_details.html.erb
+++ b/app/views/casework/crime_applications/_other_income_details.html.erb
@@ -12,18 +12,16 @@
         <%= t(income_details.manage_without_income, scope: 'values.manage_without_income') %>
       </dd>
     </div>
-    <div class="govuk-summary-list__row">
+    <%# TODO: confirm design for other option %>
+    <% if income_details.manage_without_income == 'other' %>
+      <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        <% if income_details.manage_without_income == 'other' %>
-          <%= t('labels.details') %>
-        <% end %>
+        <%= t('labels.details') %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%# TODO: confirm design for other option %>
-        <% if income_details.manage_without_income == 'other' %>
-          <%= income_details.manage_other_details %>
-        <% end %>
+        <%= income_details.manage_other_details %>
       </dd>
     </div>
+    <% end %>
   </dl>
 <% end %>

--- a/app/views/casework/crime_applications/show.html.erb
+++ b/app/views/casework/crime_applications/show.html.erb
@@ -18,6 +18,7 @@
     <%= render partial: 'supporting_evidence', locals: { crime_application: @crime_application } %>
     <% if FeatureFlags.means_journey.enabled? %>
       <%= render partial: 'income', locals: { income_details: @crime_application.means_details.income_details } %>
+      <%= render partial: 'dependants', locals: { dependants: @crime_application.dependants.formatted_dependants } %>
       <%= render partial: 'other_income_details', locals: { income_details: @crime_application.means_details.income_details } %>
   <% end %>
     <%= render partial: 'provider_details', object: @crime_application.provider_details %>

--- a/app/views/casework/crime_applications/show.html.erb
+++ b/app/views/casework/crime_applications/show.html.erb
@@ -20,7 +20,7 @@
       <%= render partial: 'income', locals: { income_details: @crime_application.means_details.income_details } %>
       <%= render partial: 'dependants', locals: { dependants: @crime_application.dependants.formatted_dependants } %>
       <%= render partial: 'other_income_details', locals: { income_details: @crime_application.means_details.income_details } %>
-  <% end %>
+    <% end %>
     <%= render partial: 'provider_details', object: @crime_application.provider_details %>
   </div>
 </div>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -77,6 +77,7 @@ en:
     correspondence_address: Correspondence address
     criminal_applications_team: CAT 1
     criminal_applications_team_2: CAT 2
+    dependants: Dependants who live with the client
     date:
       sent_back: 'Date closed:'
       completed: 'Date closed:'
@@ -90,6 +91,7 @@ en:
     financial_change_details: Changes in the client’s financial circumstances
     first_name: First name
     first_court_hearing: First court hearing the case
+    has_dependants: Has dependants?
     has_frozen_income_or_assets: Has income, savings or assets under a restraint or freezing order?
     has_savings: Has savings or investments?
     hearing_date: Date of next hearing
@@ -107,6 +109,7 @@ en:
     national_crime_team: CAT 2
     national_insurance_number: National Insurance number
     next_court_hearing: Next court hearing the case
+    number_of_dependants: Number of dependants aged %{age_range} on next birthday
     offence: Offence
     offence_date: Offence date
     offence_details: Offence details

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,3 +15,7 @@ feature_flags:
     local: true
     staging: true
     production: false
+  means_journey:
+    local: true
+    staging: true
+    production: false

--- a/spec/presenters/dependants_presenter_spec.rb
+++ b/spec/presenters/dependants_presenter_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe DependantsPresenter do
                                            '8 to 10' => 1,
                                            '11 to 12' => 1,
                                            '13 to 15' => 1,
-                                           '16 to 18' => 1
-                                           })
+                                           '16 to 18' => 1 })
     }
 
     context 'with no dependants' do

--- a/spec/presenters/dependants_presenter_spec.rb
+++ b/spec/presenters/dependants_presenter_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe DependantsPresenter do
+  subject(:dependants_presenter) { described_class.new(dependants) }
+
+  let(:dependants) do
+    [{ age: 1 }, { age: 5 }, { age: 12 }, { age: 15 }, { age: 4 }, { age: 7 }, { age: 8 }, { age: 18 }]
+  end
+
+  describe '#formatted_dependants' do
+    subject(:formatted_dependants) { dependants_presenter.formatted_dependants }
+
+    it {
+      expect(formatted_dependants).to eq({ '0 to 1' => 1,
+                                           '11 to 12' => 1,
+                                           '13 to 15' => 1,
+                                           '16 to 18' => 1,
+                                           '2 to 4' => 1,
+                                           '5 to 7' => 2,
+                                           '8 to 10' => 1 })
+    }
+
+    context 'with no dependants' do
+      let(:dependants) { nil }
+
+      it { expect(formatted_dependants).to be_nil }
+    end
+  end
+end

--- a/spec/presenters/dependants_presenter_spec.rb
+++ b/spec/presenters/dependants_presenter_spec.rb
@@ -12,12 +12,13 @@ RSpec.describe DependantsPresenter do
 
     it {
       expect(formatted_dependants).to eq({ '0 to 1' => 1,
-                                           '11 to 12' => 1,
-                                           '13 to 15' => 1,
-                                           '16 to 18' => 1,
                                            '2 to 4' => 1,
                                            '5 to 7' => 2,
-                                           '8 to 10' => 1 })
+                                           '8 to 10' => 1,
+                                           '11 to 12' => 1,
+                                           '13 to 15' => 1,
+                                           '16 to 18' => 1
+                                           })
     }
 
     context 'with no dependants' do

--- a/spec/system/casework/viewing_an_application/application_details/dependants_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/dependants_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing the dependants details of an application' do
+  include_context 'with stubbed application'
+
+  before do
+    visit crime_application_path(application_id)
+  end
+
+  context 'with dependants' do
+    let(:application_data) do
+      super().deep_merge('means_details' => { 'income_details' => { 'dependants' => [{ age: 1 }, { age: 5 }] } })
+    end
+
+    it 'shows dependants heading' do
+      expect(page).to have_content('Dependants who live with the client')
+    end
+
+    it 'shows dependants grouped by age range' do
+      expect(page).to have_content('Number of dependants aged 0 to 1 on next birthday 1')
+      expect(page).to have_content('Number of dependants aged 5 to 7 on next birthday 1')
+    end
+  end
+
+  context 'with no dependants' do
+    let(:application_data) do
+      super().deep_merge('means_details' => { 'income_details' => { 'dependants' => [] } })
+    end
+
+    it 'shows dependants heading' do
+      expect(page).to have_content('Dependants who live with the client')
+    end
+
+    it 'shows no dependants' do
+      expect(page).to have_content('Has dependants? No')
+    end
+  end
+
+  context 'with not shown dependants screen' do
+    let(:application_data) do
+      super().deep_merge('means_details' => { 'income_details' => { 'dependants' => nil } })
+    end
+
+    it 'does not show dependants section' do
+      expect(page).not_to have_content('Dependants who live with the client')
+    end
+  end
+end

--- a/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
@@ -34,4 +34,24 @@ RSpec.describe 'Viewing the income details of an application' do
       expect(page).not_to have_content('Income')
     end
   end
+
+  context 'with nil income details' do
+    let(:application_data) do
+      super().deep_merge('means_details' => { 'income_details' => { 'has_frozen_income_or_assets' => nil,
+                                                                    'client_owns_property' => nil,
+                                                                    'has_savings' => nil, } })
+    end
+
+    it 'shows has income savings assets' do
+      expect(page).to have_content('Has income, savings or assets under a restraint or freezing order? No')
+    end
+
+    it 'shows land or property' do
+      expect(page).to have_content('Has land or property? No')
+    end
+
+    it 'shows savings or investments' do
+      expect(page).to have_content('Has savings or investments? No')
+    end
+  end
 end

--- a/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
@@ -37,21 +37,26 @@ RSpec.describe 'Viewing the income details of an application' do
 
   context 'with nil income details' do
     let(:application_data) do
-      super().deep_merge('means_details' => { 'income_details' => { 'has_frozen_income_or_assets' => nil,
+      super().deep_merge('means_details' => { 'income_details' => { 'income_above_threshold' => 'yes',
+                                                                    'has_frozen_income_or_assets' => nil,
                                                                     'client_owns_property' => nil,
                                                                     'has_savings' => nil, } })
     end
 
+    it 'shows income above threshold' do
+      expect(page).to have_content('Income more than £12,475? Yes')
+    end
+
     it 'shows has income savings assets' do
-      expect(page).to have_content('Has income, savings or assets under a restraint or freezing order? No')
+      expect(page).not_to have_content('Has income, savings or assets under a restraint or freezing order?')
     end
 
     it 'shows land or property' do
-      expect(page).to have_content('Has land or property? No')
+      expect(page).not_to have_content('Has land or property?')
     end
 
     it 'shows savings or investments' do
-      expect(page).to have_content('Has savings or investments? No')
+      expect(page).not_to have_content('Has savings or investments?')
     end
   end
 end


### PR DESCRIPTION
## Description of change
Adds dependants section to application details 

Also fixes issue with income details section where rows where being displayed for questions that were not shown during the application

## Link to relevant ticket

## Notes for reviewer
Note needs to be merged after accompanying [apply PR ](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/589)to amend the serialisation and rehydration due to schema changes

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
Displays dependants section if dependants submitted as part of application 

<img width="1234" alt="Screenshot 2023-12-27 at 12 57 07" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/844c4e39-b420-431d-9618-70828d0ad5d6">

Displays no dependants if no dependants selected 

<img width="1234" alt="Screenshot 2023-12-27 at 12 56 56" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/e411ecef-702d-4232-aa12-3fed0d808d10">

Displays nothing if dependants screen was not seen during application

<img width="1234" alt="Screenshot 2023-12-27 at 12 57 18" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/662b7f93-3eb3-4d31-a989-7f0e94aee130">

## How to manually test the feature
Requires an application with dependants, an application where no dependants has been selected and an application which hasn't gone through the dependants screen on apply 

Navigate to review and check each of the following 
1. Application with dependants: displays dependants in the correct age ranges
2. Application with no dependants: displays a summary table with no dependants 
3. Application where screen was not shown: does not display the dependants section 
