### PR TITLE
[CRIMAPP-287] Add other income details section

### DIFF
--- a/app/views/casework/crime_applications/_other_income_details.html.erb
+++ b/app/views/casework/crime_applications/_other_income_details.html.erb
@@ -1,0 +1,20 @@
+<% if income_details&.manage_without_income.present? %>
+  <h2 class="govuk-heading-m">
+    <%= label_text(:other_income_details) %>
+  </h2>
+
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:manage_without_income) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <% if income_details.manage_without_income == 'other' %>
+          <%= income_details.manage_other_details %>
+      <% else %>
+          <%= t(income_details.manage_without_income, scope: 'values.manage_without_income') %>
+      <% end %>
+      </dd>
+    </div>
+  </dl>
+<% end %>

--- a/app/views/casework/crime_applications/_other_income_details.html.erb
+++ b/app/views/casework/crime_applications/_other_income_details.html.erb
@@ -9,11 +9,20 @@
         <%= label_text(:manage_without_income) %>
       </dt>
       <dd class="govuk-summary-list__value">
+        <%= t(income_details.manage_without_income, scope: 'values.manage_without_income') %>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <% if income_details.manage_without_income == 'other' %>
+          <%= t('labels.details') %>
+        <% end %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%# TODO: confirm design for other option %>
         <% if income_details.manage_without_income == 'other' %>
           <%= income_details.manage_other_details %>
-      <% else %>
-          <%= t(income_details.manage_without_income, scope: 'values.manage_without_income') %>
-      <% end %>
+        <% end %>
       </dd>
     </div>
   </dl>

--- a/app/views/casework/crime_applications/show.html.erb
+++ b/app/views/casework/crime_applications/show.html.erb
@@ -20,6 +20,7 @@
     <% end %>
     <% if FeatureFlags.means_journey.enabled? %>
       <%= render partial: 'income', locals: { income_details: @crime_application.means_details.income_details } %>
+      <%= render partial: 'other_income_details', locals: { income_details: @crime_application.means_details.income_details } %>
   <% end %>
     <%= render partial: 'provider_details', object: @crime_application.provider_details %>
   </div>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -100,6 +100,7 @@ en:
     justification: Justification
     last_name: Last name
     legal_representative: Legal representative
+    manage_without_income: How do they manage with no income?
     means_type: Means type
     name: Name
     national_crime_team: CAT 2
@@ -109,6 +110,7 @@ en:
     offence_date: Offence date
     offence_details: Offence details
     office_account_number: Office account number
+    other_income_details: Other sources of income
     other_names: Other names
     overall_offence_class: Overall offence class
     overview: Overview
@@ -228,6 +230,12 @@ en:
       marked_as_ready: blue
     download_file: "Download file <br> (%{file_extension}, %{file_size})"
     no_hearing_yet: There has not been a hearing yet
+    manage_without_income:
+      friends_sofa: They sleep on a friend's sofa for free
+      family: They stay with family for free
+      living_on_streets: They are living on the streets or homeless
+      custody: They have been in custody for more than 3 months
+      other: Other
 
   calls_to_action:
     abandon_reassign_to_self: No, do not reassign

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -83,6 +83,7 @@ en:
     date_appeal_lodged: Date the appeal was lodged
     date_of_birth: Date of birth
     date_received: 'Date received:'
+    details: Details
     end_on: Date to
     extradition: Extradition
     file_name: File name

--- a/spec/system/casework/viewing_an_application/application_details/other_income_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/other_income_details_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing the other income details of an application' do
+  include_context 'with stubbed application'
+
+  before do
+    visit crime_application_path(application_id)
+  end
+
+  context 'with other income details' do
+    context 'when Other free text option is selected' do
+      it 'shows manage without income details' do
+        expect(page).to have_content('Other sources of income')
+        expect(page).to have_content('How do they manage with no income? Another way they manage')
+      end
+    end
+
+    context 'when radio option selected' do
+      let(:application_data) do
+        super().deep_merge('means_details' => { 'income_details' => { 'manage_without_income' => 'family',
+                                                                      'manage_other_details' => 'other' } })
+      end
+
+      it 'shows manage without income details' do
+        expect(page).to have_content('How do they manage with no income? They stay with family for free')
+      end
+    end
+  end
+
+  context 'with no income details' do
+    let(:application_data) do
+      super().deep_merge('means_details' => nil)
+    end
+
+    it 'does not show income section' do
+      expect(page).not_to have_content('Other sources of income')
+    end
+  end
+end

--- a/spec/system/casework/viewing_an_application/application_details/other_income_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/other_income_details_spec.rb
@@ -9,9 +9,11 @@ RSpec.describe 'Viewing the other income details of an application' do
 
   context 'with other income details' do
     context 'when Other free text option is selected' do
+      it { expect(page).to have_content('Other sources of income') }
+
       it 'shows manage without income details' do
-        expect(page).to have_content('Other sources of income')
-        expect(page).to have_content('How do they manage with no income? Another way they manage')
+        expect(page).to have_content('How do they manage with no income? Other')
+        expect(page).to have_content('Details Another way they manage')
       end
     end
 


### PR DESCRIPTION
## Description of change
Adds other income details section to application details

## Link to relevant ticket
[CRIMAPP-287](https://dsdmoj.atlassian.net/browse/CRIMAPP-287)

## Notes for reviewer
There was no design specified in the case that Other was selected but I have replicated what is displayed in apply for a completed application

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

<img width="1234" alt="Screenshot 2023-12-29 at 12 07 14" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/9162c7e6-26ab-4d30-9624-9c14675f5700">
<img width="1036" alt="Screenshot 2023-12-29 at 12 38 23" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/7d34e817-cb7a-469d-8bd6-991f09d076e9">

## How to manually test the feature

Submit an application on apply with the other income details question answered 
Then check it is displayed in review 
Will need to check the view when the other option is selected
Also check applications that have not answered that question do not display the other income details section


[CRIMAPP-287]: https://dsdmoj.atlassian.net/browse/CRIMAPP-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ