### PR TITLE
CRIMAPP-323 Do not show MAAT id when appeal with cifc

### DIFF
--- a/app/views/casework/crime_applications/_case_details.html.erb
+++ b/app/views/casework/crime_applications/_case_details.html.erb
@@ -29,16 +29,17 @@
           <%= case_details.appeal_with_changes_details %>
         </dd>
       </div>
+    <% else %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:previous_maat_id) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= case_details.appeal_maat_id.presence || t(:not_provided, scope: 'values') %>
+        </dd>
+      </div>
     <% end %>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= label_text(:previous_maat_id) %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= case_details.appeal_maat_id.presence || t(:not_provided, scope: 'values') %>
-      </dd>
-    </div>
-  <% end%>
+  <% end %>
 
   <!-- Court hearing -->
   <div class="govuk-summary-list__row">

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -151,32 +151,16 @@ RSpec.describe 'Viewing an application unassigned, open application' do
                                                'appeal_with_changes_details' => 'Some details' })
       end
 
-      context 'when previous MAAT ID is not provided' do
-        it 'shows appeal lodged date' do
-          expect(page).to have_content('Date the appeal was lodged 25/10/2021')
-        end
-
-        it 'shows changes to details' do
-          expect(page).to have_content('Changes in the client’s financial circumstances Some details')
-        end
-
-        it 'shows that previous maat id was not provided' do
-          expect(page).to have_content('Previous MAAT ID Not provided')
-        end
+      it 'shows appeal lodged date' do
+        expect(page).to have_content('Date the appeal was lodged 25/10/2021')
       end
 
-      context 'when previous MAAT ID is provided' do
-        let(:application_data) do
-          super().deep_merge('case_details' => { 'appeal_maat_id' => '123456' })
-        end
+      it 'shows changes to details' do
+        expect(page).to have_content('Changes in the client’s financial circumstances Some details')
+      end
 
-        it 'shows changes to details' do
-          expect(page).to have_content('Changes in the client’s financial circumstances Some details')
-        end
-
-        it 'shows previous maat id' do
-          expect(page).to have_content('Previous MAAT ID 123456')
-        end
+      it 'does not show previous maat id section' do
+        expect(page).not_to have_content('Previous MAAT ID')
       end
     end
   end


### PR DESCRIPTION
## Description of change
Do not show MAAT id if appeal with change in financial circumstances.

## Link to relevant ticket
[CRIMAPP-323](https://dsdmoj.atlassian.net/browse/CRIMAPP-323)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-323]: https://dsdmoj.atlassian.net/browse/CRIMAPP-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ