### PR TITLE
Revert importmap upgrade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    importmap-rails (2.0.1)
+    importmap-rails (1.2.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)


### PR DESCRIPTION
## Description of change
Revert importmap upgrade

## Link to relevant ticket

## Notes for reviewer
This was causing assets not to build correctly on live services. Temporary reversion to prevent this issue on live services.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
