### PR TITLE
[CRIMAPP-350] Display PSE relevant details for PSE application

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.25'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.29'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 912ba25ec6153f0725813cb9381f0dee4ce4c7f1
-  tag: v1.0.25
+  revision: 5b0ecdbbb62ab4ab1cff103574c143c7f087a509
+  tag: v1.0.29
   specs:
-    laa-criminal-legal-aid-schemas (1.0.25)
+    laa-criminal-legal-aid-schemas (1.0.29)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/models/application_search_result.rb
+++ b/app/models/application_search_result.rb
@@ -6,7 +6,7 @@ class ApplicationSearchResult < ApplicationStruct
   attribute :status, Types::String
   attribute :work_stream, Types::WorkStreamType
   attribute? :application_type, Types::ApplicationType
-  attribute? :case_type, Types::CaseType
+  attribute? :case_type, Types::CaseType.optional
   attribute? :parent_id, Types::Uuid.optional
 
   include Assignable

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -108,6 +108,8 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
   end
 
   def case_details
+    return if pse?
+
     @case_details ||= CaseDetailsPresenter.present(self[:case_details])
   end
 
@@ -117,5 +119,9 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
 
   def dependants
     @dependants ||= DependantsPresenter.present(self[:means_details].income_details&.dependants)
+  end
+
+  def pse?
+    application_type == Types::ApplicationType['post_submission_evidence']
   end
 end

--- a/app/views/casework/crime_applications/_client_details.html.erb
+++ b/app/views/casework/crime_applications/_client_details.html.erb
@@ -35,53 +35,55 @@
       <%= l applicant.date_of_birth, format: :compact %>
     </dd>
   </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      <%= label_text(:national_insurance_number) %>
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <%= nino.presence || t(:not_provided, scope: 'values') %>
-    </dd>
-  </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      <%= label_text(:telephone_number) %>
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <%= applicant_tel.presence || t(:not_provided, scope: 'values') %>
-    </dd>
-  </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      <%= label_text(:home_address) %>
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <% if applicant.home_address %>
-        <%= render 'address', address: applicant.home_address %>
-      <% else %>
-        <%= t(:no_home_address, scope: 'values') %>
-      <% end %>
-    </dd>
-  </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      <%= label_text(:correspondence_address) %>
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <% if applicant.correspondence_address_type == 'other_address' %>
-        <%= render 'address', address: applicant.correspondence_address %>
-      <% else %>
-        <%= t(applicant.correspondence_address_type, scope: 'values') %>
-      <% end %>
-    </dd>
-  </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      <%= label_text(:partner) %>
-    </dt>
-    <dd class="govuk-summary-list__value">
-    <%# TODO Update this when has_partner provided by datastore %>
-      <%= t(false, scope: 'values') %>
-    </dd>
-  </div>
+  <% unless crime_application.pse? %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:national_insurance_number) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= nino.presence || t(:not_provided, scope: 'values') %>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:telephone_number) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= applicant_tel.presence || t(:not_provided, scope: 'values') %>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:home_address) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <% if applicant.home_address %>
+          <%= render 'address', address: applicant.home_address %>
+        <% else %>
+          <%= t(:no_home_address, scope: 'values') %>
+        <% end %>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:correspondence_address) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <% if applicant.correspondence_address_type == 'other_address' %>
+          <%= render 'address', address: applicant.correspondence_address %>
+        <% else %>
+          <%= t(applicant.correspondence_address_type, scope: 'values') %>
+        <% end %>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:partner) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+      <%# TODO Update this when has_partner provided by datastore %>
+        <%= t(false, scope: 'values') %>
+      </dd>
+    </div>
+  <% end %>
 </dl>

--- a/app/views/casework/crime_applications/_initial.html.erb
+++ b/app/views/casework/crime_applications/_initial.html.erb
@@ -1,0 +1,18 @@
+<%= render partial: 'client_details',
+           locals: {
+             crime_application: crime_application,
+             applicant: crime_application.client_details.applicant,
+             nino: crime_application.applicant.formatted_applicant_nino,
+             applicant_tel: crime_application.applicant.phone_number
+           } %>
+<%= render partial: 'case_details', object: crime_application.case_details %>
+<%= render partial: 'offences', object: crime_application.case_details.offences %>
+<%= render partial: 'codefendants', object: crime_application.case_details.codefendants %>
+<%= render partial: 'interests_of_justice', locals: { crime_application: } %>
+<%= render partial: 'supporting_evidence', locals: { crime_application: } %>
+<% if FeatureFlags.means_journey.enabled? %>
+  <%= render partial: 'income', locals: { income_details: crime_application.means_details.income_details } %>
+  <%= render partial: 'dependants', locals: { dependants: crime_application.dependants.formatted_dependants } %>
+  <%= render partial: 'other_income_details', locals: { income_details: crime_application.means_details.income_details } %>
+<% end %>
+<%= render partial: 'provider_details', object: crime_application.provider_details %>

--- a/app/views/casework/crime_applications/_overview.html.erb
+++ b/app/views/casework/crime_applications/_overview.html.erb
@@ -12,63 +12,65 @@
     </dd>
   </div>
 
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      <%= label_text(:means_type) %>
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <% if overview.means_passported? %>
-        <%= govuk_tag(text: t(:passported, scope: 'values'), colour: 'blue') %>
-      <% else %>
-        <%= govuk_tag(text: label_text('undetermined'), colour: 'red') %>
-      <% end %>
-    </dd>
-  </div>
-
-  <% unless overview.means_passported_on_age? %>
+  <% unless overview.pse? %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        <%= label_text(:passporting_benefit) %>
+        <%= label_text(:means_type) %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= t(overview.client_details.applicant.benefit_type.presence, scope: 'values') || t(:not_asked, scope: 'values') %>
+        <% if overview.means_passported? %>
+          <%= govuk_tag(text: t(:passported, scope: 'values'), colour: 'blue') %>
+        <% else %>
+          <%= govuk_tag(text: label_text('undetermined'), colour: 'red') %>
+        <% end %>
+      </dd>
+    </div>
+
+    <% unless overview.means_passported_on_age? %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:passporting_benefit) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(overview.client_details.applicant.benefit_type.presence, scope: 'values') || t(:not_asked, scope: 'values') %>
+        </dd>
+      </div>
+    <% end %>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:urn) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+      <span id="urn">
+        <%= overview.case_details.urn.presence || t(:not_provided, scope: 'values') %>
+      </span>
+        <% if overview.case_details.urn.presence && !overview.superseded? %>
+          <%=link_to t('calls_to_action.copy_urn'), '', id: 'copy-urn-reference-number', class: 'govuk-link--no-visited-state' %>
+        <% end %>
+      </dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:application_start_date) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= l(overview.date_stamp, format: :compact) %>
+      </dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:overall_offence_class) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <% if overview.case_details.offence_class %>
+          <%= govuk_tag(text: "#{t('values.class')} #{overview.case_details.offence_class}", colour: 'blue') %>
+        <% else %>
+          <%= govuk_tag(text: label_text('undetermined'), colour: 'red') %>
+        <% end %>
       </dd>
     </div>
   <% end %>
-
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      <%= label_text(:urn) %>
-    </dt>
-    <dd class="govuk-summary-list__value">
-    <span id="urn">
-      <%= overview.case_details.urn.presence || t(:not_provided, scope: 'values') %>
-    </span>
-      <% if overview.case_details.urn.presence && !overview.superseded? %>
-        <%=link_to t('calls_to_action.copy_urn'), '', id: 'copy-urn-reference-number', class: 'govuk-link--no-visited-state' %>
-      <% end %>
-    </dd>
-  </div>
-
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      <%= label_text(:application_start_date) %>
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <%= l(overview.date_stamp, format: :compact) %>
-    </dd>
-  </div>
-
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      <%= label_text(:overall_offence_class) %>
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <% if overview.case_details.offence_class %>
-        <%= govuk_tag(text: "#{t('values.class')} #{overview.case_details.offence_class}", colour: 'blue') %>
-      <% else %>
-        <%= govuk_tag(text: label_text('undetermined'), colour: 'red') %>
-      <% end %>
-    </dd>
-  </div>
 </dl>

--- a/app/views/casework/crime_applications/_pse.html.erb
+++ b/app/views/casework/crime_applications/_pse.html.erb
@@ -1,0 +1,9 @@
+<%= render partial: 'client_details',
+           locals: {
+             crime_application: crime_application,
+             applicant: crime_application.client_details.applicant,
+             nino: crime_application.applicant.formatted_applicant_nino,
+             applicant_tel: crime_application.applicant.phone_number
+           } %>
+<%= render partial: 'supporting_evidence', locals: { crime_application: } %>
+<%= render partial: 'provider_details', object: crime_application.provider_details %>

--- a/app/views/casework/crime_applications/_supporting_evidence.html.erb
+++ b/app/views/casework/crime_applications/_supporting_evidence.html.erb
@@ -1,6 +1,10 @@
 <% if crime_application.supporting_evidence.present? %>
   <h2 class="govuk-heading-m">
-    <%= label_text(:supporting_evidence) %>
+    <% if crime_application.pse? %>
+      <%= label_text(:post_submission_evidence) %>
+    <% else %>
+      <%= label_text(:supporting_evidence) %>
+    <% end %>
   </h2>
 
   <table class="govuk-table app-dashboard-table govuk-!-margin-bottom-9">

--- a/app/views/casework/crime_applications/show.html.erb
+++ b/app/views/casework/crime_applications/show.html.erb
@@ -5,23 +5,11 @@
   <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-9">
     <%= render partial: 'subnavigation', locals: { crime_application: @crime_application } %>
     <%= render partial: 'overview', object: @crime_application %>
-    <%= render partial: 'client_details',
-               locals: {
-                 applicant: @crime_application.client_details.applicant,
-                 nino: @crime_application.applicant.formatted_applicant_nino,
-                 applicant_tel: @crime_application.applicant.phone_number
-               } %>
-    <%= render partial: 'case_details', object: @crime_application.case_details %>
-    <%= render partial: 'offences', object: @crime_application.case_details.offences %>
-    <%= render partial: 'codefendants', object: @crime_application.case_details.codefendants %>
-    <%= render partial: 'interests_of_justice', locals: { crime_application: @crime_application } %>
-    <%= render partial: 'supporting_evidence', locals: { crime_application: @crime_application } %>
-    <% if FeatureFlags.means_journey.enabled? %>
-      <%= render partial: 'income', locals: { income_details: @crime_application.means_details.income_details } %>
-      <%= render partial: 'dependants', locals: { dependants: @crime_application.dependants.formatted_dependants } %>
-      <%= render partial: 'other_income_details', locals: { income_details: @crime_application.means_details.income_details } %>
+    <% if @crime_application.pse? %>
+      <%= render partial: 'pse', locals: { crime_application: @crime_application } %>
+    <% else %>
+      <%= render partial: 'initial', locals: { crime_application: @crime_application } %>
     <% end %>
-    <%= render partial: 'provider_details', object: @crime_application.provider_details %>
   </div>
 </div>
 

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -118,6 +118,7 @@ en:
     overall_offence_class: Overall offence class
     overview: Overview
     partner: Partner
+    post_submission_evidence: Post submission evidence
     previous_maat_id: Previous MAAT ID
     provider_details: Provider details
     provider_email: Email address

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,6 +11,10 @@ feature_flags:
     local: true
     staging: true
     production: false
+  post_submission_evidence:
+    local: true
+    staging: true
+    production: false
 
 # For settings that vary by HostEnv name
 host_env_settings:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,10 +11,6 @@ feature_flags:
     local: true
     staging: true
     production: false
-  post_submission_evidence:
-    local: true
-    staging: true
-    production: false
 
 # For settings that vary by HostEnv name
 host_env_settings:

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -240,4 +240,22 @@ RSpec.describe CrimeApplication do
       it { is_expected.to be true }
     end
   end
+
+  describe '#pse?' do
+    subject(:pse?) { application.pse? }
+
+    let(:attributes) { super().merge({ 'application_type' => application_type }) }
+
+    context 'when application is an initial application' do
+      let(:application_type) { Types::ApplicationType['initial'] }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when application is a post submission evidence application' do
+      let(:application_type) { Types::ApplicationType['post_submission_evidence'] }
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/spec/system/casework/viewing_an_application/post_submission_evidence_application_spec.rb
+++ b/spec/system/casework/viewing_an_application/post_submission_evidence_application_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing an application unassigned, open application' do
+  let(:application_id) { '21c37e3e-520f-46f1-bd1f-5c25ffc57d70' }
+  let(:application_data) { JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'post_submission_evidence').read) }
+
+  before do
+    stub_request(
+      :get,
+      "#{ENV.fetch('DATASTORE_API_ROOT')}/api/v1/applications/#{application_id}"
+    ).to_return(body: application_data.to_json, status: 200)
+
+    visit crime_application_path(application_id)
+  end
+
+  it 'includes the application type' do
+    expect(page).to have_content('Post submission evidence')
+  end
+
+  context 'with relevant client details information' do
+    it 'displays name details' do
+      expect(page).to have_content('First name Kit')
+      expect(page).to have_content('Last name Pound')
+    end
+
+    it 'displays other name details' do
+      expect(page).to have_content('Other names Not provided')
+    end
+
+    it 'displays date of birth' do
+      expect(page).to have_content('Date of birth 09/06/2001')
+    end
+
+    it 'does not display NI number' do
+      expect(page).not_to have_content('National Insurance number')
+    end
+
+    it 'does not display telephone number' do
+      expect(page).not_to have_content('UK Telephone number')
+    end
+
+    it 'does not display address information' do
+      expect(page).not_to have_content('Home address')
+      expect(page).not_to have_content('Correspondence address')
+    end
+
+    it 'does not display partner information' do
+      expect(page).not_to have_content('Partner')
+    end
+  end
+
+  context 'without standard application sections' do
+    it 'does not display case details' do
+      expect(page).not_to have_content('Case details')
+    end
+
+    it 'does not display offence details' do
+      expect(page).not_to have_content('Offence details')
+    end
+
+    it 'does not display co-defendants details' do
+      expect(page).not_to have_content('Co-defendants')
+    end
+
+    it 'does not display interest of justice details' do
+      expect(page).not_to have_content('Interest of Justice')
+    end
+  end
+
+  context 'with post submission evidence' do
+    it 'displays post submission evidence section title' do
+      expect(page).to have_content('Post submission evidence')
+      expect(page).not_to have_content('Supporting evidence')
+    end
+
+    it 'shows a table with post submission evidence' do
+      evidence_row = find(:xpath,
+                          "//table[@class='govuk-table app-dashboard-table govuk-!-margin-bottom-9']
+                            //tr[contains(td[1], 'test.pdf')]")
+      expect(evidence_row).to have_content('test.pdf Download file (pdf, 12 Bytes)')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Sets up the display for a PSE application. Displays client details, provider details and post submission evidence details, along with the application type in the overview section

## Link to relevant ticket
[CRIMAPP-350](https://dsdmoj.atlassian.net/browse/CRIMAPP-350)

## Notes for reviewer
The crime_application folder in views could do with some organisation/refactoring as there are a lot of files and I wonder if it is easy to navigate for newcomers. I think this could involve a new controller so won't do as part of this PR but i'll add a ticket to the backlog to prioritise as some point. 

Also no feature flag added (yet) as this is all dependant on PSE being live on apply

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="904" alt="Screenshot 2024-01-23 at 15 03 50" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/847bf20d-da96-4dbf-9325-7efd1b99fc96">
<img width="904" alt="Screenshot 2024-01-23 at 15 03 58" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/8e644baa-b454-44c3-8816-61d9c05a42cb">

## How to manually test the feature
Note: the work to submit a PSE application on apply has not been completed so this requires checking out of the spike branch in apply to submit a PSE application to view in review 

Steps for testing: 

- In apply, checkout of `CRIMAPP-290-PSE-spike-with-separate-pse` and go to a submitted application and click on the upload post submission evidence button and follow the steps to submit a post submission evidence application 
- In review, checkout this branch and build. Go to the open applications tab to view the PSE application and check the sections are as expected
- Also check the initial application is unchanged and displaying what is expected 

[CRIMAPP-350]: https://dsdmoj.atlassian.net/browse/CRIMAPP-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ