### PR TITLE
[CRIMAPP-375] Display mark as complete for pse applications

### DIFF
--- a/app/views/casework/crime_applications/show.html.erb
+++ b/app/views/casework/crime_applications/show.html.erb
@@ -17,7 +17,7 @@
   <div class="govuk-grid-column-three-quarters">
     <% if @crime_application.reviewable_by?(current_user_id) %>
       <div class="govuk-button-group govuk-!-margin-bottom-6">
-        <% if @crime_application.status?(:marked_as_ready) %>
+        <% if @crime_application.status?(:marked_as_ready) || @crime_application.pse? %>
         <%= button_to t('calls_to_action.mark_complete'),
                       complete_crime_application_path(@crime_application),
                       method: :put,
@@ -28,10 +28,12 @@
                       method: :put,
                       class: 'govuk-button govuk-button' %>
         <% end %>
-        <%= button_to t('calls_to_action.send_back'),
-                      new_crime_application_return_path(@crime_application),
-                      method: :get,
-                      class: 'govuk-button govuk-button--warning' %>
+        <% unless @crime_application.pse? %>
+          <%= button_to t('calls_to_action.send_back'),
+                        new_crime_application_return_path(@crime_application),
+                        method: :get,
+                        class: 'govuk-button govuk-button--warning' %>
+        <% end %>
         <%= button_to t('calls_to_action.unassign_from_self'),
                       assigned_application_path(@crime_application),
                       method: :delete,

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -390,15 +390,3 @@ en:
         <<: *LABELS
       values:
         <<: *VALUES
-    post_submissions:
-      subnavigation:
-        application_details: Application details
-        application_history: Application history
-      show:
-        page_title: Post submission
-        heading: Post submission
-        view_history: Check application history
-        view_your_list: Go to your list
-      history:
-        page_title: Application history
-        heading: Application history

--- a/spec/system/casework/viewing_an_application/post_submission_evidence_application_spec.rb
+++ b/spec/system/casework/viewing_an_application/post_submission_evidence_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Viewing an application unassigned, open application' do
+RSpec.describe 'Viewing an application unassigned, open, post submission evidence application' do
   let(:crime_application_id) { '21c37e3e-520f-46f1-bd1f-5c25ffc57d70' }
   let(:application_data) { JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'post_submission_evidence').read) }
 
@@ -111,6 +111,17 @@ RSpec.describe 'Viewing an application unassigned, open application' do
         first_row = page.first('.app-dashboard-table tbody tr').text
         expect(first_row).to match('Fred Smitheg Post submission evidence completed')
       end
+    end
+  end
+
+  context 'when reviewing application' do
+    it 'does not show the following CTAs' do
+      expect(page).not_to have_content('Mark as ready for MAAT')
+      expect(page).not_to have_content('Send back to provider')
+    end
+
+    it 'does show the mark as complete button' do
+      expect(page).not_to have_content('Mark as complete')
     end
   end
 end


### PR DESCRIPTION
## Description of change
Hides the `send back to provider` and `mark as ready for maat` review buttons for pse applications. Only displays the `mark as complete` action

## Link to relevant ticket
[CRIMAPP-375](https://dsdmoj.atlassian.net/browse/CRIMAPP-375)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1117" alt="Screenshot 2024-01-26 at 10 47 13" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/dcc3b959-d278-48ed-b173-a86495022970">

## How to manually test the feature
**Note: Make sure you have built datastore and crime apply from main**

**Steps for testing:**
- Submit a standard application in apply and review the application in review (as can only submit pse for applications that are complete)
- Then go back to apply and find the application in the submitted tab. Click on the application and click upload post submission evidence
- Submit your pse application and then go to review and find and assign the pse application to yourself 
- Check the button displayed says `mark as complete` and you can click that button and the application is marked as complete
- Also check a standard application displays the correct buttons (`Mark as ready for MAAT` and `Send back to provider` and `Mark as complete` (which displays after mark as ready for maat has been clicked))


[CRIMAPP-375]: https://dsdmoj.atlassian.net/browse/CRIMAPP-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ