### PR TITLE
CRIMAPP-314 Add "has the court remanded your client in custody" attributes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.34'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.35'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: f5f16a0410f91e1669a3897dde841ea7f5fb036b
-  tag: v1.0.34
+  revision: 921152079407aa334c1e879210a593d2a3b405b8
+  tag: v1.0.35
   specs:
-    laa-criminal-legal-aid-schemas (1.0.34)
+    laa-criminal-legal-aid-schemas (1.0.35)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/presenters/case_details_presenter.rb
+++ b/app/presenters/case_details_presenter.rb
@@ -31,6 +31,10 @@ class CaseDetailsPresenter < BasePresenter
     (has_case_concluded == 'yes') && date_case_concluded.present?
   end
 
+  def client_remanded?
+    (is_client_remanded == 'yes') && date_client_remanded.present?
+  end
+
   private
 
   def type_of(value)

--- a/app/views/casework/crime_applications/_overview.html.erb
+++ b/app/views/casework/crime_applications/_overview.html.erb
@@ -73,6 +73,26 @@
           </dd>
         </div>
       <%end%>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:is_client_remanded) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(overview.case_details.is_client_remanded, scope: 'values') || t('values.not_asked') %>
+        </dd>
+      </div>
+
+      <% if overview.case_details.client_remanded? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:date_client_remanded) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= l(overview.case_details.date_client_remanded, format: :compact) %>
+          </dd>
+        </div>
+      <%end%>
     <%end%>
 
     <div class="govuk-summary-list__row">

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -135,6 +135,8 @@ en:
     urn: Unique reference number (URN)
     has_case_concluded: Has the case concluded?
     date_case_concluded: When the case concluded
+    is_client_remanded: Has a court remanded client in custody?
+    date_client_remanded: When they were remanded
     what: What
     when: When
     who: Who


### PR DESCRIPTION
## Description of change

Display "Has the court remanded your client in custody" date conditionally (Please refer to the screenshots)

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-314

## Notes for reviewer
Actual text is different from screenshot

- Has a court remanded your client in custody? -> Has a court remanded client in custody?
- Date when they were remanded -> When they were remanded

## Screenshots of changes (if applicable)

### Before changes:
**1) For old Applications when "Has the court remanded your client in custody"  question was never asked**
<img width="667" alt="Screenshot 2024-01-26 at 14 24 30" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/195928/3051ddae-8128-4b37-88de-be4c62b4609a">

### After changes:
**For New Applications  when "Has the court remanded your client in custody"  question was asked**
<img width="692" alt="Screenshot 2024-01-26 at 14 24 12" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/195928/65b1c2e1-1f21-44d7-8013-4c78d2203863">

<img width="658" alt="Screenshot 2024-01-26 at 15 43 05" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/195928/18ed7271-3260-453b-a288-0b4b43bb6533">


## How to manually test the feature
