### PR TITLE
RIMAPP-310- Udate application details view

### DIFF
--- a/app/presenters/case_details_presenter.rb
+++ b/app/presenters/case_details_presenter.rb
@@ -27,6 +27,10 @@ class CaseDetailsPresenter < BasePresenter
     is_first_court_hearing == type_of('no_hearing_yet')
   end
 
+  def case_concluded?
+    (has_case_concluded == 'yes') && date_case_concluded.present?
+  end
+
   private
 
   def type_of(value)

--- a/app/views/casework/crime_applications/_overview.html.erb
+++ b/app/views/casework/crime_applications/_overview.html.erb
@@ -59,18 +59,20 @@
           <%= label_text(:has_case_concluded) %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= overview.case_details.has_case_concluded %>
+          <%= t(overview.case_details.has_case_concluded, scope: 'values') || t('values.not_asked') %>
         </dd>
       </div>
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= label_text(:date_case_concluded) %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= l(overview.case_details.date_case_concluded, format: :compact) %>
-        </dd>
-      </div>
+      <% if overview.case_details.case_concluded? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:date_case_concluded) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= l(overview.case_details.date_case_concluded, format: :compact) %>
+          </dd>
+        </div>
+      <%end%>
     <%end%>
 
     <div class="govuk-summary-list__row">

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -134,7 +134,7 @@ en:
     undetermined: Undetermined
     urn: Unique reference number (URN)
     has_case_concluded: Has the case concluded?
-    date_case_concluded: When did the case conclude?
+    date_case_concluded: Date when the case concluded
     what: What
     when: When
     who: Who

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -134,7 +134,7 @@ en:
     undetermined: Undetermined
     urn: Unique reference number (URN)
     has_case_concluded: Has the case concluded?
-    date_case_concluded: Date when the case concluded
+    date_case_concluded: When the case concluded
     what: What
     when: When
     who: Who


### PR DESCRIPTION
## Description of change
Display "Has the case concluded" date conditionally (Please refer to the screenshots)

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-310

## Notes for reviewer
**Actual text is different from screenshot**

- Date when the case concluded -> When the case concluded


## Screenshots of changes (if applicable)
**1) For old Applications when "Has the case concluded" question was never asked**

<img width="614" alt="Screenshot 2024-01-26 at 15 22 37" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/195928/21129d4f-cef5-478f-9c09-38bf6de25d3b">



**2) For new applications when "Has the case concluded" question was asked with 2 possible answers**
<img width="624" alt="Screenshot 2024-01-26 at 15 23 11" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/195928/17a47993-9637-4ab6-81c8-15bcfc240d15">

<img width="649" alt="Screenshot 2024-01-26 at 15 27 20" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/195928/10eb6c9c-cdbe-43da-912c-aa4788310deb">

### Before changes:

### After changes:

## How to manually test the feature
