### PR TITLE
[CRIMAPP-421] Add PSE as a competency

### DIFF
--- a/app/controllers/casework/assigned_applications_controller.rb
+++ b/app/controllers/casework/assigned_applications_controller.rb
@@ -29,7 +29,8 @@ module Casework
     end
 
     def next_application
-      next_app_id = GetNext.call(work_streams: current_user.work_streams)
+      next_app_id = GetNext.call(work_streams: current_user.work_streams,
+                                 application_types: current_user.application_types_competencies)
 
       if next_app_id
         Assigning::AssignToUser.new(

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -87,5 +87,6 @@ module Types
                                  criminal_applications_team
                                  criminal_applications_team_2
                                  extradition
+                                 post_submission_evidence
                                ])
 end

--- a/app/models/application_search_filter.rb
+++ b/app/models/application_search_filter.rb
@@ -10,6 +10,7 @@ class ApplicationSearchFilter < ApplicationStruct # rubocop:disable Metrics/Clas
     submitted_after
     submitted_before
     work_stream
+    application_type
   ].freeze
 
   attribute? :age_in_business_days, Types::Params::Nil | Types::Params::Integer
@@ -22,6 +23,7 @@ class ApplicationSearchFilter < ApplicationStruct # rubocop:disable Metrics/Clas
   attribute? :reviewed_after, Types::Params::Nil | Types::Params::Date
   attribute? :reviewed_before, Types::Params::Nil | Types::Params::Date
   attribute? :work_stream, Types::Array.of(Types::WorkStreamType)
+  attribute? :application_type, Types::Array.of(Types::ApplicationType)
 
   # Options for the assigned status filter
   # Includes "Unassigned", "All assigned" prepended to a list of all user names.
@@ -102,6 +104,10 @@ class ApplicationSearchFilter < ApplicationStruct # rubocop:disable Metrics/Clas
 
   def work_stream_datastore_param
     { work_stream: }
+  end
+
+  def application_type_datastore_param
+    { application_type: }
   end
 
   def application_status_datastore_param

--- a/app/models/concerns/user_competence.rb
+++ b/app/models/concerns/user_competence.rb
@@ -7,8 +7,19 @@ module UserCompetence
     end
   end
 
+  # Types of applications a user can process
+  def application_types_competencies
+    return [] if data_analyst?
+
+    competencies_incl_initial = competencies.dup << Types::ApplicationType['initial']
+    @application_types_competencies ||= (competencies_incl_initial &
+      Types::ApplicationType.values).map do |application_type|
+      application_type
+    end
+  end
+
   def competencies
-    return Types::CompetencyType.values if supervisor?
+    return Types::CompetencyType.values.dup if supervisor?
     return [] if data_analyst?
 
     @competencies ||= Allocating.user_competencies(id)

--- a/app/models/get_next.rb
+++ b/app/models/get_next.rb
@@ -1,6 +1,7 @@
 class GetNext
-  def initialize(work_streams:)
-    filter = ApplicationSearchFilter.new(assigned_status: 'unassigned', work_stream: work_streams)
+  def initialize(work_streams:, application_types:)
+    filter = ApplicationSearchFilter.new(assigned_status: 'unassigned', work_stream: work_streams,
+                                         application_type: application_types)
     pagination = Pagination.new(limit_value: 1)
     sorting = ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending')
     @search = ApplicationSearch.new(filter:, pagination:, sorting:)
@@ -10,9 +11,10 @@ class GetNext
     @search.results.first&.id
   end
 
-  def self.call(work_streams:)
+  def self.call(work_streams:, application_types:)
     work_streams ||= []
+    application_types ||= []
 
-    new(work_streams:).call
+    new(work_streams:, application_types:).call
   end
 end

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -118,7 +118,7 @@ en:
     overall_offence_class: Overall offence class
     overview: Overview
     partner: Partner
-    post_submission_evidence: Post submission evidence
+    post_submission_evidence: PSE
     previous_maat_id: Previous MAAT ID
     provider_details: Provider details
     provider_email: Email address

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -118,7 +118,7 @@ en:
     overall_offence_class: Overall offence class
     overview: Overview
     partner: Partner
-    post_submission_evidence: PSE
+    post_submission_evidence: Post submission evidence
     previous_maat_id: Previous MAAT ID
     provider_details: Provider details
     provider_email: Email address

--- a/spec/models/concerns/user_competence_spec.rb
+++ b/spec/models/concerns/user_competence_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe UserCompetence do
   let(:user) { User.new }
 
   describe '#work_streams' do
-    subject(:competencies) { user.work_streams }
+    subject(:work_streams) { user.work_streams }
 
     it 'defaults to an empty array' do
-      expect(competencies).to eq []
+      expect(work_streams).to eq []
     end
 
     context 'when a user has competencies assgined' do
@@ -18,7 +18,7 @@ RSpec.describe UserCompetence do
       end
 
       it 'returns an array of users competencies that are work streams' do
-        expect(competencies).to eq ['extradition']
+        expect(work_streams).to eq ['extradition']
       end
     end
   end
@@ -45,7 +45,8 @@ RSpec.describe UserCompetence do
         let(:user) { User.new(role: 'supervisor') }
 
         it 'returns all work_streams regardless of competencies' do
-          expect(competencies).to eq %w[criminal_applications_team criminal_applications_team_2 extradition]
+          expect(competencies).to eq %w[criminal_applications_team criminal_applications_team_2 extradition
+                                        post_submission_evidence]
         end
       end
 
@@ -54,6 +55,42 @@ RSpec.describe UserCompetence do
 
         it 'returns no competencies' do
           expect(competencies).to be_empty
+        end
+      end
+    end
+  end
+
+  describe '#application_types_competencies' do
+    subject(:application_types_competencies) { user.application_types_competencies }
+
+    it 'defaults to a initial application type' do
+      expect(application_types_competencies).to eq ['initial']
+    end
+
+    context 'when a user has post submission evidence assigned' do
+      before do
+        allow(Allocating).to receive(:user_competencies).with(user.id).and_return(
+          %w[crime_applications_team post_submission_evidence]
+        )
+      end
+
+      it 'returns an array of assigned application types' do
+        expect(application_types_competencies).to eq %w[post_submission_evidence initial]
+      end
+
+      context 'when user is a supervisor' do
+        let(:user) { User.new(role: 'supervisor') }
+
+        it 'returns all application types regardless of assigned competencies' do
+          expect(application_types_competencies).to eq %w[post_submission_evidence initial]
+        end
+      end
+
+      context 'when user is a data analyst' do
+        let(:user) { User.new(role: 'data_analyst') }
+
+        it 'returns no application type competencies' do
+          expect(application_types_competencies).to be_empty
         end
       end
     end

--- a/spec/system/casework/assigning/get_next_application_spec.rb
+++ b/spec/system/casework/assigning/get_next_application_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe 'Assigning an application to myself' do
       let(:expected_params) do
         ApplicationSearchFilter.new(
           assigned_status: 'unassigned',
-          work_stream: gets_next_from
+          work_stream: gets_next_from,
+          application_type: ['initial']
         ).datastore_params
       end
 


### PR DESCRIPTION
## Description of change
Supervisors can now assign a PSE competency to a caseworker
A caseworker with a PSE competency can pick up a PSE application via the get next button
A caseworker without a PSE competency can’t pick up a PSE application via the get next button

## Link to relevant ticket
[CRIMAPP-421](https://dsdmoj.atlassian.net/browse/CRIMAPP-421)

## Notes for reviewer

This is a change to the way work queues and competency assignment currently works in comparison to eForms.  
Work needs to be done consider how to explain how this works to supervisors and caseworkers on review and ensure they are trained to understand the differences

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

**Changes to the competency form** 
<img width="1180" alt="Screenshot 2024-01-29 at 11 49 54" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/954943c4-cc33-48ad-9234-ce1897380124">
<img width="1180" alt="Screenshot 2024-01-29 at 11 49 59" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/f29776e8-5f70-408f-8f78-397042cb6c73">

**Retrieving a PSE application as a caseworker with the PSE competency** 

<img width="1180" alt="Screenshot 2024-01-29 at 11 37 55" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/066f6a3a-e450-422b-93b4-debfaed86381">
<img width="1180" alt="Screenshot 2024-01-29 at 11 37 41" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/021414fd-8a44-44f0-840a-685d0894ab1c">

**Retrieving a PSE application as a caseworker without the PSE competency** 

<img width="1180" alt="Screenshot 2024-01-29 at 11 38 08" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/3977e7b8-e6c1-437f-944a-7c25f50d6693">


## How to manually test the feature

**Note: Requires a pse application to have been submitted** 
**Note: Requires a supervisor user and a caseworker user** 

Assigning a PSE competency 
- Log into review as a supervisor. Click on manage competencies. Go to a caseworker click their competencies to go to the competency form 
- Confirm that you can see post submission evidence listed as a competency option 
- Confirm that you can assign the caseworker the post submission evidence competency (Note: the caseworker will need at minimum both the CAT1 and PSE competency to be able to work on PSE applications)

Picking up a PSE application via the Get next button 
- Log into review as the caseworker you have just assigned the PSE competency to. 
- Go to the your list tab and click get next and confirm that you can get the next available PSE. (Note: you may have other older applications that are assigned first)


[CRIMAPP-421]: https://dsdmoj.atlassian.net/browse/CRIMAPP-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ