### PR TITLE
[CRIMAPP-330] Display employment section in application details

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.34'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.36'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: f5f16a0410f91e1669a3897dde841ea7f5fb036b
-  tag: v1.0.34
+  revision: 25af5226ddece2afc1cd2083427fd8b6882aac51
+  tag: v1.0.36
   specs:
-    laa-criminal-legal-aid-schemas (1.0.34)
+    laa-criminal-legal-aid-schemas (1.0.36)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/views/casework/crime_applications/_employment.html.erb
+++ b/app/views/casework/crime_applications/_employment.html.erb
@@ -1,43 +1,45 @@
-<h2 class="govuk-heading-m">
-  <%= label_text(:employment) %>
-</h2>
+<% if income_details.present? %>
+  <h2 class="govuk-heading-m">
+    <%= label_text(:employment) %>
+  </h2>
 
-<dl class="govuk-summary-list govuk-!-margin-bottom-9">
-  <% income_details.employment_type.each do |et| %>
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <% income_details.employment_type.each do |et| %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:employment_type) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(et, scope: 'values.employment_type')  %>
+        </dd>
+      </div>
+    <% end %>
+
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        <%= label_text(:employment_type) %>
+        <%= label_text(:ended_employment_within_three_months) %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= t(et, scope: 'values.employment_type')  %>
+        <%= t(income_details.ended_employment_within_three_months, scope: 'values') %>
       </dd>
     </div>
-  <% end %>
-
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      <%= label_text(:ended_employment_within_three_months) %>
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <%= t(income_details.ended_employment_within_three_months, scope: 'values') %>
-    </dd>
-  </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      <%= label_text(:lost_job_in_custody) %>
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <%= t(income_details.lost_job_in_custody, scope: 'values') %>
-    </dd>
-  </div>
-  <% if income_details.lost_job_in_custody == 'yes' %>
     <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      <%= label_text(:date_job_lost) %>
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <%= l income_details.date_job_lost, format: :compact %>
-    </dd>
-  </div>
-  <% end %>
-</dl>
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:lost_job_in_custody) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= t(income_details.lost_job_in_custody, scope: 'values') %>
+      </dd>
+    </div>
+    <% if income_details.lost_job_in_custody == 'yes' %>
+      <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:date_job_lost) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= l income_details.date_job_lost, format: :compact %>
+      </dd>
+    </div>
+    <% end %>
+  </dl>
+<% end %>

--- a/app/views/casework/crime_applications/_employment.html.erb
+++ b/app/views/casework/crime_applications/_employment.html.erb
@@ -1,0 +1,43 @@
+<h2 class="govuk-heading-m">
+  <%= label_text(:employment) %>
+</h2>
+
+<dl class="govuk-summary-list govuk-!-margin-bottom-9">
+  <% income_details.employment_type.each do |et| %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:employment_type) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= t(et, scope: 'values.employment_type')  %>
+      </dd>
+    </div>
+  <% end %>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <%= label_text(:ended_employment_within_three_months) %>
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= t(income_details.ended_employment_within_three_months, scope: 'values') %>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <%= label_text(:lost_job_in_custody) %>
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= t(income_details.lost_job_in_custody, scope: 'values') %>
+    </dd>
+  </div>
+  <% if income_details.lost_job_in_custody == 'yes' %>
+    <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <%= label_text(:date_job_lost) %>
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= l income_details.date_job_lost, format: :compact %>
+    </dd>
+  </div>
+  <% end %>
+</dl>

--- a/app/views/casework/crime_applications/_employment.html.erb
+++ b/app/views/casework/crime_applications/_employment.html.erb
@@ -23,23 +23,26 @@
         <%= t(income_details.ended_employment_within_three_months, scope: 'values') %>
       </dd>
     </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= label_text(:lost_job_in_custody) %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= t(income_details.lost_job_in_custody, scope: 'values') %>
-      </dd>
-    </div>
-    <% if income_details.lost_job_in_custody == 'yes' %>
+    <% unless income_details.lost_job_in_custody.nil? %>
       <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= label_text(:date_job_lost) %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= l income_details.date_job_lost, format: :compact %>
-      </dd>
-    </div>
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:lost_job_in_custody) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(income_details.lost_job_in_custody, scope: 'values') %>
+        </dd>
+      </div>
+
+      <% if income_details.lost_job_in_custody == 'yes' %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:date_job_lost) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= l income_details.date_job_lost, format: :compact %>
+          </dd>
+        </div>
+      <% end %>
     <% end %>
   </dl>
 <% end %>

--- a/app/views/casework/crime_applications/_initial.html.erb
+++ b/app/views/casework/crime_applications/_initial.html.erb
@@ -11,6 +11,7 @@
 <%= render partial: 'interests_of_justice', locals: { crime_application: } %>
 <%= render partial: 'supporting_evidence', locals: { crime_application: } %>
 <% if FeatureFlags.means_journey.enabled? %>
+  <%= render partial: 'employment', locals: { income_details: crime_application.means_details.income_details } %>
   <%= render partial: 'income', locals: { income_details: crime_application.means_details.income_details } %>
   <%= render partial: 'dependants', locals: { dependants: crime_application.dependants.formatted_dependants } %>
   <%= render partial: 'other_income_details', locals: { income_details: crime_application.means_details.income_details } %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -81,9 +81,13 @@ en:
       sent_back: 'Date closed:'
       completed: 'Date closed:'
     date_appeal_lodged: Date the appeal was lodged
+    date_job_lost: When did they lose their job?
     date_of_birth: Date of birth
     date_received: 'Date received:'
     details: Details
+    employment: Employment
+    employment_type: Client's employment status
+    ended_employment_within_three_months: Have they ended employment in the last 3 months?
     end_on: Date to
     extradition: Extradition
     file_name: File name
@@ -102,6 +106,7 @@ en:
     justification: Justification
     last_name: Last name
     legal_representative: Legal representative
+    lost_job_in_custody: Did they lose their job as a result of being in custody?
     manage_without_income: How do they manage with no income?
     means_tested: Is application subject to means test
     name: Name
@@ -243,6 +248,13 @@ en:
       living_on_streets: They are living on the streets or homeless
       custody: They have been in custody for more than 3 months
       other: Other
+    employment_type:
+      employed: Employed
+      self-employed: Self-employed
+      business_partnership: In a business partnership
+      director: Company directory in a private company
+      shareholder: Shareholder in a private company
+      not_working: Not working
 
   calls_to_action:
     abandon_reassign_to_self: No, do not reassign

--- a/spec/system/casework/viewing_an_application/application_details/employment_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/employment_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing the employment details of an application' do
+  include_context 'with stubbed application'
+
+  before do
+    visit crime_application_path(application_id)
+  end
+
+  context 'with employment details' do
+    it { expect(page).to have_content('Employment') }
+
+    it 'shows employment type' do
+      expect(page).to have_content("Client's employment status Not working")
+    end
+
+    it 'shows whether employment has ended in the last three months' do
+      expect(page).to have_content('Have they ended employment in the last 3 months? Yes')
+    end
+
+    it 'shows whether job was lost in custody and date details' do
+      expect(page).to have_content('Did they lose their job as a result of being in custody? Yes')
+      expect(page).to have_content('When did they lose their job? 01/09/2023')
+    end
+    
+    context 'when job was not lost in custody' do
+      let(:application_data) do
+        super().deep_merge('means_details' => { 'income_details' => { 'lost_job_in_custody' => 'no',
+                                                                      'date_job_lost' => nil } })
+      end
+
+      it 'does not show date custody lost details' do
+        expect(page).to have_content('Did they lose their job as a result of being in custody? No')
+        expect(page).not_to have_content('When did they lose their job?')
+      end
+    end
+  end
+
+  context 'with no income details' do
+    let(:application_data) do
+      super().deep_merge('means_details' => nil)
+    end
+
+    it 'does not show income section' do
+      expect(page).not_to have_content('Employment')
+    end
+  end
+end

--- a/spec/system/casework/viewing_an_application/application_details/employment_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/employment_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Viewing the employment details of an application' do
       expect(page).to have_content('Did they lose their job as a result of being in custody? Yes')
       expect(page).to have_content('When did they lose their job? 01/09/2023')
     end
-    
+
     context 'when job was not lost in custody' do
       let(:application_data) do
         super().deep_merge('means_details' => { 'income_details' => { 'lost_job_in_custody' => 'no',


### PR DESCRIPTION
## Description of change
Adds employment information to the application details section if present

## Link to relevant ticket
[CRIMAPP-330](https://dsdmoj.atlassian.net/browse/CRIMAPP-330)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

**With all employment details**
<img width="912" alt="Screenshot 2024-01-29 at 15 45 57" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/91c3613d-3a4a-4c0c-965a-5bcc26e6d29f">

**With employment details when job not lost in custody**
<img width="912" alt="Screenshot 2024-01-29 at 15 45 06" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/c2ce862c-ea7b-456b-a879-78b8f8d40670">

**With all employment details when employment not ended in the last three months**
<img width="912" alt="Screenshot 2024-01-29 at 15 44 42" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/5d219654-c9aa-42ec-b120-b334d98d0a33">


## How to manually test the feature
Requires an application with all employment details entered, an application where No has been selected for `Did they lose their job as a result of being in custody?` and an application where No has been selected for `Have they ended employment in the last 3 months?`

Navigate to review and check the application details section matches the screenshots above for the relevant application 

Also check that existing applications on review do not display the employment section and any new applications submitted without income details on apply also do not display the employment section


[CRIMAPP-330]: https://dsdmoj.atlassian.net/browse/CRIMAPP-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ