### PR TITLE
CRIMAPP-428 Show additional information.

### DIFF
--- a/app/views/casework/crime_applications/_additional_information.en.html.erb
+++ b/app/views/casework/crime_applications/_additional_information.en.html.erb
@@ -1,0 +1,6 @@
+<% unless additional_information.blank? %>
+  <%= govuk_inset_text do  %>
+    <h2 class='govuk-heading-m'>Information from the provider</h2>
+    <%= simple_format(additional_information) %>
+  <% end  %>
+<% end %>

--- a/app/views/casework/crime_applications/show.html.erb
+++ b/app/views/casework/crime_applications/show.html.erb
@@ -4,7 +4,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-9">
     <%= render partial: 'subnavigation', locals: { crime_application: @crime_application } %>
+    <%= render partial: 'additional_information', object: @crime_application.additional_information %>
     <%= render partial: 'overview', object: @crime_application %>
+
     <% if @crime_application.pse? %>
       <%= render partial: 'pse', locals: { crime_application: @crime_application } %>
     <% else %>

--- a/spec/system/casework/viewing_an_application/application_details/additional_information_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/additional_information_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing any additional information provided' do
+  include_context 'with stubbed application'
+
+  let(:additional_info_label) { 'Information from the provider' }
+
+  before do
+    visit crime_application_path(application_id)
+  end
+
+  context 'when additional information not provided' do
+    it { expect(page).not_to have_content(additional_info_label) }
+  end
+
+  context 'when additional information provided' do
+    let(:application_data) { JSON.parse(LaaCrimeSchemas.fixture(1.0).read).merge(additional_information:) }
+
+    let(:additional_information) do
+      <<STRING
+        First line of info.
+        Second line of info.
+
+        Last line of info.
+STRING
+    end
+
+    let(:inset_text) { page.find('.govuk-inset-text') }
+
+    it 'shows the additional information as inset text with the correct heading' do
+      expect(inset_text).to have_css('h2', text: additional_info_label)
+    end
+
+    it 'shows the application\'s additional information in simple format' do
+      expect(inset_text).to have_css('p', text: 'First line of info.')
+      expect(inset_text).to have_css('p', text: 'Last line of info.')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Show additional information from the provider in application details.

## Link to relevant ticket
[CRIMAPP-428](https://dsdmoj.atlassian.net/browse/CRIMAPP-428)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="827" alt="Screenshot 2024-01-30 at 14 18 35" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/1548f2df-844f-4b20-abfd-500902eca49d">


## How to manually test the feature
View an application with additional information, confirm that they are show as per design. 
View an application without additional information, confirm that the inset text is not shown.



[CRIMAPP-428]: https://dsdmoj.atlassian.net/browse/CRIMAPP-428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ