### PR TITLE
RIMAPP-366 Add-pre-order-work-page attributes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.36'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.37'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 25af5226ddece2afc1cd2083427fd8b6882aac51
-  tag: v1.0.36
+  revision: 70fabbeea84179dae570a5efb0218ef3451cf775
+  tag: v1.0.37
   specs:
-    laa-criminal-legal-aid-schemas (1.0.36)
+    laa-criminal-legal-aid-schemas (1.0.37)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/presenters/case_details_presenter.rb
+++ b/app/presenters/case_details_presenter.rb
@@ -31,6 +31,10 @@ class CaseDetailsPresenter < BasePresenter
     (has_case_concluded == 'yes') && date_case_concluded.present?
   end
 
+  def preorder_work_claimed?
+    (is_preorder_work_claimed == 'yes') && preorder_work_date.present? && preorder_work_details.present?
+  end
+
   def client_remanded?
     (is_client_remanded == 'yes') && date_client_remanded.present?
   end

--- a/app/views/casework/crime_applications/_overview.html.erb
+++ b/app/views/casework/crime_applications/_overview.html.erb
@@ -76,6 +76,34 @@
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
+          <%= label_text(:is_preorder_work_claimed) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(overview.case_details.is_preorder_work_claimed, scope: 'values') || t('values.not_asked') %>
+        </dd>
+      </div>
+
+      <% if overview.case_details.preorder_work_claimed? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:preorder_work_date) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= l(overview.case_details.preorder_work_date, format: :compact) %>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:preorder_work_details) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= overview.case_details.preorder_work_details %>
+          </dd>
+        </div>
+      <%end%>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
           <%= label_text(:is_client_remanded) %>
         </dt>
         <dd class="govuk-summary-list__value">

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -140,6 +140,9 @@ en:
     urn: Unique reference number (URN)
     has_case_concluded: Has the case concluded?
     date_case_concluded: When the case concluded
+    is_preorder_work_claimed: Do you intend to claim pre-order work?
+    preorder_work_date: When you or your firm were first instructed
+    preorder_work_details: Details about the urgency of the work
     is_client_remanded: Has a court remanded client in custody?
     date_client_remanded: When they were remanded
     what: What


### PR DESCRIPTION
## Description of change
Display "Do you intend to claim pre-order work?" `preorder_work_date` and `preorder_work_details`  conditionally (Please refer to the screenshots)

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-366

## Notes for reviewer

## Screenshots of changes (if applicable)
**1) For old Applications when "Do you intend to claim pre-order work?" question was never asked**

<img width="636" alt="Screenshot 2024-01-31 at 14 53 27" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/195928/7517e8d7-af04-4854-bf12-905f42314adc">


**2) For new applications when "Do you intend to claim pre-order work?" question was asked with 2 possible answers**

<img width="610" alt="Screenshot 2024-01-31 at 14 52 52" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/195928/999f4541-3b54-4041-8586-8b51c172f6f7">

<img width="629" alt="Screenshot 2024-01-31 at 14 51 24" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/195928/15b9371d-25b3-4e1b-9b11-dceebc779bab">

## How to manually test the feature
information is available on http://REVIEW-APP/applications/:id