### PR TITLE
[CRIMAPP-515] Display superseded styling for superseded applications

### DIFF
--- a/app/aggregates/reviewing/commands/receive_application.rb
+++ b/app/aggregates/reviewing/commands/receive_application.rb
@@ -4,7 +4,7 @@ module Reviewing
     attribute :submitted_at, Types::DateTime
     attribute? :parent_id, Types::Uuid.optional
     attribute :work_stream, Types::WorkStreamType
-    attribute? :application_type, Types::ApplicationType.optional
+    attribute? :application_type, Types::ApplicationType
     attribute? :correlation_id, Types::Uuid.optional
     attribute? :causation_id, Types::Uuid.optional
 

--- a/app/aggregates/reviewing/commands/receive_application.rb
+++ b/app/aggregates/reviewing/commands/receive_application.rb
@@ -4,7 +4,7 @@ module Reviewing
     attribute :submitted_at, Types::DateTime
     attribute? :parent_id, Types::Uuid.optional
     attribute :work_stream, Types::WorkStreamType
-    attribute? :application_type, Types::ApplicationType
+    attribute :application_type, Types::ApplicationType
     attribute? :correlation_id, Types::Uuid.optional
     attribute? :causation_id, Types::Uuid.optional
 

--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -23,7 +23,8 @@ module Reviewable
       application_id: id,
       submitted_at: submitted_at,
       parent_id: parent_id,
-      work_stream: work_stream
+      work_stream: work_stream,
+      application_type: application_type
     )
 
     @review = nil

--- a/spec/aggregates/reviewing/complete_spec.rb
+++ b/spec/aggregates/reviewing/complete_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Reviewing::Complete do
     ).and_return(return_request)
 
     Reviewing::ReceiveApplication.call(
-      application_id: application_id, submitted_at: 1.day.ago.to_s, work_stream: 'extradition'
+      application_id: application_id, submitted_at: 1.day.ago.to_s, work_stream: 'extradition',
+      application_type: 'initial'
     )
   end
 

--- a/spec/aggregates/reviewing/mark_as_ready_spec.rb
+++ b/spec/aggregates/reviewing/mark_as_ready_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Reviewing::MarkAsReady do
     ).and_return(return_request)
 
     Reviewing::ReceiveApplication.call(
-      application_id: application_id, submitted_at: 1.day.ago.to_s, work_stream: 'extradition'
+      application_id: application_id, submitted_at: 1.day.ago.to_s, work_stream: 'extradition',
+      application_type: 'initial'
     )
   end
 

--- a/spec/aggregates/reviewing/receive_application_spec.rb
+++ b/spec/aggregates/reviewing/receive_application_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Reviewing::ReceiveApplication do
       application_id: application_id,
       submitted_at: Time.zone.now.to_s,
       parent_id: nil,
-      work_stream: 'extradition'
+      work_stream: 'extradition',
+      application_type: 'initial'
     )
   end
 

--- a/spec/aggregates/reviewing/send_back_spec.rb
+++ b/spec/aggregates/reviewing/send_back_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Reviewing::SendBack do
 
   before do
     Reviewing::ReceiveApplication.call(
-      application_id: application_id, submitted_at: 1.day.ago.to_s, work_stream: 'extradition'
+      application_id: application_id, submitted_at: 1.day.ago.to_s, work_stream: 'extradition',
+      application_type: 'initial'
     )
 
     allow(DatastoreApi::Requests::UpdateApplication).to receive(:new).with(

--- a/spec/read_models/received_on_reports/configuration_spec.rb
+++ b/spec/read_models/received_on_reports/configuration_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe ReceivedOnReports::Configuration do
       travel_to submitted_at
 
       Reviewing::ReceiveApplication.call(
-        application_id: application_id, submitted_at: submitted_at.to_s, work_stream: 'extradition'
+        application_id: application_id, submitted_at: submitted_at.to_s, work_stream: 'extradition',
+        application_type: 'initial'
       )
 
       travel_to submitted_at + 3.days

--- a/spec/read_models/received_on_reports/projection_spec.rb
+++ b/spec/read_models/received_on_reports/projection_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ReceivedOnReports::Projection do
     let(:observed_at) { Time.current }
     let(:cat1) { Types::WorkStreamType['criminal_applications_team'] }
     let(:extradition) { Types::WorkStreamType['extradition'] }
+    let(:initial) { Types::ApplicationType['initial'] }
 
     describe '#dataset' do
       subject(:dataset) { described_class.new(stream_name:, observed_at:).dataset }
@@ -22,10 +23,10 @@ RSpec.describe ReceivedOnReports::Projection do
         a, b, c, d = Array.new(4) { SecureRandom.uuid }
 
         # Receive three CAT 1 and one extradition application
-        receive_application(a, cat1)
-        receive_application(b, cat1)
-        receive_application(c, cat1)
-        receive_application(d, extradition)
+        receive_application(a, cat1, initial)
+        receive_application(b, cat1, initial)
+        receive_application(c, cat1, initial)
+        receive_application(d, extradition, initial)
 
         event_store.publish(Reviewing::Completed.new(
                               data: { application_id: b }
@@ -42,7 +43,7 @@ RSpec.describe ReceivedOnReports::Projection do
                             ))
 
         # This application should not be included in the data
-        receive_application(SecureRandom.uuid, cat1)
+        receive_application(SecureRandom.uuid, cat1, initial)
 
         travel_back
       end
@@ -99,11 +100,11 @@ RSpec.describe ReceivedOnReports::Projection do
   end
   # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-  def receive_application(application_id, work_stream)
+  def receive_application(application_id, work_stream, application_type)
     submitted_at = Time.current
 
     Reviewing::ReceiveApplication.new(
-      application_id:, submitted_at:, work_stream:
+      application_id:, submitted_at:, work_stream:, application_type:
     ).call
   end
 end


### PR DESCRIPTION
## Description of change
Fixes local regression where superseded applications are missing superseded styling elements (e.g. the link to go to the latest version of the application, greyed out test etc..). This was due to recent changes to prevent initial applications from adopting the superseded styling when a pse application is submitted. 

## Link to relevant ticket
[CRIMAPP-515](https://dsdmoj.atlassian.net/browse/CRIMAPP-515)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="948" alt="Screenshot 2024-02-15 at 09 48 16" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/803d4dcf-e2f5-449f-9fcf-5965fe788ee5">

### After changes:
<img width="1146" alt="Screenshot 2024-02-15 at 09 41 52" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/13eb9e3d-5327-462d-9eb0-f36399aa1e28">


## How to manually test the feature

1. Submit an application in Apply
2. In Review, assign that application to list and return to provider with any reason
3. Resubmit from Apply
4. In Review go to Closed Applications tab and open the 1st version that was submitted. 

Confirm the following styling:

- Greyed out reference number and name
- Copy reference number link should not be visible
- Warning text: This application has been resubmitted. Go to the latest version

Also click the link and it should take you to the latest application

[CRIMAPP-515]: https://dsdmoj.atlassian.net/browse/CRIMAPP-515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ