### PR TITLE
Fix mini report bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,5 @@
   "dependencies": {
     "govuk-frontend": "5.2.0",
     "@ministryofjustice/frontend": "2.1.1"
-  },
-  "scripts": {
-    "postinstall": "bin/importmap pin govuk-frontend@5.2.0"
   }
 }


### PR DESCRIPTION
## Description of change
Fix bug seen on staging where the mini reports on the open/closed applications pages were not displaying 
Also checked reports are working as expected

Seems to be due to the post install script that was changing the pin in the import map for govuk frontend from pin `"govuk-frontend", to: "https://ga.jspm.io/npm:govuk-frontend@5.2.0/dist/govuk/all.mjs"`  to pin `"govuk-frontend" # @5.2.0`

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
![Screenshot 2024-03-11 at 10 30 07](https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/b734a8c6-0a30-4567-a9dd-e832b8ef63bc)

### After changes:

## How to manually test the feature
Pull down this branch 
Run yarn install
Check the mini reports on the open/closed applications pages are visible and displaying the correct data
Also check the reports are displaying as expected (need to be signed in as a supervisor or data analyst to view)
