### PR TITLE
[CRIMAPP-505] Display frozen income savings assets in capital

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.52'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.54'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: f60a82b368d47a828f96e2c3739107bbc283a342
-  tag: v1.0.52
+  revision: 9dfbef13229645869d629565eaf8f9d9c3a61f0b
+  tag: v1.0.54
   specs:
-    laa-criminal-legal-aid-schemas (1.0.52)
+    laa-criminal-legal-aid-schemas (1.0.54)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/views/casework/crime_applications/_capital_details.html.erb
+++ b/app/views/casework/crime_applications/_capital_details.html.erb
@@ -1,1 +1,2 @@
 <%= render partial: 'casework/crime_applications/sections/trust_fund', locals: { capital_details: crime_application.means_details.capital_details } %>
+<%= render partial: 'casework/crime_applications/sections/other_capital_details', locals: { capital_details: crime_application.means_details.capital_details } %>

--- a/app/views/casework/crime_applications/sections/_other_capital_details.html.erb
+++ b/app/views/casework/crime_applications/sections/_other_capital_details.html.erb
@@ -1,0 +1,16 @@
+<% unless capital_details&.has_frozen_income_or_assets.nil? %>
+  <h2 class="govuk-heading-m">
+    <%= label_text(:other_capital_details) %>
+  </h2>
+
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:has_frozen_income_or_assets) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= t(capital_details.has_frozen_income_or_assets, scope: 'values') %>
+      </dd>
+    </div>
+  </dl>
+<% end %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -120,6 +120,7 @@ en:
     offence_date: Offence date
     offence_details: Offence details
     office_account_number: Office account number
+    other_capital_details: Other capital
     other_income_details: Other sources of income
     other_outgoings_details: Other outgoings
     other_names: Other names

--- a/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Viewing the income details of an application' do
     end
 
     it 'shows savings or investments' do
-      expect(page).to have_content('Has savings or investments? No')
+      expect(page).to have_content('Has savings or investments? Yes')
     end
   end
 

--- a/spec/system/casework/viewing_an_application/application_details/other_capital_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/other_capital_details_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing the other capital details of an application' do
+  include_context 'with stubbed application'
+
+  before do
+    visit crime_application_path(application_id)
+  end
+
+  context 'when user was not asked about frozen income or assets in capital' do
+    it { expect(page).not_to have_content('Other capital') }
+  end
+
+  context 'when user was asked about frozen income or assets in capital' do
+    let(:application_data) do
+      super().deep_merge('means_details' => { 'capital_details' => { 'has_frozen_income_or_assets' => 'no' } })
+    end
+
+    it { expect(page).to have_content('Other capital') }
+
+    it 'shows whether client has income, savings or assets under a restraint or freezing order' do
+      expect(page).to have_content('Has income, savings or assets under a restraint or freezing order? No')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Displays answer to step "Does your client have any income, savings or assets under a restraint or freezing order?" in the capital section if it was not asked in the income assessment section on apply
If this question was not asked, the other capital section is not shown

## Link to relevant ticket
[CRIMAPP-505](https://dsdmoj.atlassian.net/browse/CRIMAPP-505)

## Notes for reviewer
Requires [apply PR](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/712) with apply side changes for local testing

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="742" alt="Screenshot 2024-03-19 at 08 18 38" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/6bf94871-e68e-48d9-94a4-2d865561fbec">
<img width="742" alt="Screenshot 2024-03-19 at 08 18 51" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/f1e69c65-df62-493c-a38a-d15b60fde89b">

## How to manually test the feature
Submit an application in apply with the step `Does your client have any income, savings or assets under a restraint or freezing order?` answered. Instructions for this is in the apply pr 
Then confirm a `other capital` section is shown in review with the correct data 
Then submit an application without answering the step in apply and confirm the `other capital` section is not shown on review

[CRIMAPP-505]: https://dsdmoj.atlassian.net/browse/CRIMAPP-505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ