### PR TITLE
CRIMAPP-626 Add PSE to workload report

### DIFF
--- a/app/aggregates/reviewing/review.rb
+++ b/app/aggregates/reviewing/review.rb
@@ -4,6 +4,7 @@ module Reviewing
 
     def initialize(id)
       @id = id
+      @application_type = nil
       @state = nil
       @return_reason = nil
       @reviewer_id = nil
@@ -18,7 +19,7 @@ module Reviewing
 
     attr_reader :id, :state, :return_reason, :reviewed_at, :reviewer_id,
                 :submitted_at, :superseded_by, :superseded_at, :parent_id,
-                :work_stream
+                :work_stream, :application_type
 
     alias application_id id
 
@@ -72,6 +73,7 @@ module Reviewing
       @received_at = event.timestamp
       @submitted_at = event.data[:submitted_at]
       @parent_id = event.data[:parent_id]
+      @application_type = event.data.fetch(:application_type, Types::ApplicationType['initial'])
       @work_stream = event.data.fetch(:work_stream, Types::WorkStreamType['criminal_applications_team'])
     end
 

--- a/app/controllers/reporting/snapshots_controller.rb
+++ b/app/controllers/reporting/snapshots_controller.rb
@@ -4,7 +4,11 @@ module Reporting
     before_action :require_report_access!
 
     def show
-      @report = Reporting::Snapshot.from_param(report_type: @report_type, date: params[:date], time: params[:time])
+      @report = Reporting::Snapshot.from_param(
+        report_type: @report_type,
+        date: params[:date],
+        time: params[:time]
+      )
     end
 
     def now

--- a/app/models/reporting/workload_report.rb
+++ b/app/models/reporting/workload_report.rb
@@ -4,23 +4,17 @@ module Reporting
 
     # Builds a Workload Report from "observed_at" until "age_limit" business days
     # ago.
-    def initialize(observed_at: Time.current, work_streams: Types::WorkStreamType.values)
+    def initialize(observed_at: Time.current, work_streams: WorkStream.all)
       @work_streams = work_streams
       @observed_at = observed_at
     end
 
     def rows
       @rows ||= @work_streams.map do |work_stream|
-        work_stream_dataset = raw_dataset.map { |rd| rd.fetch(work_stream) }
-        WorkloadReportRow.new(work_stream: work_stream, dataset: work_stream_dataset)
-      end
-    end
-
-    attr_reader :observed_at
-
-    def raw_dataset
-      @raw_dataset ||= business_days.map do |business_day|
-        ReceivedOnReports::Projection.for_date(business_day.date, observed_at:).dataset
+        application_types.map do |application_type|
+          dataset = raw_dataset.map { |rd| rd.dig(work_stream.to_s, application_type) }
+          WorkloadReportRow.new(work_stream:, dataset:, application_type:)
+        end
       end
     end
 
@@ -28,6 +22,23 @@ module Reporting
       @business_days ||= BusinessDay.list_backwards(
         day_zero: observed_at, age_limit: AGE_LIMIT
       )
+    end
+
+    private
+
+    attr_reader :observed_at
+
+    def application_types
+      [
+        Types::ApplicationType['initial'],
+        Types::ApplicationType['post_submission_evidence']
+      ]
+    end
+
+    def raw_dataset
+      @raw_dataset ||= business_days.map do |business_day|
+        ReceivedOnReports::Projection.for_date(business_day.date, observed_at:).dataset
+      end
     end
   end
 end

--- a/app/models/reporting/workload_report_row.rb
+++ b/app/models/reporting/workload_report_row.rb
@@ -1,10 +1,11 @@
 module Reporting
   class WorkloadReportRow
-    attr_reader :work_stream
+    attr_reader :work_stream, :application_type
 
-    def initialize(work_stream:, dataset:)
+    def initialize(work_stream:, application_type:, dataset:)
       @work_stream = work_stream
       @dataset = dataset
+      @application_type = application_type
     end
 
     def received_this_business_day

--- a/app/read_models/reviews/update_from_aggregate.rb
+++ b/app/read_models/reviews/update_from_aggregate.rb
@@ -24,6 +24,7 @@ module Reviews
           reviewer_id: review_aggregate.reviewer_id,
           parent_id: review_aggregate.parent_id,
           business_day: review_aggregate.business_day.to_s,
+          application_type: review_aggregate.application_type,
           reviewed_on: review_aggregate.reviewed_on,
           work_stream: review_aggregate.work_stream
         },

--- a/app/views/reporting/base/_workload_report.en.html.erb
+++ b/app/views/reporting/base/_workload_report.en.html.erb
@@ -1,125 +1,134 @@
-<%= govuk_table(classes: ['app-table']) do |table| # rubocop:disable Metrics/BlockLength
-      # rubocop:disable Metrics/BlockLength
-      table.with_colgroup do |colgroup|
-        colgroup.with_col(span: 1)
-        colgroup.with_col(span: 2)
-        colgroup.with_col(span: 6)
-      end
-      table.with_head do |head|
-        head.with_row(classes: 'colgroup-headers') do |row|
-          row.with_cell(text: '', colspan: 1, scope: 'colgroup')
-          row.with_cell(text: "From #{report.observed_business_period_text}", numeric: true, colspan: 2, scope: 'colgroup', classes: [])
-          row.with_cell(text: "Applications still open by age in business days at #{report.observed_at_time}", colspan: 6, scope: 'colgroup')
-        end
+<%= govuk_tabs(title: report.title) do |tabs| # rubocop:disable Metrics/BlockLength
+      report.rows.each do |data_rows| # rubocop:disable Metrics/BlockLength
+        work_stream = data_rows.first.work_stream
 
-        head.with_row(classes: 'colgroup-details') do |row|
-          row.with_cell(text: '')
-          row.with_cell(text: 'Received', numeric: true, classes: 'colgroup-total')
-          row.with_cell(text: 'Closed', numeric: true, classes: 'colgroup-total')
-          row.with_cell(text: '0 days', numeric: true, classes: 'colgroup-detail')
-          row.with_cell(text: '1 day', numeric: true, classes: 'colgroup-detail')
-          row.with_cell(text: '2 days', numeric: true, classes: 'colgroup-detail')
-          row.with_cell(text: '3 days', numeric: true, classes: 'colgroup-detail')
-          row.with_cell(text: '4-9 days', numeric: true, classes: 'colgroup-detail')
-          row.with_cell(text: 'Total', numeric: true, classes: 'colgroup-total')
-        end
-      end
-      table.with_body do |body|
-        report.rows.each do |data_row|
-          body.with_row do |row|
-            row.with_cell(
-              text: label_text(data_row.work_stream),
-              header: true
-            )
-            row.with_cell(
-              text: data_row.received_this_business_day,
-              numeric: true,
-              classes: 'colgroup-total'
-            )
-            row.with_cell(
-              text: data_row.closed_this_business_day,
-              numeric: true,
-              classes: 'colgroup-total'
-            )
-            row.with_cell(
-              text: data_row.day0,
-              numeric: true,
-              classes: 'colgroup-detail'
-            )
-            row.with_cell(
-              text: data_row.day1,
-              numeric: true,
-              classes: 'colgroup-detail'
-            )
-            row.with_cell(
-              text: data_row.day2,
-              numeric: true,
-              classes: 'colgroup-detail'
-            )
-            row.with_cell(
-              text: data_row.day3,
-              numeric: true,
-              classes: 'colgroup-detail'
-            )
-            row.with_cell(
-              text: data_row.day4_to_last_day,
-              numeric: true,
-              classes: 'colgroup-detail'
-            )
-            row.with_cell(
-              text: data_row.day0_to_last_day,
-              numeric: true,
-              classes: 'colgroup-total'
-            )
+        tabs.with_tab(label: work_stream.label) do # rubocop:disable Metrics/BlockLength
+          govuk_table(classes: ['app-table']) do |table| # rubocop:disable Metrics/BlockLength
+            table.with_caption { "#{work_stream.label} workload" }
+            table.with_colgroup do |colgroup|
+              colgroup.with_col(span: 1)
+              colgroup.with_col(span: 2)
+              colgroup.with_col(span: 6)
+            end
+
+            table.with_head do |head|
+              head.with_row(classes: 'colgroup-headers') do |row|
+                row.with_cell(text: '', colspan: 1, scope: 'colgroup')
+                row.with_cell(text: "From #{report.observed_business_period_text}", numeric: true, colspan: 2, scope: 'colgroup', classes: [])
+                row.with_cell(text: "Applications still open by age in business days at #{report.observed_at_time}", colspan: 6, scope: 'colgroup')
+              end
+
+              head.with_row(classes: 'colgroup-details') do |row|
+                row.with_cell(text: '')
+                row.with_cell(text: 'Received', numeric: true, classes: 'colgroup-total')
+                row.with_cell(text: 'Closed', numeric: true, classes: 'colgroup-total')
+                row.with_cell(text: '0 days', numeric: true, classes: 'colgroup-detail')
+                row.with_cell(text: '1 day', numeric: true, classes: 'colgroup-detail')
+                row.with_cell(text: '2 days', numeric: true, classes: 'colgroup-detail')
+                row.with_cell(text: '3 days', numeric: true, classes: 'colgroup-detail')
+                row.with_cell(text: '4-9 days', numeric: true, classes: 'colgroup-detail')
+                row.with_cell(text: 'Total', numeric: true, classes: 'colgroup-total')
+              end
+            end
+
+            table.with_body do |body| # rubocop:disable Metrics/BlockLength
+              data_rows.each do |data_row| # rubocop:disable Metrics/BlockLength
+                body.with_row do |row| # rubocop:disable Metrics/BlockLength
+                  row.with_cell(
+                    text: t(data_row.application_type, scope: :values),
+                    header: true
+                  )
+                  row.with_cell(
+                    text: data_row.received_this_business_day,
+                    numeric: true,
+                    classes: 'colgroup-total'
+                  )
+                  row.with_cell(
+                    text: data_row.closed_this_business_day,
+                    numeric: true,
+                    classes: 'colgroup-total'
+                  )
+                  row.with_cell(
+                    text: data_row.day0,
+                    numeric: true,
+                    classes: 'colgroup-detail'
+                  )
+                  row.with_cell(
+                    text: data_row.day1,
+                    numeric: true,
+                    classes: 'colgroup-detail'
+                  )
+                  row.with_cell(
+                    text: data_row.day2,
+                    numeric: true,
+                    classes: 'colgroup-detail'
+                  )
+                  row.with_cell(
+                    text: data_row.day3,
+                    numeric: true,
+                    classes: 'colgroup-detail'
+                  )
+                  row.with_cell(
+                    text: data_row.day4_to_last_day,
+                    numeric: true,
+                    classes: 'colgroup-detail'
+                  )
+                  row.with_cell(
+                    text: data_row.day0_to_last_day,
+                    numeric: true,
+                    classes: 'colgroup-total'
+                  )
+                end
+              end
+
+              body.with_row(classes: 'total') do |row| # rubocop:disable Metrics/BlockLength
+                row.with_cell(
+                  text: 'Total',
+                  header: true
+                )
+                row.with_cell(
+                  text: data_rows.sum(&:received_this_business_day),
+                  numeric: true,
+                  classes: 'colgroup-total'
+                )
+                row.with_cell(
+                  text: data_rows.sum(&:closed_this_business_day),
+                  numeric: true,
+                  classes: 'colgroup-total'
+                )
+                row.with_cell(
+                  text: data_rows.sum(&:day0),
+                  numeric: true,
+                  classes: 'colgroup-detail'
+                )
+                row.with_cell(
+                  text: data_rows.sum(&:day1),
+                  numeric: true,
+                  classes: 'colgroup-detail'
+                )
+                row.with_cell(
+                  text: data_rows.sum(&:day2),
+                  numeric: true,
+                  classes: 'colgroup-detail'
+                )
+                row.with_cell(
+                  text: data_rows.sum(&:day3),
+                  numeric: true,
+                  classes: 'colgroup-detail'
+                )
+                row.with_cell(
+                  text: data_rows.sum(&:day4_to_last_day),
+                  numeric: true,
+                  classes: 'colgroup-detail'
+                )
+                row.with_cell(
+                  text: data_rows.sum(&:day0_to_last_day),
+                  numeric: true,
+                  classes: 'colgroup-total'
+                )
+              end
+            end
           end
         end
-        body.with_row(classes: 'total') do |row|
-          row.with_cell(
-            text: 'Total',
-            header: true
-          )
-          row.with_cell(
-            text: report.rows.sum(&:received_this_business_day),
-            numeric: true,
-            classes: 'colgroup-total'
-          )
-          row.with_cell(
-            text: report.rows.sum(&:closed_this_business_day),
-            numeric: true,
-            classes: 'colgroup-total'
-          )
-          row.with_cell(
-            text: report.rows.sum(&:day0),
-            numeric: true,
-            classes: 'colgroup-detail'
-          )
-          row.with_cell(
-            text: report.rows.sum(&:day1),
-            numeric: true,
-            classes: 'colgroup-detail'
-          )
-          row.with_cell(
-            text: report.rows.sum(&:day2),
-            numeric: true,
-            classes: 'colgroup-detail'
-          )
-          row.with_cell(
-            text: report.rows.sum(&:day3),
-            numeric: true,
-            classes: 'colgroup-detail'
-          )
-          row.with_cell(
-            text: report.rows.sum(&:day4_to_last_day),
-            numeric: true,
-            classes: 'colgroup-detail'
-          )
-          row.with_cell(
-            text: report.rows.sum(&:day0_to_last_day),
-            numeric: true,
-            classes: 'colgroup-total'
-          )
-        end
       end
-
-      # rubocop:enable Metrics/BlockLength
     end %>

--- a/db/migrate/20240315132443_add_appplication_type_to_review_read_model.rb
+++ b/db/migrate/20240315132443_add_appplication_type_to_review_read_model.rb
@@ -1,0 +1,6 @@
+class AddAppplicationTypeToReviewReadModel < ActiveRecord::Migration[7.1]
+  def change
+    add_column :reviews, :application_type, :string, default: Types::ApplicationType['initial']
+    add_index :reviews, :application_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_29_145427) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_15_132443) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -66,7 +66,9 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_29_145427) do
     t.date "business_day"
     t.string "work_stream", default: "criminal_applications_team"
     t.date "reviewed_on"
+    t.string "application_type", default: "initial"
     t.index ["application_id"], name: "index_reviews_on_application_id", unique: true
+    t.index ["application_type"], name: "index_reviews_on_application_type"
     t.index ["business_day"], name: "index_reviews_on_business_day"
     t.index ["parent_id"], name: "index_reviews_on_parent_id"
     t.index ["reviewed_on"], name: "index_reviews_on_reviewed_on"

--- a/spec/models/reporting/workload_report_spec.rb
+++ b/spec/models/reporting/workload_report_spec.rb
@@ -8,11 +8,34 @@ RSpec.describe Reporting::WorkloadReport do
   describe '#rows' do
     subject(:rows) { report.rows }
 
-    it 'returns a row for each work stream by default' do
-      expect(rows.size).to eq(3)
-      expect(rows.map(&:work_stream)).to contain_exactly(
-        'criminal_applications_team', 'criminal_applications_team_2', 'extradition'
-      )
+    describe 'CAT 1 rows' do
+      let(:rows) { report.rows.first }
+
+      it 'returns expected rows' do
+        expect(rows.map(&:work_stream)).to all eq(WorkStream.new('criminal_applications_team'))
+
+        expect(rows.map(&:application_type)).to contain_exactly('initial', 'post_submission_evidence')
+      end
+    end
+
+    describe 'CAT 2 rows' do
+      let(:rows) { report.rows.second }
+
+      it 'returns expected rows' do
+        expect(rows.map(&:work_stream)).to all eq(WorkStream.new('criminal_applications_team_2'))
+
+        expect(rows.map(&:application_type)).to contain_exactly('initial', 'post_submission_evidence')
+      end
+    end
+
+    describe 'Extradition rows' do
+      let(:rows) { report.rows.last }
+
+      it 'returns expected rows' do
+        expect(rows.map(&:work_stream)).to all eq(WorkStream.new('extradition'))
+
+        expect(rows.map(&:application_type)).to contain_exactly('initial', 'post_submission_evidence')
+      end
     end
   end
 

--- a/spec/read_models/received_on_reports/projection_spec.rb
+++ b/spec/read_models/received_on_reports/projection_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ReceivedOnReports::Projection do
-  # rubocop:disable RSpec/MultipleMemoizedHelpers
+  # rubocop:disable RSpec/MultipleMemoizedHelpers, RSpec/IndexedLet
   let(:event_store) { Rails.configuration.event_store }
 
   describe 'instance' do
@@ -9,8 +9,10 @@ RSpec.describe ReceivedOnReports::Projection do
     let(:split_time) { Time.zone.local(2023, 10, 5, 1, 21) }
     let(:observed_at) { Time.current }
     let(:cat1) { Types::WorkStreamType['criminal_applications_team'] }
+    let(:cat2) { Types::WorkStreamType['criminal_applications_team_2'] }
     let(:extradition) { Types::WorkStreamType['extradition'] }
     let(:initial) { Types::ApplicationType['initial'] }
+    let(:pse) { Types::ApplicationType['post_submission_evidence'] }
 
     describe '#dataset' do
       subject(:dataset) { described_class.new(stream_name:, observed_at:).dataset }
@@ -20,12 +22,12 @@ RSpec.describe ReceivedOnReports::Projection do
         # We use the "split_time" to test being able to observe the stream at a given time.
         travel_to split_time - 1.day
 
-        a, b, c, d = Array.new(4) { SecureRandom.uuid }
+        a, b, c, d, = Array.new(4) { SecureRandom.uuid }
 
-        # Receive three CAT 1 and one extradition application
+        # Receive four CAT 1 (including 1 PSE) and one extradition application
         receive_application(a, cat1, initial)
         receive_application(b, cat1, initial)
-        receive_application(c, cat1, initial)
+        receive_application(c, cat1, pse)
         receive_application(d, extradition, initial)
 
         event_store.publish(Reviewing::Completed.new(
@@ -48,25 +50,41 @@ RSpec.describe ReceivedOnReports::Projection do
         travel_back
       end
 
-      let(:cat1_data) { dataset.fetch(cat1) }
-      let(:extradition_data) { dataset.fetch(extradition) }
+      let(:cat1_initial) { dataset.dig(cat1, initial) }
+      let(:cat1_pse) { dataset.dig(cat1, pse) }
+      let(:extradition_initial) { dataset.dig(extradition, initial) }
+      let(:extradition_pse) { dataset.dig(extradition, pse) }
 
-      it 'returns a tally of received applications by work stream' do
-        expect(cat1_data.total_received).to be 3
-        expect(extradition_data.total_received).to be 1
+      describe 'cat1 workstream data' do
+        it 'returns a tally of received applications by application type' do
+          expect(cat1_initial.total_received).to be 2
+          expect(cat1_pse.total_received).to be 1
+        end
+
+        it 'returns a tally of closed applications by application type' do
+          expect(cat1_initial.total_closed).to be 1
+          expect(cat1_pse.total_closed).to be 1
+        end
       end
 
-      it 'returns a tally of closed applications by work stream' do
-        expect(cat1_data.total_closed).to be 2
-        expect(extradition_data.total_closed).to be 1
+      describe 'extradition workstream data' do
+        it 'returns a tally of received applications by application type' do
+          expect(extradition_initial.total_received).to be 1
+          expect(extradition_pse.total_received).to be 0
+        end
+
+        it 'returns a tally of closed applications by application type' do
+          expect(extradition_initial.total_closed).to be 1
+          expect(extradition_pse.total_closed).to be 0
+        end
       end
 
       context 'when observing 1 second before an event' do
         let(:observed_at) { split_time.in_time_zone('London') - 1.second }
 
         it 'excludes the event from the tally' do
-          expect(cat1_data.total_closed).to be 1
-          expect(extradition_data.total_closed).to be 0
+          expect(cat1_pse.total_closed).to be 0
+          expect(extradition_initial.total_closed).to be 0
         end
       end
 
@@ -74,8 +92,8 @@ RSpec.describe ReceivedOnReports::Projection do
         let(:observed_at) { split_time.in_time_zone('London') }
 
         it 'includes the event in the tally' do
-          expect(cat1_data.total_closed).to be 2
-          expect(extradition_data.total_closed).to be 1
+          expect(cat1_pse.total_closed).to be 1
+          expect(extradition_initial.total_closed).to be 1
         end
       end
     end
@@ -98,7 +116,7 @@ RSpec.describe ReceivedOnReports::Projection do
       end
     end
   end
-  # rubocop:enable RSpec/MultipleMemoizedHelpers
+  # rubocop:enable RSpec/MultipleMemoizedHelpers, RSpec/IndexedLet
 
   def receive_application(application_id, work_stream, application_type)
     submitted_at = Time.current

--- a/spec/read_models/received_on_reports/projection_spec.rb
+++ b/spec/read_models/received_on_reports/projection_spec.rb
@@ -50,32 +50,32 @@ RSpec.describe ReceivedOnReports::Projection do
         travel_back
       end
 
-      let(:cat1_initial) { dataset.dig(cat1, initial) }
-      let(:cat1_pse) { dataset.dig(cat1, pse) }
-      let(:extradition_initial) { dataset.dig(extradition, initial) }
-      let(:extradition_pse) { dataset.dig(extradition, pse) }
+      let(:cat1_initial_row) { dataset.dig(cat1, initial) }
+      let(:cat1_pse_row) { dataset.dig(cat1, pse) }
+      let(:extradition_initial_row) { dataset.dig(extradition, initial) }
+      let(:extradition_pse_row) { dataset.dig(extradition, pse) }
 
       describe 'cat1 workstream data' do
         it 'returns a tally of received applications by application type' do
-          expect(cat1_initial.total_received).to be 2
-          expect(cat1_pse.total_received).to be 1
+          expect(cat1_initial_row.total_received).to be 2
+          expect(cat1_pse_row.total_received).to be 1
         end
 
         it 'returns a tally of closed applications by application type' do
-          expect(cat1_initial.total_closed).to be 1
-          expect(cat1_pse.total_closed).to be 1
+          expect(cat1_initial_row.total_closed).to be 1
+          expect(cat1_pse_row.total_closed).to be 1
         end
       end
 
       describe 'extradition workstream data' do
         it 'returns a tally of received applications by application type' do
-          expect(extradition_initial.total_received).to be 1
-          expect(extradition_pse.total_received).to be 0
+          expect(extradition_initial_row.total_received).to be 1
+          expect(extradition_pse_row.total_received).to be 0
         end
 
         it 'returns a tally of closed applications by application type' do
-          expect(extradition_initial.total_closed).to be 1
-          expect(extradition_pse.total_closed).to be 0
+          expect(extradition_initial_row.total_closed).to be 1
+          expect(extradition_pse_row.total_closed).to be 0
         end
       end
 
@@ -83,8 +83,8 @@ RSpec.describe ReceivedOnReports::Projection do
         let(:observed_at) { split_time.in_time_zone('London') - 1.second }
 
         it 'excludes the event from the tally' do
-          expect(cat1_pse.total_closed).to be 0
-          expect(extradition_initial.total_closed).to be 0
+          expect(cat1_pse_row.total_closed).to be 0
+          expect(extradition_initial_row.total_closed).to be 0
         end
       end
 
@@ -92,8 +92,8 @@ RSpec.describe ReceivedOnReports::Projection do
         let(:observed_at) { split_time.in_time_zone('London') }
 
         it 'includes the event in the tally' do
-          expect(cat1_pse.total_closed).to be 1
-          expect(extradition_initial.total_closed).to be 1
+          expect(cat1_pse_row.total_closed).to be 1
+          expect(extradition_initial_row.total_closed).to be 1
         end
       end
     end

--- a/spec/read_models/reviews/update_from_aggreate_spec.rb
+++ b/spec/read_models/reviews/update_from_aggreate_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Reviews::UpdateFromAggregate' do
     let(:state) { 'received' }
     let(:parent_id) { SecureRandom.uuid }
     let(:work_stream) { 'extradition' }
+    let(:application_type) { 'initial' }
     let(:reviewer_id) { SecureRandom.uuid }
     let(:reviewed_on) { Date.new(2023, 4, 23) }
 
@@ -18,7 +19,7 @@ RSpec.describe 'Reviews::UpdateFromAggregate' do
       aggregate = instance_double(
         Reviewing::Review,
         id:, state:, submitted_at:, reviewer_id:, parent_id:,
-        business_day:, work_stream:, reviewed_on:
+        business_day:, work_stream:, reviewed_on:, application_type:
       )
 
       allow(Reviewing::LoadReview).to receive(:call).with(application_id:) {
@@ -34,7 +35,7 @@ RSpec.describe 'Reviews::UpdateFromAggregate' do
       subject(:read_model) { Review.find_by(application_id:) }
 
       %i[application_id state submitted_at reviewer_id parent_id business_day
-         work_stream reviewed_on].each do |attribute|
+         work_stream reviewed_on application_type].each do |attribute|
         it "sets the #{attribute}" do
           expect(read_model.public_send(attribute)).to eq(send(attribute))
         end

--- a/spec/system/casework/open_applications_dashboard_spec.rb
+++ b/spec/system/casework/open_applications_dashboard_spec.rb
@@ -59,49 +59,47 @@ RSpec.describe 'Open Applications' do
     let(:inactive_sort_headers) { ['Applicant\'s name', 'Type of application'] }
   end
 
-  context 'when work stream feature flag in is enabled' do
-    it 'includes tabs for work streams' do
-      tabs = find(:xpath, "//div[@class='govuk-tabs']")
+  it 'includes tabs for work streams' do
+    tabs = find(:xpath, "//div[@class='govuk-tabs']")
 
-      expect(tabs).to have_content 'CAT 1 CAT 2 Extradition'
+    expect(tabs).to have_content 'CAT 1 CAT 2 Extradition'
+  end
+
+  context 'when viewing open applications by work stream' do
+    it 'searches for extradition open applications' do
+      click_on 'Extradition'
+      expect(page.find('.govuk-tabs__list-item--selected')).to have_content 'Extradition'
+      expect_datastore_to_have_been_searched_with(
+        { review_status: Types::REVIEW_STATUS_GROUPS['open'],
+          work_stream: %w[extradition] },
+        sorting: ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending')
+      )
     end
 
-    context 'when viewing open applications by work stream' do
-      it 'searches for extradition open applications' do
-        click_on 'Extradition'
-        expect(page.find('.govuk-tabs__list-item--selected')).to have_content 'Extradition'
-        expect_datastore_to_have_been_searched_with(
-          { review_status: Types::REVIEW_STATUS_GROUPS['open'],
-            work_stream: %w[extradition] },
-          sorting: ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending')
-        )
-      end
+    it 'shows the correct mini report' do
+      click_on 'CAT 2'
+      expect(report_turbo_link_work_stream_params).to eq ['cat_2']
+    end
 
-      it 'shows the correct mini report' do
-        click_on 'CAT 2'
-        expect(report_turbo_link_work_stream_params).to eq ['cat_2']
-      end
+    it 'searches for CAT 2 open applications' do
+      click_on 'CAT 2'
+      expect(page.find('.govuk-tabs__list-item--selected')).to have_content 'CAT 2'
+      expect_datastore_to_have_been_searched_with(
+        { review_status: Types::REVIEW_STATUS_GROUPS['open'],
+          work_stream: %w[criminal_applications_team_2] },
+        sorting: ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending')
+      )
+    end
 
-      it 'searches for CAT 2 open applications' do
-        click_on 'CAT 2'
-        expect(page.find('.govuk-tabs__list-item--selected')).to have_content 'CAT 2'
-        expect_datastore_to_have_been_searched_with(
-          { review_status: Types::REVIEW_STATUS_GROUPS['open'],
-            work_stream: %w[criminal_applications_team_2] },
-          sorting: ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending')
-        )
-      end
-
-      it 'searches for CAT 1 open applications' do
-        click_on 'CAT 1'
-        expect(page.find('.govuk-tabs__list-item--selected')).to have_content 'CAT 1'
-        expect_datastore_to_have_been_searched_with(
-          { review_status: Types::REVIEW_STATUS_GROUPS['open'],
-            work_stream: %w[criminal_applications_team] },
-          sorting: ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending'),
-          number_of_times: 2
-        )
-      end
+    it 'searches for CAT 1 open applications' do
+      click_on 'CAT 1'
+      expect(page.find('.govuk-tabs__list-item--selected')).to have_content 'CAT 1'
+      expect_datastore_to_have_been_searched_with(
+        { review_status: Types::REVIEW_STATUS_GROUPS['open'],
+          work_stream: %w[criminal_applications_team] },
+        sorting: ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending'),
+        number_of_times: 2
+      )
     end
 
     context 'with a caseworker that access to only one work stream' do

--- a/spec/system/reporting/snapshot_reports_spec.rb
+++ b/spec/system/reporting/snapshot_reports_spec.rb
@@ -22,19 +22,6 @@ RSpec.describe 'Snapshot report' do
       expect(page.title).to have_text 'Workload report'
     end
 
-    it 'shows the correct column headers' do
-      expected_headers = ['', 'Received', 'Closed', '0 days', '1 day', '2 days', '3 days', '4-9 days', 'Total']
-
-      page.all('table thead tr.colgroup-details th').each_with_index do |el, i|
-        expect(el).to have_content expected_headers[i]
-      end
-    end
-
-    it 'shows the correct row headers for each work stream' do
-      column = all('table tbody tr th:first-child').map(&:text)
-      expect(column).to eq ['CAT 1', 'CAT 2', 'Extradition', 'Total']
-    end
-
     it 'can navigate to the end of the the previous day' do
       expect { click_link(previous_day) }.to change { current_path }
         .from('/reporting/workload_report/now')

--- a/spec/system/reporting/workload_report_spec.rb
+++ b/spec/system/reporting/workload_report_spec.rb
@@ -13,20 +13,33 @@ RSpec.describe 'Workload Report' do
   it 'shows the correct detail column headers' do
     expected_headers = ['', 'Received', 'Closed', '0 days', '1 day', '2 days', '3 days', '4-9 days', 'Total']
 
-    page.all('table thead tr.colgroup-details th').each_with_index do |el, i|
-      expect(el).to have_content expected_headers[i]
+    within('#cat-1') do
+      page.all('table thead tr.colgroup-details th').each_with_index do |el, i|
+        expect(el).to have_content expected_headers[i]
+      end
+    end
+  end
+
+  it 'shows the expected caption' do
+    expected_captions = [
+      'CAT 1 workload',
+      'CAT 2 workload',
+      'Extradition workload'
+    ]
+
+    page.all('table caption').each_with_index do |el, i|
+      expect(el).to have_content expected_captions[i]
     end
   end
 
   it 'shows the expected colgroup headers' do
-    expected_headers = [
-      '',
-      'From 00:00 until 23:59',
-      'Applications still open by age in business days at 23:59'
-    ]
+    expected_headers = ['', 'From 00:00 until 23:59',
+                        'Applications still open by age in business days at 23:59']
 
-    page.all('table thead tr.colgroup-headers th').each_with_index do |el, i|
-      expect(el).to have_content expected_headers[i]
+    within('#cat-1') do
+      page.all('table thead tr.colgroup-headers th').each_with_index do |el, i|
+        expect(el).to have_content expected_headers[i]
+      end
     end
   end
 
@@ -39,7 +52,9 @@ RSpec.describe 'Workload Report' do
   end
 
   it 'shows the correct row headers for each work stream' do
-    column = all('table tbody tr th:first-child').map(&:text)
-    expect(column).to eq ['CAT 1', 'CAT 2', 'Extradition', 'Total']
+    within('#cat-1') do
+      column = all('table tbody tr th:first-child').map(&:text)
+      expect(column).to eq ['Initial application', 'Post submission evidence', 'Total']
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Add separate rows for `initial` and `pse` in the workload report.
Show each workstream as a separate table in the workload report.
Store application_type on Review read model.

## Link to relevant ticket
[CRIMAPP-626](https://dsdmoj.atlassian.net/browse/CRIMAPP-626)

## Notes for reviewer
This is required for release of PSE

## Screenshots of changes (if applicable)

### Before changes:
<img width="1064" alt="Screenshot 2024-03-19 at 15 59 48" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/1294527a-23a1-4152-b527-a87f6f68e9e1">


### After changes:
<img width="1194" alt="Screenshot 2024-03-19 at 15 59 09" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/dfd12391-795b-4d16-920c-3b57c78c9d7e">


## How to manually test the feature


[CRIMAPP-626]: https://dsdmoj.atlassian.net/browse/CRIMAPP-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ