### PR TITLE
CRIMAPP-348 sort by application type

### DIFF
--- a/app/models/application_search_sorting.rb
+++ b/app/models/application_search_sorting.rb
@@ -1,10 +1,11 @@
 class ApplicationSearchSorting < ApplicationStruct
   SORTABLE_COLUMNS = %w[
+    applicant_name
+    application_type
+    case_type
+    reviewed_at
     submitted_at
     time_passed
-    reviewed_at
-    applicant_name
-    case_type
   ].freeze
 
   DEFAULT_SORT_BY = 'submitted_at'.freeze

--- a/spec/system/casework/assigning/viewing_your_assigned_applications_spec.rb
+++ b/spec/system/casework/assigning/viewing_your_assigned_applications_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'Viewing your assigned application' do
     it_behaves_like 'a table with sortable headers' do
       let(:active_sort_headers) { ['Date received', 'Business days since application was received'] }
       let(:active_sort_direction) { 'ascending' }
-      let(:inactive_sort_headers) { ['Applicant\'s name'] }
+      let(:inactive_sort_headers) { ['Applicant\'s name', 'Type of application'] }
     end
   end
 

--- a/spec/system/casework/closed_applications_dashboard_spec.rb
+++ b/spec/system/casework/closed_applications_dashboard_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'Closed Applications' do
   it_behaves_like 'a table with sortable headers' do
     let(:active_sort_headers) { ['Date closed'] }
     let(:active_sort_direction) { 'descending' }
-    let(:inactive_sort_headers) { ['Applicant\'s name', 'Date received'] }
+    let(:inactive_sort_headers) { ['Applicant\'s name', 'Date received', 'Type of application'] }
   end
 
   context 'when work stream feature flag is enabled' do

--- a/spec/system/casework/open_applications_dashboard_spec.rb
+++ b/spec/system/casework/open_applications_dashboard_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Open Applications' do
   it_behaves_like 'a table with sortable headers' do
     let(:active_sort_headers) { ['Date received', 'Business days since application was received'] }
     let(:active_sort_direction) { 'ascending' }
-    let(:inactive_sort_headers) { ['Applicant\'s name'] }
+    let(:inactive_sort_headers) { ['Applicant\'s name', 'Type of application'] }
   end
 
   context 'when work stream feature flag in is enabled' do

--- a/spec/system/casework/searching/sorting_search_results_spec.rb
+++ b/spec/system/casework/searching/sorting_search_results_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Sorting search results' do
   it_behaves_like 'a table with sortable headers' do
     let(:active_sort_headers) { ['Date received'] }
     let(:active_sort_direction) { 'ascending' }
-    let(:inactive_sort_headers) { ['Applicant\'s name', 'Case type', 'Date closed'] }
+    let(:inactive_sort_headers) { ['Applicant\'s name', 'Case type', 'Date closed', 'Type of application'] }
   end
 
   describe 'Search results remain after sorting' do


### PR DESCRIPTION
## Description of change
Add sorting by application type to open applications, closed applications, search and your list pages.

## Link to relevant ticket
[CRIMAPP-348](https://dsdmoj.atlassian.net/browse/CRIMAPP-348)

## Notes for reviewer
requires https://github.com/ministryofjustice/laa-criminal-applications-datastore/compare/CRIMAPP-348-sort-by-application-type?expand=1

## Screenshots of changes (if applicable)

### Search before changes:

<img width="1130" alt="Screenshot 2024-03-19 at 17 09 04" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/21cfdb28-8f2b-42bf-bf29-c30be0e71cf3">

### Search after changes:

<img width="1038" alt="Screenshot 2024-03-19 at 17 08 13" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/5bd057dc-21a4-4fe5-9e87-7c022ff7f366">

### Open apps before changes:

<img width="1032" alt="Screenshot 2024-03-19 at 17 08 53" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/2b01d7ee-46d4-485b-bbea-167591d8f00c">

### Open apps after changes:

<img width="1030" alt="Screenshot 2024-03-19 at 17 08 22" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/c8828836-229a-4a84-a437-988d399e367f">


## How to manually test the feature

[CRIMAPP-348]: https://dsdmoj.atlassian.net/browse/CRIMAPP-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ