### PR TITLE
CRIMAPP-646 change competency defaults

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,3 +89,7 @@ RSpec/ExpectChange:
 
 Capybara/ClickLinkOrButtonStyle:
   Enabled: false
+
+Style/RedundantConstantBase:
+  Exclude:
+    - 'app/views/**/*'

--- a/app/controllers/concerns/work_streamable.rb
+++ b/app/controllers/concerns/work_streamable.rb
@@ -11,7 +11,11 @@ module WorkStreamable
   attr_reader :current_work_stream
 
   def set_current_work_stream
-    work_stream = WorkStream.from_param(work_stream_param)
+    work_stream = if work_stream_param
+                    WorkStream.from_param(work_stream_param)
+                  else
+                    current_user.work_streams.first
+                  end
 
     raise Allocating::WorkStreamNotFound unless current_user.work_streams.include?(work_stream)
 
@@ -21,7 +25,13 @@ module WorkStreamable
   end
 
   def work_stream_param
-    params[:work_stream] || session[:current_work_stream] || current_user.work_streams.first.to_param
+    params[:work_stream] || work_stream_session_param
+  end
+
+  def work_stream_session_param
+    return nil unless current_user.work_streams.map(&:to_param).include?(session[:current_work_stream])
+
+    session[:current_work_stream]
   end
 
   def require_app_work_stream

--- a/app/controllers/manage_competencies/caseworker_competencies_controller.rb
+++ b/app/controllers/manage_competencies/caseworker_competencies_controller.rb
@@ -1,18 +1,24 @@
 module ManageCompetencies
   class CaseworkerCompetenciesController < BaseController
     def index
-      @caseworkers = User.caseworker.order(first_name: :asc, last_name: :asc).page params[:page]
+      @caseworkers = user_scope.order(first_name: :asc, last_name: :asc).page params[:page]
     end
 
     def edit
-      @caseworker = User.caseworker.find(params[:id])
+      @caseworker = user_scope.find(params[:id])
     end
 
     def update
-      @caseworker = User.caseworker.find(params[:id])
+      user = user_scope.find(params[:id])
       competencies = permitted_params[:competencies].compact_blank
-      Allocating::SetCompetencies.call(user: @caseworker, by_whom: current_user, competencies: competencies)
-      set_flash(:competencies_updated, user_name: @caseworker.name)
+
+      Allocating::SetCompetencies.call(
+        user: user,
+        by_whom: current_user,
+        competencies: competencies
+      )
+
+      set_flash(:competencies_updated, user_name: user.name)
       redirect_to manage_competencies_root_path
     end
 
@@ -20,6 +26,13 @@ module ManageCompetencies
 
     def permitted_params
       params.require(:user).permit(competencies: [])
+    end
+
+    def user_scope
+      User.active.where(
+        role: [Types::CASEWORKER_ROLE, Types::SUPERVISOR_ROLE],
+        can_manage_others: false
+      )
     end
   end
 end

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -84,7 +84,6 @@ module Types
   SortBy = String.default('submitted_at'.freeze).enum(*SORTABLE_COLUMNS)
 
   APPLICATION_TYPE_COMPETENCIES = %w[
-
     post_submission_evidence
     initial
   ].freeze

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -83,11 +83,19 @@ module Types
   ].freeze
   SortBy = String.default('submitted_at'.freeze).enum(*SORTABLE_COLUMNS)
 
-  CompetencyType = String.enum(*%w[
-                                 criminal_applications_team
-                                 criminal_applications_team_2
-                                 extradition
-                                 post_submission_evidence
-                                 initial
-                               ])
+  APPLICATION_TYPE_COMPETENCIES = %w[
+
+    post_submission_evidence
+    initial
+  ].freeze
+
+  WORK_STREAM_COMPETENCIES = %w[
+    criminal_applications_team
+    criminal_applications_team_2
+    extradition
+  ].freeze
+
+  CompetencyType = String.enum(
+    *WORK_STREAM_COMPETENCIES, *APPLICATION_TYPE_COMPETENCIES
+  )
 end

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -88,5 +88,6 @@ module Types
                                  criminal_applications_team_2
                                  extradition
                                  post_submission_evidence
+                                 initial
                                ])
 end

--- a/app/models/concerns/user_competence.rb
+++ b/app/models/concerns/user_competence.rb
@@ -11,15 +11,10 @@ module UserCompetence
   def application_types_competencies
     return [] if data_analyst?
 
-    competencies_incl_initial = competencies.dup << Types::ApplicationType['initial']
-    @application_types_competencies ||= (competencies_incl_initial &
-      Types::ApplicationType.values).map do |application_type|
-      application_type
-    end
+    @application_types_competencies ||= competencies & Types::ApplicationType.values
   end
 
   def competencies
-    return Types::CompetencyType.values.dup if supervisor?
     return [] if data_analyst?
 
     @competencies ||= Allocating.user_competencies(id)

--- a/app/models/get_next.rb
+++ b/app/models/get_next.rb
@@ -1,5 +1,6 @@
 class GetNext
   def initialize(work_streams:, application_types:)
+    @application_types = application_types
     filter = ApplicationSearchFilter.new(assigned_status: 'unassigned', work_stream: work_streams,
                                          application_type: application_types)
     pagination = Pagination.new(limit_value: 1)
@@ -8,6 +9,8 @@ class GetNext
   end
 
   def call
+    return nil if @application_types.empty?
+
     @search.results.first&.id
   end
 

--- a/app/presenters/caseworker_presenter.rb
+++ b/app/presenters/caseworker_presenter.rb
@@ -1,6 +1,4 @@
 class CaseworkerPresenter < BasePresenter
-  CASEWORKER_COMPETENCIES = Types::CompetencyType.values
-
   def formatted_user_competencies
     if Allocating.user_competencies(id).present?
       competencies = Allocating.user_competencies(id).map { |c| t(c, scope: 'labels') }

--- a/app/views/manage_competencies/caseworker_competencies/edit.html.erb
+++ b/app/views/manage_competencies/caseworker_competencies/edit.html.erb
@@ -3,13 +3,22 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= form_with(url: manage_competencies_caseworker_competency_path(id: @caseworker), model: @caseworker, method: :patch) do |f| %>
+      <%= f.govuk_check_boxes_fieldset :competencies, legend: { text: confirm_text(:change_competencies, user_name: @caseworker.name, from: @caseworker.role.humanize), size: 'xl' }, hint: { text: t('manage_competencies.hint') } do %>
 
-      <%= f.govuk_check_boxes_fieldset :competencies, legend: { text: confirm_text(:change_competencies, user_name: @caseworker.name, from: @caseworker.role.humanize), size: 'xl' } do %>
-        <div class="govuk-hint"> <%= t('manage_competencies.hint') %></div>
-        <% CaseworkerPresenter::CASEWORKER_COMPETENCIES.each_with_index do |competency| %>
-          <%= f.govuk_check_box :competencies, competency, label: { text: t(competency, scope: 'labels') } %>
+        <%= f.govuk_check_boxes_fieldset :competencies, legend: { text: label_text(:work_stream_competencies), size: 's' } do %>
+          <% ::Types::WORK_STREAM_COMPETENCIES.each do |competency| %>
+            <%= f.govuk_check_box :competencies, competency, label: { text: t(competency, scope: 'labels') } %>
+          <% end %>
         <% end %>
+
+        <%= f.govuk_check_boxes_fieldset :competencies, legend: { text: label_text(:application_type_competencies), size: 's' } do %>
+          <% ::Types::APPLICATION_TYPE_COMPETENCIES.each do |competency| %>
+            <%= f.govuk_check_box :competencies, competency, label: { text: t(competency, scope: 'labels') } %>
+          <% end %>
+        <% end %>
+
         <%= f.govuk_check_box_divider %>
+
         <%= f.govuk_check_box :competencies, [], exclusive: true, label: { text: 'No competencies' }, checked: f.object.competencies.empty? %>
       <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
     extradition: Extradition
     national_crime_team: CAT 2
     criminal_applications_team: CAT 1
+    initial: Initial
 
   number:
     currency:

--- a/config/locales/en/manage_competencies.yml
+++ b/config/locales/en/manage_competencies.yml
@@ -32,7 +32,11 @@ en:
     actions:
       save: Save
 
-    hint: Select all that apply.
+    hint: Select all that apply
+    
+    labels:
+      application_type_competencies: Types of application
+      work_stream_competencies: Work queuest
 
     flash:
       success:

--- a/config/locales/en/manage_competencies.yml
+++ b/config/locales/en/manage_competencies.yml
@@ -36,7 +36,7 @@ en:
     
     labels:
       application_type_competencies: Types of application
-      work_stream_competencies: Work queuest
+      work_stream_competencies: Work queues
 
     flash:
       success:

--- a/spec/controllers/concerns/work_streamable_spec.rb
+++ b/spec/controllers/concerns/work_streamable_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/FilePath, RSpec/SpecFilePathFormat
+
+RSpec.describe ApplicationController do
+  controller do
+    include WorkStreamable
+    before_action :set_current_work_stream
+
+    def index
+      render plain: current_work_stream
+    end
+  end
+
+  describe 'GET #index' do
+    subject(:request) { get :index, params: }
+
+    let(:params) { {} }
+    let(:user) { instance_double(User, work_streams: user_work_streams) }
+    let(:user_work_streams) { WorkStream.all }
+
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+    end
+
+    context 'when a work_stream param is present' do
+      let(:params) { { work_stream: 'cat_2' } }
+
+      context 'when the user has the requested work stream as a competency' do
+        it 'sets current_work_stream to be that of the param' do
+          request
+          expect(response.body).to eq 'criminal_applications_team_2'
+        end
+      end
+
+      context 'when the user does not have requested work stream as a competency' do
+        let(:user_work_streams) { [WorkStream.new('criminal_applications_team')] }
+
+        it 'raises an Allocating::WorkStreamNotFound' do
+          expect { request }.to raise_error Allocating::WorkStreamNotFound
+        end
+      end
+    end
+
+    context 'when neither work_stream_param nor session param is present' do
+      it 'sets current_work_stream to the users first work stream' do
+        request
+        expect(response.body).to eq user_work_streams.first.to_s
+      end
+    end
+
+    context 'when the current work_stream is set in the session' do
+      before do
+        session[:current_work_stream] = 'extradition'
+      end
+
+      context 'when the user has the session work_stream as a competency' do
+        it 'sets current_work_stream to the session work stream' do
+          request
+          expect(response.body).to eq 'extradition'
+        end
+      end
+
+      context 'when the user does not have the session work stream as a competency' do
+        let(:user_work_streams) { [WorkStream.new('criminal_applications_team')] }
+
+        it 'sets current_work_stream to the users first work stream' do
+          request
+          expect(response.body).to eq 'criminal_applications_team'
+        end
+      end
+
+      context 'when the user does not have any competencies' do
+        let(:user_work_streams) { [] }
+
+        it 'raises an Allocating::WorkStreamNotFound' do
+          expect { request }.to raise_error Allocating::WorkStreamNotFound
+        end
+      end
+    end
+  end
+end
+
+# rubocop:enable RSpec/FilePath, RSpec/SpecFilePathFormat

--- a/spec/models/concerns/user_competence_spec.rb
+++ b/spec/models/concerns/user_competence_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe UserCompetence do
   describe '#work_streams' do
     subject(:work_streams) { user.work_streams }
 
-    it 'defaults to an empty array' do
-      expect(work_streams).to eq []
-    end
+    it { is_expected.to be_empty }
 
     context 'when a user has competencies assgined' do
       before do
@@ -17,18 +15,14 @@ RSpec.describe UserCompetence do
         )
       end
 
-      it 'returns an array of users competencies that are work streams' do
-        expect(work_streams).to eq ['extradition']
-      end
+      it { is_expected.to eq %w[extradition] }
     end
   end
 
   describe '#competencies' do
     subject(:competencies) { user.competencies }
 
-    it 'defaults to an empty array' do
-      expect(competencies).to eq []
-    end
+    it { is_expected.to be_empty }
 
     context 'when a user has competencies assigned' do
       before do
@@ -37,25 +31,18 @@ RSpec.describe UserCompetence do
         )
       end
 
-      it 'returns an array of assigned competencies' do
-        expect(competencies).to eq %w[crime_applications_team post_submission_evidence]
-      end
+      it { is_expected.to eq %w[crime_applications_team post_submission_evidence] }
 
       context 'when user is a supervisor' do
         let(:user) { User.new(role: 'supervisor') }
 
-        it 'returns all work_streams regardless of competencies' do
-          expect(competencies).to eq %w[criminal_applications_team criminal_applications_team_2 extradition
-                                        post_submission_evidence]
-        end
+        it { is_expected.to eq %w[crime_applications_team post_submission_evidence] }
       end
 
       context 'when user is a data analyst' do
         let(:user) { User.new(role: 'data_analyst') }
 
-        it 'returns no competencies' do
-          expect(competencies).to be_empty
-        end
+        it { is_expected.to be_empty }
       end
     end
   end
@@ -63,35 +50,27 @@ RSpec.describe UserCompetence do
   describe '#application_types_competencies' do
     subject(:application_types_competencies) { user.application_types_competencies }
 
-    it 'defaults to a initial application type' do
-      expect(application_types_competencies).to eq ['initial']
-    end
+    it { is_expected.to be_empty }
 
-    context 'when a user has post submission evidence assigned' do
+    context 'when a user has competencies assigned' do
       before do
         allow(Allocating).to receive(:user_competencies).with(user.id).and_return(
-          %w[crime_applications_team post_submission_evidence]
+          %w[crime_applications_team post_submission_evidence extradition initial]
         )
       end
 
-      it 'returns an array of assigned application types' do
-        expect(application_types_competencies).to eq %w[post_submission_evidence initial]
-      end
+      it { is_expected.to eq %w[post_submission_evidence initial] }
 
       context 'when user is a supervisor' do
         let(:user) { User.new(role: 'supervisor') }
 
-        it 'returns all application types regardless of assigned competencies' do
-          expect(application_types_competencies).to eq %w[post_submission_evidence initial]
-        end
+        it { is_expected.to eq %w[post_submission_evidence initial] }
       end
 
       context 'when user is a data analyst' do
         let(:user) { User.new(role: 'data_analyst') }
 
-        it 'returns no application type competencies' do
-          expect(application_types_competencies).to be_empty
-        end
+        it { is_expected.to be_empty }
       end
     end
   end

--- a/spec/shared_contexts/with_a_logged_in_user.rb
+++ b/spec/shared_contexts/with_a_logged_in_user.rb
@@ -2,7 +2,6 @@ RSpec.shared_context 'with a logged in user', shared_context: :metadata do
   before do
     current_user
 
-    # Supervisors get all competencies by default
     unless current_user.supervisor?
       allow(Allocating).to receive(:user_competencies).with(current_user.id) { current_user_competencies }
     end
@@ -34,5 +33,5 @@ RSpec.shared_context 'with a logged in user', shared_context: :metadata do
 
   let(:current_user_auth_subject_id) { SecureRandom.uuid }
 
-  let(:current_user_competencies) { Types::WorkStreamType.values }
+  let(:current_user_competencies) { Types::CompetencyType.values }
 end

--- a/spec/system/casework/assigning/get_next_application_spec.rb
+++ b/spec/system/casework/assigning/get_next_application_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe 'Assigning an application to myself' do
     include_context 'with stubbed assignments and reviews'
     include_context 'when search results are returned'
 
+    let(:current_user_competencies) { Types::CompetencyType.values }
+
     before do
       visit '/'
     end
@@ -46,6 +48,16 @@ RSpec.describe 'Assigning an application to myself' do
 
         it 'only gets next from the specified work stream' do
           expect_datastore_to_have_been_searched_with(expected_params, pagination: Pagination.new(limit_value: 1))
+        end
+      end
+
+      context 'when competent in no application types' do
+        let(:current_user_competencies) { [Types::WorkStreamType['extradition']] }
+        let(:gets_next_from) { [Types::WorkStreamType['extradition']] }
+        let(:get_next_types) { [Types::ApplicationType['initial']] }
+
+        it 'only gets next from the specified work stream' do
+          expect(page).to have_content('There are no new applications to be reviewed')
         end
       end
     end

--- a/spec/system/casework/assigning/get_next_application_spec.rb
+++ b/spec/system/casework/assigning/get_next_application_spec.rb
@@ -25,13 +25,14 @@ RSpec.describe 'Assigning an application to myself' do
         ApplicationSearchFilter.new(
           assigned_status: 'unassigned',
           work_stream: gets_next_from,
-          application_type: ['initial']
+          application_type: get_next_types
         ).datastore_params
       end
 
       context 'when competent in all work streams' do
-        let(:current_user_competencies) { Types::WorkStreamType.values }
+        let(:current_user_competencies) { Types::CompetencyType.values }
         let(:gets_next_from) { Types::WorkStreamType.values }
+        let(:get_next_types) { [Types::ApplicationType['post_submission_evidence'], Types::ApplicationType['initial']] }
 
         it 'gets next across all work streams' do
           expect_datastore_to_have_been_searched_with(expected_params, pagination: Pagination.new(limit_value: 1))
@@ -39,8 +40,9 @@ RSpec.describe 'Assigning an application to myself' do
       end
 
       context 'when competent in only one work streams' do
-        let(:current_user_competencies) { [Types::WorkStreamType['extradition']] }
+        let(:current_user_competencies) { [Types::WorkStreamType['extradition'], Types::ApplicationType['initial']] }
         let(:gets_next_from) { [Types::WorkStreamType['extradition']] }
+        let(:get_next_types) { [Types::ApplicationType['initial']] }
 
         it 'only gets next from the specified work stream' do
           expect_datastore_to_have_been_searched_with(expected_params, pagination: Pagination.new(limit_value: 1))

--- a/spec/system/manage_competencies/change_user_competencies_spec.rb
+++ b/spec/system/manage_competencies/change_user_competencies_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe 'Change caseworker competencies' do
       email: 'test@example.com',
       first_name: 'Iain',
       last_name: 'Testing',
-     auth_subject_id: SecureRandom.uuid
+      auth_subject_id: SecureRandom.uuid
     )
     visit manage_competencies_root_path
-    find("tr", :text => /Iain/).click_on('No competencies')
+    find('tr', text: /Iain/).click_on('No competencies')
   end
 
   describe 'when viewing the form' do

--- a/spec/system/manage_competencies/change_user_competencies_spec.rb
+++ b/spec/system/manage_competencies/change_user_competencies_spec.rb
@@ -4,40 +4,48 @@ RSpec.describe 'Change caseworker competencies' do
   let(:current_user_role) { UserRole::SUPERVISOR }
 
   before do
-    User.create!(email: 'test@example.com', first_name: 'Test', last_name: 'Testing',
-                 auth_subject_id: SecureRandom.uuid)
+    User.create!(
+      email: 'test@example.com',
+      first_name: 'Iain',
+      last_name: 'Testing',
+     auth_subject_id: SecureRandom.uuid
+    )
     visit manage_competencies_root_path
-    click_on('No competencies')
+    find("tr", :text => /Iain/).click_on('No competencies')
   end
 
   describe 'when viewing the form' do
-    # rubocop:disable RSpec/MultipleExpectations
-    it 'shows other available competencies' do
+    it 'shows other available competencies' do # rubocop:disable RSpec/MultipleExpectations
       expect(page).to have_unchecked_field('Extradition')
       expect(page).to have_unchecked_field('CAT 2')
       expect(page).to have_unchecked_field('CAT 1')
+      expect(page).to have_unchecked_field('Initial')
+      expect(page).to have_unchecked_field('Post submission evidence')
     end
-    # rubocop:enable RSpec/MultipleExpectations
   end
 
   describe "when there is an update to a caseworker's competencies" do
     before do
       check 'Extradition'
+      check 'Initial'
       click_on 'Save'
     end
 
     it 'displays selected competency' do
       first_data_row = page.first('.govuk-table tbody tr').text
-      expect(first_data_row).to eq(['Test Testing Extradition View history'].join(' '))
+      expect(first_data_row).to eq('Iain Testing Extradition, Initial View history')
     end
 
     it 'form is pre-populated with selected competency' do
       click_on('Extradition')
       expect(page).to have_checked_field('Extradition')
+      expect(page).to have_checked_field('Initial')
     end
 
     it 'displays success message' do
-      expect(page).to have_success_notification_banner(text: "Test Testing's competencies saved")
+      expect(page).to have_success_notification_banner(
+        text: "Iain Testing's competencies saved"
+      )
     end
   end
 

--- a/spec/system/manage_competencies/viewing_spec.rb
+++ b/spec/system/manage_competencies/viewing_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Manage Competencies Dashboard' do
   context 'when user does have access to manage competencies' do
     let(:current_user_role) { UserRole::SUPERVISOR }
     let(:caseworker) do
-      User.create!(email: 'test@example.com', first_name: 'Test', last_name: 'Testing',
+      User.create!(email: 'test@example.com', first_name: 'Iain', last_name: 'Testing',
                    auth_subject_id: SecureRandom.uuid)
     end
 
@@ -37,17 +37,17 @@ RSpec.describe 'Manage Competencies Dashboard' do
 
     it 'shows the correct table content' do
       first_data_row = page.first('.govuk-table tbody tr').text
-      expect(first_data_row).to eq(['Test Testing No competencies View history'].join(' '))
+      expect(first_data_row).to eq(['Iain Testing No competencies View history'].join(' '))
     end
 
     context 'when clicking links' do
       it 'redirects to the edit competency form page' do
-        expect { click_on('No competencies') }.to change { page.current_path }
+        expect { page.first('.govuk-table tbody tr').click_on('No competencies') }.to change { page.current_path }
           .from(manage_competencies_root_path).to(edit_manage_competencies_caseworker_competency_path(caseworker))
       end
 
       it 'redirects to the competency history page' do
-        expect { click_on('View history') }.to change { page.current_path }
+        expect { page.first('.govuk-table tbody tr').click_on('View history') }.to change { page.current_path }
           .from(manage_competencies_root_path).to(manage_competencies_history_path(caseworker))
       end
     end
@@ -56,7 +56,7 @@ RSpec.describe 'Manage Competencies Dashboard' do
 
     it_behaves_like 'an ordered user list' do
       let(:path) { manage_competencies_root_path }
-      let(:expected_order) { ['Arthur Sample', 'Hassan Example', 'Hassan Sample', 'Test Testing'] }
+      let(:expected_order) { ['Arthur Sample', 'Hassan Example', 'Hassan Sample', 'Iain Testing', 'Joe EXAMPLE'] }
       let(:column_num) { 1 }
     end
   end

--- a/spec/system/manage_competencies/viewing_spec.rb
+++ b/spec/system/manage_competencies/viewing_spec.rb
@@ -14,9 +14,16 @@ RSpec.describe 'Manage Competencies Dashboard' do
 
   context 'when user does have access to manage competencies' do
     let(:current_user_role) { UserRole::SUPERVISOR }
+
+    let(:current_user_competencies) { [] }
+
     let(:caseworker) do
-      User.create!(email: 'test@example.com', first_name: 'Iain', last_name: 'Testing',
-                   auth_subject_id: SecureRandom.uuid)
+      User.create!(
+        email: 'test@example.com',
+        first_name: 'Iain',
+        last_name: 'Testing',
+        auth_subject_id: SecureRandom.uuid
+      )
     end
 
     before do


### PR DESCRIPTION
## Description of change
Stop setting 'initial' as the default competency for all caseworkers.
Make supervisors competencies configurable.
Visually distinguish competencies by type on the edit form.

## Link to relevant ticket
[CRIMAPP-646](https://dsdmoj.atlassian.net/browse/CRIMAPP-646)

## Notes for reviewer

In order to allow some caseworkers to focus exclusively on PSE, supervisors need the ability remove the ‘initial’ competency which is currently assigned to all caseworkers by default.

## Screenshots of changes (if applicable)

### Before changes:

<img width="1112" alt="Screenshot 2024-03-20 at 14 13 28" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/94b7b6a5-30b6-4486-af33-419c9f3759e1">


### After changes:

<img width="1101" alt="Screenshot 2024-03-20 at 14 13 11" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/84d0bf35-06b9-4c0f-bad2-04409f94882b">


## How to manually test the feature

see ticket

[CRIMAPP-646]: https://dsdmoj.atlassian.net/browse/CRIMAPP-646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ