### PR TITLE
[CRIMAPP-284] Display income payments client gets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'laa-criminal-applications-datastore-api-client',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.54'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.56'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 9dfbef13229645869d629565eaf8f9d9c3a61f0b
-  tag: v1.0.54
+  revision: 47b673ce0947e87dfdf44841bddf0e371290d828
+  tag: v1.0.56
   specs:
-    laa-criminal-legal-aid-schemas (1.0.54)
+    laa-criminal-legal-aid-schemas (1.0.56)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -135,6 +135,10 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication
     @outgoings_details ||= OutgoingsDetailsPresenter.present(self[:means_details].outgoings_details)
   end
 
+  def income_payments
+    @income_payments ||= IncomePaymentsPresenter.present(self[:means_details].income_details&.income_payments)
+  end
+
   def pse?
     application_type == Types::ApplicationType['post_submission_evidence']
   end

--- a/app/presenters/income_payments_presenter.rb
+++ b/app/presenters/income_payments_presenter.rb
@@ -1,0 +1,29 @@
+class IncomePaymentsPresenter < BasePresenter
+  def initialize(income_payments)
+    super(
+      @income_payments = income_payments
+    )
+  end
+
+  def formatted_income_payments
+    return unless @income_payments
+
+    ordered_payments
+  end
+
+  private
+
+  def ordered_payments
+    return {} if @income_payments.empty?
+
+    income_payment_types.index_with { |val| income_payment_of_type(val) }
+  end
+
+  def income_payment_of_type(type)
+    @income_payments.detect { |income_payment| income_payment.payment_type == type }
+  end
+
+  def income_payment_types
+    LaaCrimeSchemas::Types::IncomePaymentType.values
+  end
+end

--- a/app/presenters/income_payments_presenter.rb
+++ b/app/presenters/income_payments_presenter.rb
@@ -1,4 +1,18 @@
 class IncomePaymentsPresenter < BasePresenter
+  # NOTE: Remember to add any new types to this list otherwise it will not show on page edit
+  INCOME_PAYMENT_TYPES_ORDER = %w[
+    maintenance
+    private_pension
+    state_pension
+    interest_investment
+    student_loan_grant
+    board_from_family
+    rent
+    financial_support_with_access
+    from_friends_relatives
+    other
+  ].freeze
+
   def initialize(income_payments)
     super(
       @income_payments = income_payments
@@ -16,14 +30,10 @@ class IncomePaymentsPresenter < BasePresenter
   def ordered_payments
     return {} if @income_payments.empty?
 
-    income_payment_types.index_with { |val| income_payment_of_type(val) }
+    INCOME_PAYMENT_TYPES_ORDER.index_with { |val| income_payment_of_type(val) }
   end
 
   def income_payment_of_type(type)
     @income_payments.detect { |income_payment| income_payment.payment_type == type }
-  end
-
-  def income_payment_types
-    LaaCrimeSchemas::Types::IncomePaymentType.values
   end
 end

--- a/app/presenters/income_payments_presenter.rb
+++ b/app/presenters/income_payments_presenter.rb
@@ -1,18 +1,4 @@
 class IncomePaymentsPresenter < BasePresenter
-  # NOTE: Remember to add any new types to this list otherwise it will not show on page edit
-  INCOME_PAYMENT_TYPES_ORDER = %w[
-    maintenance
-    private_pension
-    state_pension
-    interest_investment
-    student_loan_grant
-    board_from_family
-    rent
-    financial_support_with_access
-    from_friends_relatives
-    other
-  ].freeze
-
   def initialize(income_payments)
     super(
       @income_payments = income_payments
@@ -30,10 +16,14 @@ class IncomePaymentsPresenter < BasePresenter
   def ordered_payments
     return {} if @income_payments.empty?
 
-    INCOME_PAYMENT_TYPES_ORDER.index_with { |val| income_payment_of_type(val) }
+    income_payment_types.index_with { |val| income_payment_of_type(val) }
   end
 
   def income_payment_of_type(type)
     @income_payments.detect { |income_payment| income_payment.payment_type == type }
+  end
+
+  def income_payment_types
+    LaaCrimeSchemas::Types::IncomePaymentType.values
   end
 end

--- a/app/views/casework/crime_applications/_address.html.erb
+++ b/app/views/casework/crime_applications/_address.html.erb
@@ -5,7 +5,7 @@
 <br>
 <%= address.city %>
 <br>
-<%= address.country %>
-<br>
 <%= address.postcode %>
+<br>
+<%= address.country %>
 </p>

--- a/app/views/casework/crime_applications/_income_details.html.erb
+++ b/app/views/casework/crime_applications/_income_details.html.erb
@@ -1,4 +1,5 @@
 <%= render partial: 'casework/crime_applications/sections/employment', locals: { income_details: crime_application.means_details.income_details } %>
 <%= render partial: 'casework/crime_applications/sections/income', locals: { income_details: crime_application.means_details.income_details } %>
+<%= render partial: 'casework/crime_applications/sections/income_payments', locals: { income_payments: crime_application.income_payments.formatted_income_payments } %>
 <%= render partial: 'casework/crime_applications/sections/dependants', locals: { dependants: crime_application.dependants.formatted_dependants } %>
 <%= render partial: 'casework/crime_applications/sections/other_income_details', locals: { income_details: crime_application.means_details.income_details } %>

--- a/app/views/casework/crime_applications/_payment_with_frequency.html.erb
+++ b/app/views/casework/crime_applications/_payment_with_frequency.html.erb
@@ -1,13 +1,14 @@
-<% return unless payment %>
-<% return unless payment.amount && payment.frequency %>
-
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key">
     <%= key %>
   </dt>
   <dd class="govuk-summary-list__value">
-    <%= t('values.payment_with_frequency',
-          amount: number_to_currency(payment.amount * 0.01),
-          frequency: t(payment.frequency, scope: [:values, :frequency])) %>
+    <% if payment&.amount && payment&.frequency %>
+      <%= t('values.payment_with_frequency',
+            amount: number_to_currency(payment.amount * 0.01),
+            frequency: t(payment.frequency, scope: [:values, :frequency])) %>
+    <% else %>
+      <%= t(:does_not_get, scope: 'values') %>
+    <% end  %>
   </dd>
 </div>

--- a/app/views/casework/crime_applications/_payment_with_frequency.html.erb
+++ b/app/views/casework/crime_applications/_payment_with_frequency.html.erb
@@ -3,7 +3,7 @@
     <%= key %>
   </dt>
   <dd class="govuk-summary-list__value">
-    <% if payment&.amount && payment&.frequency %>
+    <% if payment %>
       <%= t('values.payment_with_frequency',
             amount: number_to_currency(payment.amount * 0.01),
             frequency: t(payment.frequency, scope: [:values, :frequency])) %>

--- a/app/views/casework/crime_applications/sections/_income_payments.html.erb
+++ b/app/views/casework/crime_applications/sections/_income_payments.html.erb
@@ -1,0 +1,26 @@
+<% if income_payments %>
+  <h2 class="govuk-heading-m">
+    <%= label_text(:payments_the_client_gets) %>
+  </h2>
+
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <% if income_payments.any? %>
+      <% income_payments.each do |payment_type, value| %>
+        <%= render partial: 'payment_with_frequency',
+                   locals: {
+                     key: label_text("payment_#{payment_type}"),
+                     payment: value
+                   } %>
+      <% end %>
+    <% else %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:which_payments_does_the_client_get) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t('values.none') %>
+        </dd>
+      </div>
+    <% end %>
+  </dl>
+<% end %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -138,6 +138,17 @@ en:
     overview: Overview
     partner: Partner
     pays_council_tax: Does client pay Council Tax?
+    payment_board_from_family: Board from family members living with the client
+    payment_financial_support_with_access: Financial support from someone who allows the client access to their assets or money
+    payment_from_friends_relatives: Money from friends or family
+    payment_interest_investment: Interest or income from savings or investments
+    payment_maintenance: Maintenance payments
+    payment_other: Other sources of income
+    payment_private_pension: Private pensions
+    payment_rent: Rent from a tenant
+    payment_state_pension: State Pension
+    payment_student_loan_grant: Student grant or loan
+    payments_the_client_gets: Payments the client gets
     post_submission_evidence: Post submission evidence
     previous_maat_id: Previous MAAT ID
     provider_details: Provider details
@@ -166,6 +177,7 @@ en:
     who: Who
     which_housing_payment_type: Does client pay rent, mortgage, or board and lodgings?
     will_benefit_from_trust_fund: Does your client stand to benefit from a trust fund inside or outside the UK?
+    which_payments_does_the_client_get: Which payments does the client get?
     trust_fund_amount_held: Enter the amount held in the fund
     trust_fund_yearly_dividend: Enter the yearly dividend
 
@@ -195,6 +207,7 @@ en:
       annual: year
     not_provided: Not provided
     not_asked: Not asked when this application was submitted
+    does_not_get: Does not get
     deleted_user_name: '[deleted]'
     no_one: no one
     initial: Initial application

--- a/spec/system/casework/viewing_an_application/address_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/address_details_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Viewing an applications address details' do
     subject(:home_address) { page.find('dt', text: 'Home address').find('+dd') }
 
     it 'shows the applicants postal address' do
-      expect(home_address).to have_content('1 Road Village Some nice city United Kingdom SW1A 2AA')
+      expect(home_address).to have_content('1 Road Village Some nice city SW1A 2AA United Kingdom')
     end
   end
 
@@ -32,7 +32,7 @@ RSpec.describe 'Viewing an applications address details' do
                                                                     'address_line_one' => 'Other House',
                                                                     'address_line_two' => 'Second Road',
                                                                     'city' => 'London',
-                                                                    'country' => 'London',
+                                                                    'country' => 'United Kingdom',
                                                                     'postcode' => 'EC2A 2AA',
                                                                     'lookup_id' => '1'
                                                                   } } })
@@ -40,7 +40,7 @@ RSpec.describe 'Viewing an applications address details' do
 
       it 'shows the correspondence address' do
         expect(correspondence_address).to have_content(
-          'Other House Second Road London London EC2A 2AA'
+          'Other House Second Road London EC2A 2AA United Kingdom'
         )
       end
     end

--- a/spec/system/casework/viewing_an_application/application_details/income_payments_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_payments_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing the income payments of an application' do
+  include_context 'with stubbed application'
+
+  before do
+    visit crime_application_path(application_id)
+  end
+
+  context 'with income payments details' do
+    it { expect(page).to have_content('Payments the client gets') }
+
+    # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+    it 'shows income payment details' do
+      expect(page).to have_content('Private pensions Does not get')
+      expect(page).to have_content('State Pension Does not get')
+      expect(page).to have_content('Maintenance payments Does not get')
+      expect(page).to have_content('Interest or income from savings or investments Does not get')
+      expect(page).to have_content('Student grant or loan Does not get')
+      expect(page).to have_content('Board from family members living with the client £16.03 every week')
+      expect(page).to have_content('Rent from a tenant Does not get')
+      expect(page).to have_content(
+        'Financial support from someone who allows the client access to their assets or money Does not get'
+      )
+      expect(page).to have_content('Money from friends or family Does not get')
+      expect(page).to have_content('Other sources of income £25.00 every year')
+    end
+    # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
+  end
+
+  context 'with no income payments details' do
+    let(:application_data) do
+      super().deep_merge(
+        'means_details' => {
+          'income_details' => { 'income_payments' => [] }
+        }
+      )
+    end
+
+    it 'shows income payment details' do
+      expect(page).to have_content('Which payments does the client get? None')
+    end
+  end
+end

--- a/spec/system/casework/viewing_an_application/application_details/trust_fund_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/trust_fund_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe 'Viewing the trust fund details of an application' do
     end
 
     it 'does not show amount held in the fund and the yearly dividend' do
-      expect(page).not_to have_content('Enter the amount held in the fund £10.00')
-      expect(page).not_to have_content('Enter the yearly dividend £2000.00')
+      expect(page).not_to have_content('Enter the amount held in the fund £1,000.00')
+      expect(page).not_to have_content('Enter the yearly dividend £2,000.00')
     end
   end
 


### PR DESCRIPTION
## Description of change
Displays income payments a client gets
Also updates presentation order of address fields 

## Link to relevant ticket
[CRIMAPP-284](https://dsdmoj.atlassian.net/browse/CRIMAPP-284)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="791" alt="Screenshot 2024-03-21 at 13 19 08" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/27d26c52-4d18-4071-a41f-3b6dcee2dca3">

### After changes:
<img width="829" alt="Screenshot 2024-03-21 at 11 45 16" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/d53e5808-907e-4448-aa0e-4332722b3dc6">
<img width="791" alt="Screenshot 2024-03-21 at 11 46 22" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/cf516cd9-bc8b-47d0-b92a-d46116070893">
<img width="535" alt="Screenshot 2024-03-21 at 14 05 48" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/0e7bc7b3-6e4a-49b5-b9b2-ec174ae2fdcd">

## How to manually test the feature
Submit an application with income payment details. Then confirm details appear similar to the first screenshot above
Also submit an application where `My client does not get any of these payments` has been selected for income payment details and confirm it appears as the second screenshot 

[CRIMAPP-284]: https://dsdmoj.atlassian.net/browse/CRIMAPP-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ