### PR TITLE
User manager competencies can be configured on staging

### DIFF
--- a/app/controllers/manage_competencies/caseworker_competencies_controller.rb
+++ b/app/controllers/manage_competencies/caseworker_competencies_controller.rb
@@ -29,10 +29,11 @@ module ManageCompetencies
     end
 
     def user_scope
-      User.active.where(
-        role: [Types::CASEWORKER_ROLE, Types::SUPERVISOR_ROLE],
-        can_manage_others: false
-      )
+      scope = User.active.where(role: [Types::CASEWORKER_ROLE, Types::SUPERVISOR_ROLE])
+
+      return scope if FeatureFlags.allow_user_managers_service_access.enabled?
+
+      scope.where(can_manage_others: false)
     end
   end
 end

--- a/spec/system/manage_competencies/viewing_spec.rb
+++ b/spec/system/manage_competencies/viewing_spec.rb
@@ -59,6 +59,36 @@ RSpec.describe 'Manage Competencies Dashboard' do
       end
     end
 
+    describe 'user manager competencies' do
+      before do
+        User.create!(
+          email: 'amanda@example.com',
+          first_name: 'Amanda',
+          last_name: 'Manager',
+          auth_subject_id: SecureRandom.uuid,
+          can_manage_others: true
+        )
+      end
+
+      it 'are not normally listed' do
+        visit manage_competencies_root_path
+        expect(page).not_to have_content('Amanda Manager')
+      end
+
+      context 'when user managers have service access' do
+        before do
+          allow(FeatureFlags).to receive(:allow_user_managers_service_access) {
+            instance_double(FeatureFlags::EnabledFeature, enabled?: true)
+          }
+        end
+
+        it 'their competencies are listed' do
+          visit manage_competencies_root_path
+          expect(page).to have_content('Amanda Manager')
+        end
+      end
+    end
+
     it_behaves_like 'a paginated page', path: '/manage_competencies?page=2'
 
     it_behaves_like 'an ordered user list' do


### PR DESCRIPTION
## Description of change
Allow user managers' competencies to be configured on staging.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
