### PR TITLE
Display outgoing payments in review

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -143,6 +143,10 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication  # rubocop:d
     @income_payments ||= IncomePaymentsPresenter.present(self[:means_details].income_details&.income_payments)
   end
 
+  def outgoing_payments
+    @outgoing_payments ||= OutgoingPaymentsPresenter.present(self[:means_details].outgoings_details&.outgoings)
+  end
+
   def properties
     @properties ||= PropertiesPresenter.present(self[:means_details].capital_details&.properties)
   end

--- a/app/presenters/income_benefits_presenter.rb
+++ b/app/presenters/income_benefits_presenter.rb
@@ -8,6 +8,8 @@ class IncomeBenefitsPresenter < BasePresenter
   end
 
   def formatted_income_benefits
+    # throw @income_benefits
+    # throw income_benefit_types
     return unless @income_benefits
 
     ordered_benefits

--- a/app/presenters/outgoing_payments_presenter.rb
+++ b/app/presenters/outgoing_payments_presenter.rb
@@ -1,0 +1,43 @@
+require 'laa_crime_schemas'
+
+class OutgoingPaymentsPresenter < BasePresenter
+  def initialize(outgoing_payments)
+    super(
+      @outgoing_payments = outgoing_payments
+    )
+  end
+
+  def formatted_outgoing_payments
+    return unless @outgoing_payments
+
+    ordered_payments
+  end
+
+  private
+
+  def ordered_payments
+    remove_housing_payments
+
+    return {} if @outgoing_payments.empty?
+
+    outgoing_payment_types.index_with { |val| outgoing_payment_of_type(val) }
+  end
+
+  def outgoing_payment_of_type(type)
+    @outgoing_payments.detect { |outgoing_payment| outgoing_payment.payment_type == type }
+  end
+
+  def remove_housing_payments
+    @outgoing_payments.reject! do |outgoing_payment|
+      housing_payment_types.include?(outgoing_payment.payment_type)
+    end
+  end
+
+  def outgoing_payment_types
+    %w[childcare maintenance legal_aid_contribution]
+  end
+
+  def housing_payment_types
+    %w[rent mortgage board_and_lodging]
+  end
+end

--- a/app/views/casework/crime_applications/_income_details.html.erb
+++ b/app/views/casework/crime_applications/_income_details.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'casework/crime_applications/sections/employment', locals: { income_details: crime_application.means_details.income_details } %>
 <%= render partial: 'casework/crime_applications/sections/income', locals: { income_details: crime_application.means_details.income_details } %>
 <%= render partial: 'casework/crime_applications/sections/income_payments', locals: { income_payments: crime_application.income_payments.formatted_income_payments } %>
+<%= render partial: 'casework/crime_applications/sections/income_benefits', locals: { income_benefits: crime_application.income_benefits.formatted_income_benefits } %>
 <%= render partial: 'casework/crime_applications/sections/dependants', locals: { dependants: crime_application.dependants.formatted_dependants } %>
 <%= render partial: 'casework/crime_applications/sections/other_income_details', locals: { income_details: crime_application.means_details.income_details } %>
-<%= render partial: 'casework/crime_applications/sections/income_benefits', locals: { income_benefits: crime_application.income_benefits.formatted_income_benefits } %>

--- a/app/views/casework/crime_applications/_initial.html.erb
+++ b/app/views/casework/crime_applications/_initial.html.erb
@@ -13,7 +13,7 @@
 
 <% if FeatureFlags.means_journey.enabled? %>
   <%= render partial: 'income_details', locals: { crime_application: } %>
-  <%= render partial: 'outgoings_details', locals: { outgoings_details: crime_application.outgoings_details } %>
+  <%= render partial: 'outgoings_details', locals: { crime_application: } %>
 
   <% if crime_application.means_details.capital_details %>
     <%= render partial: 'capital_details', locals: { crime_application: } %>

--- a/app/views/casework/crime_applications/_outgoings_details.html.erb
+++ b/app/views/casework/crime_applications/_outgoings_details.html.erb
@@ -1,2 +1,3 @@
-<%= render partial: 'casework/crime_applications/sections/housing_payments', locals: { outgoings_details: } %>
-<%= render partial: 'casework/crime_applications/sections/other_outgoings_details', locals: { outgoings_details: } %>
+<%= render partial: 'casework/crime_applications/sections/housing_payments', locals: { outgoings_details: crime_application.outgoings_details } %>
+<%= render partial: 'casework/crime_applications/sections/outgoing_payments', locals: { outgoing_payments: crime_application.outgoing_payments.formatted_outgoing_payments } %>
+<%= render partial: 'casework/crime_applications/sections/other_outgoings_details', locals: { outgoings_details: crime_application.outgoings_details } %>

--- a/app/views/casework/crime_applications/_payment_with_frequency.html.erb
+++ b/app/views/casework/crime_applications/_payment_with_frequency.html.erb
@@ -8,7 +8,7 @@
             amount: number_to_currency(payment.amount * 0.01),
             frequency: t(payment.frequency, scope: [:values, :frequency])) %>
     <% else %>
-      <%= t(:does_not_get, scope: 'values') %>
-    <% end  %>
+      <%= does_not_text %>
+  <% end %>
   </dd>
 </div>

--- a/app/views/casework/crime_applications/sections/_housing_payments.html.erb
+++ b/app/views/casework/crime_applications/sections/_housing_payments.html.erb
@@ -28,7 +28,8 @@
 
     <%= render partial: 'payment_with_frequency', locals: {
           key: label_text("how_much_#{payment.payment_type}"),
-          payment: payment
+          payment: payment,
+          does_not_text: t(:does_not_get, scope: 'values')
         } unless payment.payment_type == 'board_and_lodging' %>
 
     <!-- Board and Lodging Metadata -->

--- a/app/views/casework/crime_applications/sections/_income_benefits.html.erb
+++ b/app/views/casework/crime_applications/sections/_income_benefits.html.erb
@@ -9,7 +9,8 @@
         <%= render partial: 'payment_with_frequency',
                    locals: {
                      key: label_text("benefit_#{benefit_type}"),
-                     payment: value
+                     payment: value,
+                     does_not_text: t(:does_not_get, scope: 'values')
                    } %>
       <% end %>
     <% else %>

--- a/app/views/casework/crime_applications/sections/_income_payments.html.erb
+++ b/app/views/casework/crime_applications/sections/_income_payments.html.erb
@@ -9,7 +9,8 @@
         <%= render partial: 'payment_with_frequency',
                    locals: {
                      key: label_text("payment_#{payment_type}"),
-                     payment: value
+                     payment: value,
+                     does_not_text: t(:does_not_get, scope: 'values')
                    } %>
       <% end %>
     <% else %>

--- a/app/views/casework/crime_applications/sections/_outgoing_payments.html.erb
+++ b/app/views/casework/crime_applications/sections/_outgoing_payments.html.erb
@@ -1,0 +1,37 @@
+<% if outgoing_payments %>
+  <h2 class="govuk-heading-m">
+    <%= label_text(:payments_the_client_pays) %>
+  </h2>
+
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <% if outgoing_payments.any? %>
+      <% outgoing_payments.each do |payment_type, value| %>
+        <%= render partial: 'payment_with_frequency',
+                   locals: {
+                     key: label_text("outgoing_payment_#{payment_type}"),
+                     payment: value,
+                     does_not_text: t('values.does_not_pay')
+                   } %>
+        <% if payment_type == 'legal_aid_contribution' && value.present? %>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              <%= label_text(:case_reference) %>
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= value.metadata.case_reference %>
+            </dd>
+          </div>
+        <% end %>
+      <% end %>
+    <% else %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:which_payments_does_the_client_pay) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t('values.none') %>
+        </dd>
+      </div>
+    <% end %>
+  </dl>
+<% end %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -76,6 +76,7 @@ en:
     capital: Capital
     case_details: Case details
     case_type: Case type
+    case_reference: Case reference of the criminal rep order or civil certificate
     caseworker: Caseworker
     client_details: Client details
     client_owns_property: Has land or property?
@@ -162,6 +163,9 @@ en:
     other_income_details: Other sources of income
     other_names: Other names
     other_outgoings_details: Other outgoings
+    outgoing_payment_childcare: Childcare payments
+    outgoing_payment_maintenance: Maintenance payments to a former partner
+    outgoing_payment_legal_aid_contribution: Contributions towards criminal or civil legal aid
     outgoings_more_than_income: Are client's outgoings more than their income?
     outgoings_metadata:
       board_amount: Amount paid for board and lodgings
@@ -184,6 +188,7 @@ en:
     payment_state_pension: State Pension
     payment_student_loan_grant: Student grant or loan
     payments_the_client_gets: Payments the client gets
+    payments_the_client_pays: Payments the client pays
     post_submission_evidence: Post submission evidence
     premium_bonds: Premium Bonds 
     premium_bonds_holder_number: Holder number
@@ -224,6 +229,7 @@ en:
     will_benefit_from_trust_fund: Does your client stand to benefit from a trust fund inside or outside the UK?
     which_benefits_does_the_client_get: Which benefits does the client get?
     which_payments_does_the_client_get: Which payments does the client get?
+    which_payments_does_the_client_pay: Which payments does the client pay?
     trust_fund_amount_held: Enter the amount held in the fund
     trust_fund_yearly_dividend: Enter the yearly dividend
     properties_title: Assets
@@ -275,6 +281,7 @@ en:
     not_provided: Not provided
     not_asked: Not asked when this application was submitted
     does_not_get: Does not get
+    does_not_pay: Does not pay
     already_in_crown_court: Trial already in crown court
     appeal_to_crown_court: Appeal to crown court
     appeal_to_crown_court_with_changes: Appeal to crown court with changes in financial circumstances

--- a/spec/presenters/outgoing_payments_presenter_spec.rb
+++ b/spec/presenters/outgoing_payments_presenter_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe OutgoingPaymentsPresenter do
+  subject(:payments_presenter) { described_class.new(crime_application.means_details.outgoings_details.outgoings) }
+
+  let(:attributes) { JSON.parse(LaaCrimeSchemas.fixture(1.0).read) }
+  let(:crime_application) { CrimeApplication.new(attributes) }
+
+  describe '#formatted_outgoing_payments' do
+    subject(:formatted_outgoing_payments) { payments_presenter.formatted_outgoing_payments }
+
+    # rubocop:disable Layout/LineLength
+    it {
+      expect(formatted_outgoing_payments).to include({ 'childcare' => be_a(LaaCrimeSchemas::Structs::OutgoingsDetails::Outgoing),
+                                                     'maintenance' => nil,
+                                                     'legal_aid_contribution' => be_a(LaaCrimeSchemas::Structs::OutgoingsDetails::Outgoing) })
+    }
+    # rubocop:enable Layout/LineLength
+
+    context 'with empty outgoing payments' do
+      before do
+        attributes['means_details']['outgoings_details']['outgoings'] = []
+      end
+
+      it { expect(formatted_outgoing_payments).to eq({}) }
+    end
+  end
+end

--- a/spec/system/casework/viewing_an_application/application_details/outgoing_payments_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/outgoing_payments_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing the outgoing payments of an application' do
+  include_context 'with stubbed application'
+
+  before do
+    visit crime_application_path(application_id)
+  end
+
+  context 'with outgoing payment details' do
+    it { expect(page).to have_content('Payments the client pays') }
+
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'shows outgoing payments details' do
+      expect(page).to have_content('Childcare payments £982.81 every week')
+      expect(page).to have_content('Maintenance payments to a former partner Does not pay')
+      expect(page).to have_content('Contributions towards criminal or civil legal aid £12.34 every week')
+      expect(page).to have_content('Case reference of the criminal rep order or civil certificate CASE1234')
+    end
+    # rubocop:enable RSpec/MultipleExpectations
+  end
+
+  context 'with no outgoing payments details' do
+    let(:application_data) do
+      super().deep_merge(
+        'means_details' => {
+          'outgoings_details' => { 'outgoings' => [] }
+        }
+      )
+    end
+
+    it 'shows outgoing payment details' do
+      expect(page).to have_content('Which payments does the client pay? None')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Displays outgoing payments a client gets

## Link to relevant ticket
[CRIMAPP-284](https://dsdmoj.atlassian.net/browse/CRIMAPP-284)

## Notes for reviewer
Housing payments and outgoing payments are bundled together so there is some code to remove the housing payments before formatting them. 

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1212" alt="Screenshot 2024-04-05 at 16 07 01" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/a7a3b1f5-a8d4-4e9b-99e7-936b3918bd71">

<img width="889" alt="Screenshot 2024-04-05 at 16 55 19" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/44326a73-41b7-48d1-af1c-9fb6a2e6564a">

## How to manually test the feature
Submit an application with outgoing payment details. Then confirm details appear similar to the first screenshot above
Also submit an application where `My client does not make any of these payments` has been selected for the outgoing payment details and confirm it appears as the second screenshot 

[CRIMAPP-284]: https://dsdmoj.atlassian.net/browse/CRIMAPP-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ