### PR TITLE
[CRIMAPP-728, 729] Add other income benefit/payment details

### DIFF
--- a/app/views/casework/crime_applications/sections/_income_benefits.html.erb
+++ b/app/views/casework/crime_applications/sections/_income_benefits.html.erb
@@ -12,6 +12,16 @@
                      payment: value,
                      does_not_text: t(:does_not_get, scope: 'values')
                    } %>
+        <% if benefit_type == 'other' && value.present? %>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              <%= label_text(:other_benefits_details) %>
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= value.metadata.details %>
+            </dd>
+          </div>
+        <% end %>
       <% end %>
     <% else %>
       <div class="govuk-summary-list__row">

--- a/app/views/casework/crime_applications/sections/_income_payments.html.erb
+++ b/app/views/casework/crime_applications/sections/_income_payments.html.erb
@@ -12,6 +12,16 @@
                      payment: value,
                      does_not_text: t(:does_not_get, scope: 'values')
                    } %>
+        <% if payment_type == 'other' && value.present? %>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              <%= label_text(:other_payment_details) %>
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= value.metadata.details %>
+            </dd>
+          </div>
+        <% end %>
       <% end %>
     <% else %>
       <div class="govuk-summary-list__row">

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -71,7 +71,7 @@ en:
     benefit_incapacity: Incapacity Benefit
     benefit_industrial_injuries_disablement: Industrial Injuries Disablement Benefit
     benefit_jsa: Contribution-based Jobseeker's Allowance
-    benefit_other: Other benefits (except disregarded benefits)
+    benefit_other: Other benefits
     benefits_the_client_gets: Benefits the client gets
     capital: Capital
     case_details: Case details
@@ -159,10 +159,12 @@ en:
     offence_date: Offence date
     offence_details: Offence details
     office_account_number: Office account number
+    other_benefits_details: Other benefits
     other_capital_details: Other capital
     other_income_details: Other sources of income
     other_names: Other names
     other_outgoings_details: Other outgoings
+    other_payment_details: Other sources of income details
     outgoing_payment_childcare: Childcare payments
     outgoing_payment_maintenance: Maintenance payments to a former partner
     outgoing_payment_legal_aid_contribution: Contributions towards criminal or civil legal aid

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -159,7 +159,7 @@ en:
     offence_date: Offence date
     offence_details: Offence details
     office_account_number: Office account number
-    other_benefits_details: Other benefits
+    other_benefits_details: Other benefits details
     other_capital_details: Other capital
     other_income_details: Other sources of income
     other_names: Other names

--- a/spec/system/casework/viewing_an_application/application_details/income_benefits_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_benefits_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe 'Viewing the income benefits of an application' do
       expect(page).to have_content('Incapacity Benefit Does not get')
       expect(page).to have_content('Industrial Injuries Disablement Benefit Does not get')
       expect(page).to have_content("Contribution-based Jobseeker's Allowance Does not get")
-      expect(page).to have_content('Other benefits (except disregarded benefits) £18.84 every 2 weeks')
+      expect(page).to have_content('Other benefits £18.84 every 2 weeks')
+      expect(page).to have_content('Other benefits Top up')
     end
     # rubocop:enable RSpec/MultipleExpectations
   end

--- a/spec/system/casework/viewing_an_application/application_details/income_benefits_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_benefits_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Viewing the income benefits of an application' do
       expect(page).to have_content('Industrial Injuries Disablement Benefit Does not get')
       expect(page).to have_content("Contribution-based Jobseeker's Allowance Does not get")
       expect(page).to have_content('Other benefits £18.84 every 2 weeks')
-      expect(page).to have_content('Other benefits Top up')
+      expect(page).to have_content('Other benefits details Top up')
     end
     # rubocop:enable RSpec/MultipleExpectations
   end

--- a/spec/system/casework/viewing_an_application/application_details/income_payments_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_payments_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'Viewing the income payments of an application' do
       )
       expect(page).to have_content('Money from friends or family Does not get')
       expect(page).to have_content('Other sources of income £25.00 every year')
+      expect(page).to have_content('Other sources of income details Book royalty')
     end
     # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
   end


### PR DESCRIPTION
## Description of change
Display other income benefits/payments details in review

## Link to relevant ticket
[CRIMAPP-728](https://dsdmoj.atlassian.net/browse/CRIMAPP-728)
[CRIMAPP-729](https://dsdmoj.atlassian.net/browse/CRIMAPP-729)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1280" alt="Screenshot 2024-04-15 at 17 32 16" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/b6d2e010-3019-4e50-be9c-02f81bc7d4cc">

## How to manually test the feature
Submit an application in apply with other income benefits and payments details
Confirm the rows are being displayed in review
Also confirm the rows are not displayed if no other income benefits and payments were selected and when there are no income payments/benefits 


[CRIMAPP-728]: https://dsdmoj.atlassian.net/browse/CRIMAPP-728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-729]: https://dsdmoj.atlassian.net/browse/CRIMAPP-729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ