### PR TITLE
[CRIMAPP-735] display absent asset, savings, investments, nsc records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.0.66'
+    tag: 'v1.0.67'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.0.67'
+    tag: 'v1.0.68'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 547a6aece53cd7dd7ef1443672e6c071d1552550
-  tag: v1.0.66
+  revision: 48107816d1c8316f9817b22404c966b333ca11fd
+  tag: v1.0.67
   specs:
-    laa-criminal-legal-aid-schemas (1.0.66)
+    laa-criminal-legal-aid-schemas (1.0.67)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 48107816d1c8316f9817b22404c966b333ca11fd
-  tag: v1.0.67
+  revision: a1adca98151c6bf85a1ec002bc5a4d0db90a29e5
+  tag: v1.0.68
   specs:
-    laa-criminal-legal-aid-schemas (1.0.67)
+    laa-criminal-legal-aid-schemas (1.0.68)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -157,8 +157,8 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication  # rubocop:d
 
   def requires_full_capital?
     %w[either_way indictable already_in_crown_court].include?(case_details.case_type)
-  end 
-  
+  end
+
   def last_jsa_appointment_date?
     client_details.applicant.benefit_type == 'jsa' && client_details.applicant.last_jsa_appointment_date.present?
   end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -155,10 +155,6 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication  # rubocop:d
     application_type == Types::ApplicationType['post_submission_evidence']
   end
 
-  def requires_full_capital?
-    %w[either_way indictable already_in_crown_court].include?(case_details.case_type)
-  end
-
   def last_jsa_appointment_date?
     client_details.applicant.benefit_type == 'jsa' && client_details.applicant.last_jsa_appointment_date.present?
   end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -147,10 +147,6 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication  # rubocop:d
     @outgoing_payments ||= OutgoingPaymentsPresenter.present(self[:means_details].outgoings_details&.outgoings)
   end
 
-  def properties
-    @properties ||= PropertiesPresenter.present(self[:means_details].capital_details&.properties)
-  end
-
   def pse?
     application_type == Types::ApplicationType['post_submission_evidence']
   end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -154,4 +154,8 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication  # rubocop:d
   def pse?
     application_type == Types::ApplicationType['post_submission_evidence']
   end
+
+  def requires_full_capital?
+    %w[either_way indictable already_in_crown_court].include?(case_details.case_type)
+  end
 end

--- a/app/presenters/properties_presenter.rb
+++ b/app/presenters/properties_presenter.rb
@@ -11,10 +11,4 @@ class PropertiesPresenter < BasePresenter
     commercial: { display_name: 'property' },
     land: { display_name: 'land' }
   }.freeze
-
-  def initialize(properties)
-    super(
-      @properties = properties.sort_by { |d| d[:property_type] }
-    )
-  end
 end

--- a/app/views/casework/crime_applications/_capital_details.html.erb
+++ b/app/views/casework/crime_applications/_capital_details.html.erb
@@ -1,11 +1,11 @@
 <%= render(
       partial: 'casework/crime_applications/sections/properties',
-      locals: { properties: crime_application.properties, crime_application: crime_application }
+      locals: { capital_details: crime_application.means_details.capital_details }
     ) %>
 
 <%= render(
       partial: 'casework/crime_applications/sections/savings',
-      locals: { savings: crime_application.means_details.capital_details.savings, crime_application: crime_application }
+      locals: { capital_details: crime_application.means_details.capital_details }
     ) %>
 
 <%= render(
@@ -15,12 +15,12 @@
 
 <%= render(
       partial: 'casework/crime_applications/sections/national_savings_certificates',
-      locals: { national_savings_certificates: crime_application.means_details.capital_details.national_savings_certificates, crime_application: crime_application }
+      locals: { capital_details: crime_application.means_details.capital_details }
     ) %>
 
 <%= render(
       partial: 'casework/crime_applications/sections/investments',
-      locals: { investments: crime_application.means_details.capital_details.investments, crime_application: crime_application }
+      locals: { capital_details: crime_application.means_details.capital_details }
     ) %>
 
 <%= render partial: 'casework/crime_applications/sections/trust_fund', locals: { capital_details: crime_application.means_details.capital_details } %>

--- a/app/views/casework/crime_applications/_capital_details.html.erb
+++ b/app/views/casework/crime_applications/_capital_details.html.erb
@@ -1,11 +1,11 @@
 <%= render(
       partial: 'casework/crime_applications/sections/properties',
-      object: crime_application.properties
+      locals: { properties: crime_application.properties, crime_application: crime_application }
     ) %>
 
 <%= render(
       partial: 'casework/crime_applications/sections/savings',
-      object: crime_application.means_details.capital_details.savings
+      locals: { savings: crime_application.means_details.capital_details.savings, crime_application: crime_application }
     ) %>
 
 <%= render(
@@ -15,12 +15,12 @@
 
 <%= render(
       partial: 'casework/crime_applications/sections/national_savings_certificates',
-      object: crime_application.means_details.capital_details.national_savings_certificates
+      locals: { national_savings_certificates: crime_application.means_details.capital_details.national_savings_certificates, crime_application: crime_application }
     ) %>
 
 <%= render(
       partial: 'casework/crime_applications/sections/investments',
-      object: crime_application.means_details.capital_details.investments
+      locals: { investments: crime_application.means_details.capital_details.investments, crime_application: crime_application }
     ) %>
 
 <%= render partial: 'casework/crime_applications/sections/trust_fund', locals: { capital_details: crime_application.means_details.capital_details } %>

--- a/app/views/casework/crime_applications/_income_details.html.erb
+++ b/app/views/casework/crime_applications/_income_details.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'casework/crime_applications/sections/employment', locals: { income_details: crime_application.means_details.income_details } %>
 <%= render partial: 'casework/crime_applications/sections/income', locals: { income_details: crime_application.means_details.income_details } %>
-<%= render partial: 'casework/crime_applications/sections/income_payments', locals: { income_payments: crime_application.income_payments.formatted_income_payments } %>
-<%= render partial: 'casework/crime_applications/sections/income_benefits', locals: { income_benefits: crime_application.income_benefits.formatted_income_benefits } %>
+<%= render partial: 'casework/crime_applications/sections/income_payments', locals: { income_details: crime_application.means_details.income_details, income_payments: crime_application.income_payments.formatted_income_payments } %>
+<%= render partial: 'casework/crime_applications/sections/income_benefits', locals: { income_details: crime_application.means_details.income_details, income_benefits: crime_application.income_benefits.formatted_income_benefits } %>
 <%= render partial: 'casework/crime_applications/sections/dependants', locals: { dependants: crime_application.dependants.formatted_dependants } %>
 <%= render partial: 'casework/crime_applications/sections/other_income_details', locals: { income_details: crime_application.means_details.income_details } %>

--- a/app/views/casework/crime_applications/_initial.html.erb
+++ b/app/views/casework/crime_applications/_initial.html.erb
@@ -9,7 +9,6 @@
 <%= render partial: 'offences', object: crime_application.case_details.offences %>
 <%= render partial: 'codefendants', object: crime_application.case_details.codefendants %>
 <%= render partial: 'interests_of_justice', locals: { crime_application: } %>
-<%= render partial: 'supporting_evidence', locals: { crime_application: } %>
 
 <% if FeatureFlags.means_journey.enabled? %>
   <%= render partial: 'income_details', locals: { crime_application: } %>
@@ -19,5 +18,7 @@
     <%= render partial: 'capital_details', locals: { crime_application: } %>
   <% end %>
 <% end %>
+
+<%= render partial: 'supporting_evidence', locals: { crime_application: } %>
 
 <%= render partial: 'provider_details', object: crime_application.provider_details %>

--- a/app/views/casework/crime_applications/_outgoings_details.html.erb
+++ b/app/views/casework/crime_applications/_outgoings_details.html.erb
@@ -1,3 +1,3 @@
 <%= render partial: 'casework/crime_applications/sections/housing_payments', locals: { outgoings_details: crime_application.outgoings_details } %>
-<%= render partial: 'casework/crime_applications/sections/outgoing_payments', locals: { outgoing_payments: crime_application.outgoing_payments.formatted_outgoing_payments } %>
+<%= render partial: 'casework/crime_applications/sections/outgoing_payments', locals: { outgoings_details: crime_application.outgoings_details, outgoing_payments: crime_application.outgoing_payments.formatted_outgoing_payments } %>
 <%= render partial: 'casework/crime_applications/sections/other_outgoings_details', locals: { outgoings_details: crime_application.outgoings_details } %>

--- a/app/views/casework/crime_applications/sections/_income_benefits.html.erb
+++ b/app/views/casework/crime_applications/sections/_income_benefits.html.erb
@@ -1,10 +1,19 @@
-<% if income_benefits %>
+<% if income_details.present? %>
   <h2 class="govuk-heading-m">
     <%= label_text(:benefits_the_client_gets) %>
   </h2>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-    <% if income_benefits.any? %>
+    <% if income_details.has_no_income_benefits == 'yes' %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:which_benefits_does_the_client_get) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t('values.none') %>
+        </dd>
+      </div>
+    <% elsif income_benefits.any? %>
       <% income_benefits.each do |benefit_type, value| %>
         <%= render partial: 'payment_with_frequency',
                    locals: {
@@ -23,15 +32,6 @@
           </div>
         <% end %>
       <% end %>
-    <% else %>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= label_text(:which_benefits_does_the_client_get) %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= t('values.none') %>
-        </dd>
-      </div>
     <% end %>
   </dl>
 <% end %>

--- a/app/views/casework/crime_applications/sections/_income_payments.html.erb
+++ b/app/views/casework/crime_applications/sections/_income_payments.html.erb
@@ -1,10 +1,19 @@
-<% if income_payments %>
+<% if income_details.present? %>
   <h2 class="govuk-heading-m">
     <%= label_text(:payments_the_client_gets) %>
   </h2>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-    <% if income_payments.any? %>
+    <% if income_details.has_no_income_payments == 'yes' %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:which_payments_does_the_client_get) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t('values.none') %>
+        </dd>
+      </div>
+    <% elsif income_payments.any? %>
       <% income_payments.each do |payment_type, value| %>
         <%= render partial: 'payment_with_frequency',
                    locals: {
@@ -23,15 +32,6 @@
           </div>
         <% end %>
       <% end %>
-    <% else %>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= label_text(:which_payments_does_the_client_get) %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= t('values.none') %>
-        </dd>
-      </div>
     <% end %>
   </dl>
 <% end %>

--- a/app/views/casework/crime_applications/sections/_investments.html.erb
+++ b/app/views/casework/crime_applications/sections/_investments.html.erb
@@ -1,4 +1,4 @@
-<% if investments.empty? && crime_application.requires_full_capital?  %>
+<% if capital_details.has_no_investments == 'yes'  %>
   <%= govuk_summary_card(title: label_text(:investments)) do %>
     <%= govuk_summary_list(actions: false) do |list|
           list.with_row do |row|
@@ -7,10 +7,10 @@
           end
         end %>
   <% end %>
-<% elsif investments.present? %>
+<% elsif capital_details.investments.present? %>
   <h2 class="govuk-heading-m"><%= label_text(:investments) %></h2>
 
-  <% investments.group_by(&:investment_type).each do |item_type, group| %>
+  <% capital_details.investments.group_by(&:investment_type).each do |item_type, group| %>
     <%= app_card_list(items: group, item_name: label_text("investment_type.#{item_type}")) do |card|
           govuk_summary_list(actions: false) do |list|
             list.with_row do |row|

--- a/app/views/casework/crime_applications/sections/_investments.html.erb
+++ b/app/views/casework/crime_applications/sections/_investments.html.erb
@@ -2,7 +2,7 @@
   <%= govuk_summary_card(title: label_text(:investments)) do %>
     <%= govuk_summary_list(actions: false) do |list|
           list.with_row do |row|
-            row.with_key { label_text(:has_investments) }
+            row.with_key { label_text(:which_investments_does_client_have) }
             row.with_value { value_text('none') }
           end
         end %>

--- a/app/views/casework/crime_applications/sections/_investments.html.erb
+++ b/app/views/casework/crime_applications/sections/_investments.html.erb
@@ -1,4 +1,13 @@
-<% unless investments.empty? %>
+<% if investments.empty? && crime_application.requires_full_capital?  %>
+  <%= govuk_summary_card(title: label_text(:investments)) do %>
+    <%= govuk_summary_list(actions: false) do |list|
+          list.with_row do |row|
+            row.with_key { label_text(:has_investments) }
+            row.with_value { value_text('none') }
+          end
+        end %>
+  <% end %>
+<% elsif investments.present? %>
   <h2 class="govuk-heading-m"><%= label_text(:investments) %></h2>
 
   <% investments.group_by(&:investment_type).each do |item_type, group| %>

--- a/app/views/casework/crime_applications/sections/_national_savings_certificates.html.erb
+++ b/app/views/casework/crime_applications/sections/_national_savings_certificates.html.erb
@@ -1,4 +1,4 @@
-<% if national_savings_certificates.empty? && crime_application.requires_full_capital?  %>
+<% if capital_details.has_national_savings_certificates == 'no' %>
   <%= govuk_summary_card(title: label_text(:national_savings_certificates)) do %>
     <%= govuk_summary_list(actions: false) do |list|
           list.with_row do |row|
@@ -7,10 +7,10 @@
           end
         end %>
   <% end %>
-<% elsif national_savings_certificates.present? %>
+<% elsif capital_details.national_savings_certificates.present? %>
   <h2 class="govuk-heading-m"><%= label_text(:national_savings_certificates) %></h2>
 
-  <%= app_card_list items: national_savings_certificates, item_name: label_text(:national_savings_certificate) do |card|
+  <%= app_card_list items: capital_details.national_savings_certificates, item_name: label_text(:national_savings_certificate) do |card|
         govuk_summary_list(actions: false) do |list|
           list.with_row do |row|
             row.with_key { label_text(:national_savings_certificate_holder_number) }

--- a/app/views/casework/crime_applications/sections/_national_savings_certificates.html.erb
+++ b/app/views/casework/crime_applications/sections/_national_savings_certificates.html.erb
@@ -2,7 +2,7 @@
   <%= govuk_summary_card(title: label_text(:national_savings_certificates)) do %>
     <%= govuk_summary_list(actions: false) do |list|
           list.with_row do |row|
-            row.with_key { label_text(:has_national_savings_certificates) }
+            row.with_key { label_text(:does_client_have_national_savings_certificates) }
             row.with_value { value_text('none') }
           end
         end %>

--- a/app/views/casework/crime_applications/sections/_national_savings_certificates.html.erb
+++ b/app/views/casework/crime_applications/sections/_national_savings_certificates.html.erb
@@ -1,4 +1,13 @@
-<% unless national_savings_certificates.empty? %>
+<% if national_savings_certificates.empty? && crime_application.requires_full_capital?  %>
+  <%= govuk_summary_card(title: label_text(:national_savings_certificates)) do %>
+    <%= govuk_summary_list(actions: false) do |list|
+          list.with_row do |row|
+            row.with_key { label_text(:has_national_savings_certificates) }
+            row.with_value { value_text('none') }
+          end
+        end %>
+  <% end %>
+<% elsif national_savings_certificates.present? %>
   <h2 class="govuk-heading-m"><%= label_text(:national_savings_certificates) %></h2>
 
   <%= app_card_list items: national_savings_certificates, item_name: label_text(:national_savings_certificate) do |card|

--- a/app/views/casework/crime_applications/sections/_outgoing_payments.html.erb
+++ b/app/views/casework/crime_applications/sections/_outgoing_payments.html.erb
@@ -1,10 +1,19 @@
-<% if outgoing_payments %>
+<% if outgoings_details.present? %>
   <h2 class="govuk-heading-m">
     <%= label_text(:payments_the_client_pays) %>
   </h2>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-    <% if outgoing_payments.any? %>
+    <% if outgoings_details.has_no_other_outgoings == 'yes' %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:which_payments_does_the_client_pay) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t('values.none') %>
+        </dd>
+      </div>
+    <% elsif outgoing_payments.any? %>
       <% outgoing_payments.each do |payment_type, value| %>
         <%= render partial: 'payment_with_frequency',
                    locals: {
@@ -23,15 +32,6 @@
           </div>
         <% end %>
       <% end %>
-    <% else %>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= label_text(:which_payments_does_the_client_pay) %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= t('values.none') %>
-        </dd>
-      </div>
     <% end %>
   </dl>
 <% end %>

--- a/app/views/casework/crime_applications/sections/_properties.html.erb
+++ b/app/views/casework/crime_applications/sections/_properties.html.erb
@@ -1,4 +1,13 @@
-<% unless properties.empty? %>
+<% if properties.empty? && crime_application.requires_full_capital?  %>
+  <%= govuk_summary_card(title: label_text(:properties_title)) do %>
+    <%= govuk_summary_list(actions: false) do |list|
+          list.with_row do |row|
+            row.with_key { label_text(:has_assets) }
+            row.with_value { value_text('none') }
+          end
+        end %>
+  <% end %>
+<% elsif properties.present? %>
   <h2 class="govuk-heading-m"><%= label_text(:properties_title) %></h2>
 
   <% properties.group_by(&:property_type).each do |item_type, group| %>

--- a/app/views/casework/crime_applications/sections/_properties.html.erb
+++ b/app/views/casework/crime_applications/sections/_properties.html.erb
@@ -1,4 +1,4 @@
-<% if properties.empty? && crime_application.requires_full_capital?  %>
+<% if capital_details.has_no_properties == 'yes'  %>
   <%= govuk_summary_card(title: label_text(:properties_title)) do %>
     <%= govuk_summary_list(actions: false) do |list|
           list.with_row do |row|
@@ -7,10 +7,10 @@
           end
         end %>
   <% end %>
-<% elsif properties.present? %>
+<% elsif capital_details.properties.present? %>
   <h2 class="govuk-heading-m"><%= label_text(:properties_title) %></h2>
 
-  <% properties.group_by(&:property_type).each do |item_type, group| %>
+  <% capital_details.properties.group_by(&:property_type).each do |item_type, group| %>
     <%= app_card_list(items: group, item_name: label_text("property_type.#{item_type}")) do |card|
           property = card.item
           asset = PropertiesPresenter::PROPERTY_TYPE_MAPPING[property.property_type.to_sym][:display_name]

--- a/app/views/casework/crime_applications/sections/_properties.html.erb
+++ b/app/views/casework/crime_applications/sections/_properties.html.erb
@@ -2,7 +2,7 @@
   <%= govuk_summary_card(title: label_text(:properties_title)) do %>
     <%= govuk_summary_list(actions: false) do |list|
           list.with_row do |row|
-            row.with_key { label_text(:has_assets) }
+            row.with_key { label_text(:which_assets_does_the_client_own) }
             row.with_value { value_text('none') }
           end
         end %>

--- a/app/views/casework/crime_applications/sections/_savings.html.erb
+++ b/app/views/casework/crime_applications/sections/_savings.html.erb
@@ -1,4 +1,4 @@
-<% if savings.empty? && crime_application.requires_full_capital?  %>
+<% if capital_details.has_no_savings == 'yes' %>
   <%= govuk_summary_card(title: label_text(:savings)) do %>
     <%= govuk_summary_list(actions: false) do |list|
           list.with_row do |row|
@@ -7,10 +7,10 @@
           end
         end %>
   <% end %>
-<% elsif savings.present? %>
+<% elsif capital_details.savings.present? %>
   <h2 class="govuk-heading-m"><%= label_text(:savings) %></h2>
 
-  <% savings.group_by(&:saving_type).each do |item_type, group| %>
+  <% capital_details.savings.group_by(&:saving_type).each do |item_type, group| %>
     <%= app_card_list(items: group, item_name: label_text(item_type, scope: :saving_type)) do |card|
           govuk_summary_list(actions: false) do |list|
             list.with_row do |row|

--- a/app/views/casework/crime_applications/sections/_savings.html.erb
+++ b/app/views/casework/crime_applications/sections/_savings.html.erb
@@ -2,7 +2,7 @@
   <%= govuk_summary_card(title: label_text(:savings)) do %>
     <%= govuk_summary_list(actions: false) do |list|
           list.with_row do |row|
-            row.with_key { label_text(:has_savings_capital) }
+            row.with_key { label_text(:which_savings_does_client_have) }
             row.with_value { value_text('none') }
           end
         end %>

--- a/app/views/casework/crime_applications/sections/_savings.html.erb
+++ b/app/views/casework/crime_applications/sections/_savings.html.erb
@@ -1,4 +1,13 @@
-<% unless savings.empty? %>
+<% if savings.empty? && crime_application.requires_full_capital?  %>
+  <%= govuk_summary_card(title: label_text(:savings)) do %>
+    <%= govuk_summary_list(actions: false) do |list|
+          list.with_row do |row|
+            row.with_key { label_text(:has_savings_capital) }
+            row.with_value { value_text('none') }
+          end
+        end %>
+  <% end %>
+<% elsif savings.present? %>
   <h2 class="govuk-heading-m"><%= label_text(:savings) %></h2>
 
   <% savings.group_by(&:saving_type).each do |item_type, group| %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -96,6 +96,7 @@ en:
     date_received: 'Date received:'
     dependants: Dependants who live with the client
     details: Details
+    does_client_have_national_savings_certificates: Does the client have any National Savings Certificates?
     employment: Employment
     employment_type: Client's employment status
     end_on: Date to
@@ -106,15 +107,11 @@ en:
     first_court_hearing: First court hearing the case
     first_name: First name
     has_case_concluded: Has the case concluded?
-    has_assets: Does client have any assets?
     has_dependants: Has dependants?
     has_frozen_income_or_assets: Has income, savings or assets under a restraint or freezing order?
-    has_investments: Does client have any investments?
-    has_national_savings_certificates: Does client have any National Savings Certificates?
     has_no_other_assets: Client has no other assets or capital
     has_premium_bonds: Does client have any Premium Bonds?
     has_savings: Has savings or investments?
-    has_savings_capital: Does client have any savings?
     hearing_date: Date of next hearing
     home_address: Home address
     housing_payments: Housing payments
@@ -230,10 +227,13 @@ en:
     when: When
     who: Who
     which_housing_payment_type: Does client pay rent, mortgage, or board and lodgings?
+    which_assets_does_the_client_own: Which assets does the client own or part-own inside or outside the UK?
     will_benefit_from_trust_fund: Does your client stand to benefit from a trust fund inside or outside the UK?
     which_benefits_does_the_client_get: Which benefits does the client get?
+    which_investments_does_client_have: Which investments does the client have inside or outside the UK?
     which_payments_does_the_client_get: Which payments does the client get?
     which_payments_does_the_client_pay: Which payments does the client pay?
+    which_savings_does_client_have: Which savings does the client have inside or outside the UK?
     trust_fund_amount_held: Enter the amount held in the fund
     trust_fund_yearly_dividend: Enter the yearly dividend
     properties_title: Assets

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -106,11 +106,15 @@ en:
     first_court_hearing: First court hearing the case
     first_name: First name
     has_case_concluded: Has the case concluded?
+    has_assets: Does client have any assets?
     has_dependants: Has dependants?
     has_frozen_income_or_assets: Has income, savings or assets under a restraint or freezing order?
+    has_investments: Does client have any investments?
+    has_national_savings_certificates: Does client have any National Savings Certificates?
     has_no_other_assets: Client has no other assets or capital
     has_premium_bonds: Does client have any Premium Bonds?
     has_savings: Has savings or investments?
+    has_savings_capital: Does client have any savings?
     hearing_date: Date of next hearing
     home_address: Home address
     housing_payments: Housing payments
@@ -201,7 +205,7 @@ en:
     provider_phone_number: Phone
     return_reason_details: We'll share this information with the provider
     return_reason_details_legend: Give further details
-    saving_account_balance: Account balance 
+    saving_account_balance: Account balance
     saving_account_holder: Name the account is in 
     saving_account_number: Account number
     saving_provider_name: Name of bank, building society or other holder of the savings

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -258,4 +258,20 @@ RSpec.describe CrimeApplication do
       it { is_expected.to be true }
     end
   end
+
+  describe '#requires_full_capital?' do
+    subject(:requires_full_capital?) { application.requires_full_capital? }
+
+    context 'when application is an appeal to crown court application' do
+      it { is_expected.to be false }
+    end
+
+    context 'when application is a either way application' do
+      let(:attributes) do
+        super().deep_merge('case_details' => { 'case_type' => 'either_way' })
+      end
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -316,4 +316,24 @@ RSpec.describe CrimeApplication do
       it { is_expected.to be false }
     end
   end
+
+  describe '#relevant_ioj_passport' do
+    subject(:relevant_ioj_passport) { application.relevant_ioj_passport }
+
+    let(:attributes) do
+      super().merge('ioj_passport' => ioj_passport)
+    end
+
+    context 'when on offence and age' do
+      let(:ioj_passport) { %w[on_age_under18 on_offence] }
+
+      it { is_expected.to eq 'on_age_under18' }
+    end
+
+    context 'when on offence' do
+      let(:ioj_passport) { ['on_offence'] }
+
+      it { is_expected.to eq 'on_offence' }
+    end
+  end
 end

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -259,22 +259,6 @@ RSpec.describe CrimeApplication do
     end
   end
 
-  describe '#requires_full_capital?' do
-    subject(:requires_full_capital?) { application.requires_full_capital? }
-
-    context 'when application is an appeal to crown court application' do
-      it { is_expected.to be false }
-    end
-
-    context 'when application is a either way application' do
-      let(:attributes) do
-        super().deep_merge('case_details' => { 'case_type' => 'either_way' })
-      end
-
-      it { is_expected.to be true }
-    end
-  end
-
   describe '#last_jsa_appointment_date?' do
     subject(:last_jsa_appointment_date?) { application.last_jsa_appointment_date? }
 

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -272,9 +272,9 @@ RSpec.describe CrimeApplication do
       end
 
       it { is_expected.to be true }
-    end 
-  end 
-  
+    end
+  end
+
   describe '#last_jsa_appointment_date?' do
     subject(:last_jsa_appointment_date?) { application.last_jsa_appointment_date? }
 

--- a/spec/system/casework/viewing_an_application/application_details/income_benefits_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_benefits_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Viewing the income benefits of an application' do
     let(:application_data) do
       super().deep_merge(
         'means_details' => {
-          'income_details' => { 'income_benefits' => [] }
+          'income_details' => { 'income_benefits' => [], 'has_no_income_benefits' => 'yes' }
         }
       )
     end

--- a/spec/system/casework/viewing_an_application/application_details/income_payments_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_payments_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Viewing the income payments of an application' do
     let(:application_data) do
       super().deep_merge(
         'means_details' => {
-          'income_details' => { 'income_payments' => [] }
+          'income_details' => { 'income_payments' => [], 'has_no_income_payments' => 'yes' }
         }
       )
     end

--- a/spec/system/casework/viewing_an_application/application_details/investments_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/investments_spec.rb
@@ -40,10 +40,11 @@ RSpec.describe 'Viewing the investments of an application' do
   context 'when client does not have investments' do
     let(:application_data) do
       super().deep_merge('case_details' => { 'case_type' => 'either_way' },
-                         'means_details' => { 'capital_details' => { 'investments' => [] } })
+                         'means_details' => { 'capital_details' => { 'investments' => [],
+'has_no_investments' => 'yes' } })
     end
 
-    describe 'an absent answer investments card' do
+    describe 'a no investments card' do
       subject(:investment_card) do
         page.find('h2.govuk-summary-card__title', text: 'Investments').ancestor('div.govuk-summary-card')
       end

--- a/spec/system/casework/viewing_an_application/application_details/investments_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/investments_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Viewing the investments of an application' do
 
       it 'shows absent answer investments details' do
         within(investment_card) do |card|
-          expect(card).to have_summary_row 'Does client have any investments?', 'None'
+          expect(card).to have_summary_row 'Which investments does the client have inside or outside the UK?', 'None'
         end
       end
     end

--- a/spec/system/casework/viewing_an_application/application_details/investments_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/investments_spec.rb
@@ -36,4 +36,23 @@ RSpec.describe 'Viewing the investments of an application' do
       end
     end
   end
+
+  context 'when client does not have investments' do
+    let(:application_data) do
+      super().deep_merge('case_details' => { 'case_type' => 'either_way' },
+                         'means_details' => { 'capital_details' => { 'investments' => [] } })
+    end
+
+    describe 'an absent answer investments card' do
+      subject(:investment_card) do
+        page.find('h2.govuk-summary-card__title', text: 'Investments').ancestor('div.govuk-summary-card')
+      end
+
+      it 'shows absent answer investments details' do
+        within(investment_card) do |card|
+          expect(card).to have_summary_row 'Does client have any investments?', 'None'
+        end
+      end
+    end
+  end
 end

--- a/spec/system/casework/viewing_an_application/application_details/national_savings_certificates_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/national_savings_certificates_spec.rb
@@ -40,4 +40,23 @@ RSpec.describe 'Viewing the National Savings Certificates of an application' do
       end
     end
   end
+
+  context 'when client does not have national savings certificates' do
+    let(:application_data) do
+      super().deep_merge('case_details' => { 'case_type' => 'either_way' },
+                         'means_details' => { 'capital_details' => { 'national_savings_certificates' => [] } })
+    end
+
+    describe 'an absent answer national savings certificates card' do
+      subject(:investment_card) do
+        page.find('h2.govuk-summary-card__title', text: 'National Savings Certificates').ancestor('div.govuk-summary-card')
+      end
+
+      it 'shows absent answer national savings certificates details' do
+        within(investment_card) do |card|
+          expect(card).to have_summary_row 'Does client have any National Savings Certificates?', 'None'
+        end
+      end
+    end
+  end
 end

--- a/spec/system/casework/viewing_an_application/application_details/national_savings_certificates_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/national_savings_certificates_spec.rb
@@ -44,17 +44,18 @@ RSpec.describe 'Viewing the National Savings Certificates of an application' do
   context 'when client does not have national savings certificates' do
     let(:application_data) do
       super().deep_merge('case_details' => { 'case_type' => 'either_way' },
-                         'means_details' => { 'capital_details' => { 'national_savings_certificates' => [] } })
+                         'means_details' => { 'capital_details' => { 'national_savings_certificates' => [],
+                                                                     'has_national_savings_certificates' => 'no' } })
     end
 
-    describe 'an absent answer national savings certificates card' do
-      subject(:investment_card) do
+    describe 'a no national savings certificates card' do
+      subject(:certificates_card) do
         page.find('h2.govuk-summary-card__title',
                   text: 'National Savings Certificates').ancestor('div.govuk-summary-card')
       end
 
       it 'shows absent answer national savings certificates details' do
-        within(investment_card) do |card|
+        within(certificates_card) do |card|
           expect(card).to have_summary_row 'Does the client have any National Savings Certificates?', 'None'
         end
       end

--- a/spec/system/casework/viewing_an_application/application_details/national_savings_certificates_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/national_savings_certificates_spec.rb
@@ -49,12 +49,13 @@ RSpec.describe 'Viewing the National Savings Certificates of an application' do
 
     describe 'an absent answer national savings certificates card' do
       subject(:investment_card) do
-        page.find('h2.govuk-summary-card__title', text: 'National Savings Certificates').ancestor('div.govuk-summary-card')
+        page.find('h2.govuk-summary-card__title',
+                  text: 'National Savings Certificates').ancestor('div.govuk-summary-card')
       end
 
       it 'shows absent answer national savings certificates details' do
         within(investment_card) do |card|
-          expect(card).to have_summary_row 'Does client have any National Savings Certificates?', 'None'
+          expect(card).to have_summary_row 'Does the client have any National Savings Certificates?', 'None'
         end
       end
     end

--- a/spec/system/casework/viewing_an_application/application_details/outgoing_payments_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/outgoing_payments_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Viewing the outgoing payments of an application' do
     let(:application_data) do
       super().deep_merge(
         'means_details' => {
-          'outgoings_details' => { 'outgoings' => [] }
+          'outgoings_details' => { 'outgoings' => [], 'has_no_other_outgoings' => 'yes' }
         }
       )
     end

--- a/spec/system/casework/viewing_an_application/application_details/properties_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/properties_spec.rb
@@ -52,10 +52,11 @@ RSpec.describe 'Viewing the properties of an application' do
   context 'when client does not have properties' do
     let(:application_data) do
       super().deep_merge('case_details' => { 'case_type' => 'either_way' },
-                         'means_details' => { 'capital_details' => { 'properties' => [] } })
+                         'means_details' => { 'capital_details' => { 'properties' => [],
+'has_no_properties' => 'yes' } })
     end
 
-    describe 'an absent answer assets card' do
+    describe 'an no assets card' do
       subject(:property_card) do
         page.find('h2.govuk-summary-card__title', text: 'Assets').ancestor('div.govuk-summary-card')
       end

--- a/spec/system/casework/viewing_an_application/application_details/properties_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/properties_spec.rb
@@ -48,4 +48,23 @@ RSpec.describe 'Viewing the properties of an application' do
       end
     end
   end
+
+  context 'when client does not have properties' do
+    let(:application_data) do
+      super().deep_merge('case_details' => { 'case_type' => 'either_way' },
+                         'means_details' => { 'capital_details' => { 'properties' => [] } })
+    end
+
+    describe 'an absent answer assets card' do
+      subject(:property_card) do
+        page.find('h2.govuk-summary-card__title', text: 'Assets').ancestor('div.govuk-summary-card')
+      end
+
+      it 'shows absent answer assets details' do
+        within(property_card) do |card|
+          expect(card).to have_summary_row 'Does client have any assets?', 'None'
+        end
+      end
+    end
+  end
 end

--- a/spec/system/casework/viewing_an_application/application_details/properties_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/properties_spec.rb
@@ -62,7 +62,8 @@ RSpec.describe 'Viewing the properties of an application' do
 
       it 'shows absent answer assets details' do
         within(property_card) do |card|
-          expect(card).to have_summary_row 'Does client have any assets?', 'None'
+          expect(card).to have_summary_row 'Which assets does the client own or part-own inside or outside the UK?',
+                                           'None'
         end
       end
     end

--- a/spec/system/casework/viewing_an_application/application_details/savings_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/savings_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Viewing the savings of an application' do
 
       it 'shows absent answer savings details' do
         within(saving_card) do |card|
-          expect(card).to have_summary_row 'Does client have any savings?', 'None'
+          expect(card).to have_summary_row 'Which savings does the client have inside or outside the UK?', 'None'
         end
       end
     end

--- a/spec/system/casework/viewing_an_application/application_details/savings_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/savings_spec.rb
@@ -44,12 +44,12 @@ RSpec.describe 'Viewing the savings of an application' do
   context 'when client does not have savings' do
     let(:application_data) do
       super().deep_merge('case_details' => { 'case_type' => 'either_way' },
-                         'means_details' => { 'capital_details' => { 'savings' => [] } })
+                         'means_details' => { 'capital_details' => { 'savings' => [], 'has_no_savings' => 'yes' } })
     end
 
-    describe 'an absent answer savings card' do
+    describe 'a no savings card' do
       subject(:saving_card) do
-        page.find('h2.govuk-summary-card__title', text: 'Savings').ancestor('div.govuk-summary-card')
+        page.first('h2.govuk-summary-card__title', text: 'Savings').ancestor('div.govuk-summary-card')
       end
 
       it 'shows absent answer savings details' do

--- a/spec/system/casework/viewing_an_application/application_details/savings_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/savings_spec.rb
@@ -40,4 +40,23 @@ RSpec.describe 'Viewing the savings of an application' do
       end
     end
   end
+
+  context 'when client does not have savings' do
+    let(:application_data) do
+      super().deep_merge('case_details' => { 'case_type' => 'either_way' },
+                         'means_details' => { 'capital_details' => { 'savings' => [] } })
+    end
+
+    describe 'an absent answer savings card' do
+      subject(:saving_card) do
+        page.find('h2.govuk-summary-card__title', text: 'Savings').ancestor('div.govuk-summary-card')
+      end
+
+      it 'shows absent answer savings details' do
+        within(saving_card) do |card|
+          expect(card).to have_summary_row 'Does client have any savings?', 'None'
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
Display assets, savings, investments, national saving certificates when none selected 
Also updates income payments, income benefits and outgoings payments to use newly added attributes

## Link to relevant ticket
[CRIMAPP-735](https://dsdmoj.atlassian.net/browse/CRIMAPP-735)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="783" alt="Screenshot 2024-04-16 at 17 58 34" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/5e5fde30-28e5-4957-9313-e4e5d082653d">
<img width="1079" alt="Screenshot 2024-04-16 at 17 58 24" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/3ed32e80-4b15-415a-a98f-dfacfe5e3e6a">

## How to manually test the feature


[CRIMAPP-735]: https://dsdmoj.atlassian.net/browse/CRIMAPP-735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ