### PR TITLE
[CRIMAPP-441] Display last jsa appointment date

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    ref: '6c29ae11b8bdab158d9851307990ff8341a3bd3f'
+    tag: 'v1.0.64'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.0.64'
+    tag: 'v1.0.65'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.0.63'
+    tag: 'v1.0.64'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.0.64'
+    ref: '6c29ae11b8bdab158d9851307990ff8341a3bd3f'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 6c29ae11b8bdab158d9851307990ff8341a3bd3f
-  ref: 6c29ae11b8bdab158d9851307990ff8341a3bd3f
+  revision: 9ec9abc36bf532fe83af91455da0ae5abe51ecfd
+  tag: v1.0.64
   specs:
     laa-criminal-legal-aid-schemas (1.0.64)
       dry-schema (~> 1.13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 9ec9abc36bf532fe83af91455da0ae5abe51ecfd
-  tag: v1.0.64
+  revision: daed6ed8db2d48877656fb4bdc06443561c177f2
+  tag: v1.0.65
   specs:
-    laa-criminal-legal-aid-schemas (1.0.64)
+    laa-criminal-legal-aid-schemas (1.0.65)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: f9b07151b8c8ce7d85ecfe55f7b8358b1fd5dc32
-  tag: v1.0.63
+  revision: 6c29ae11b8bdab158d9851307990ff8341a3bd3f
+  ref: 6c29ae11b8bdab158d9851307990ff8341a3bd3f
   specs:
-    laa-criminal-legal-aid-schemas (1.0.63)
+    laa-criminal-legal-aid-schemas (1.0.64)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -154,4 +154,8 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication  # rubocop:d
   def pse?
     application_type == Types::ApplicationType['post_submission_evidence']
   end
+
+  def last_jsa_appointment_date?
+    client_details.applicant.benefit_type == 'jsa' && client_details.applicant.last_jsa_appointment_date.present?
+  end
 end

--- a/app/views/casework/crime_applications/_initial.html.erb
+++ b/app/views/casework/crime_applications/_initial.html.erb
@@ -9,7 +9,6 @@
 <%= render partial: 'offences', object: crime_application.case_details.offences %>
 <%= render partial: 'codefendants', object: crime_application.case_details.codefendants %>
 <%= render partial: 'interests_of_justice', locals: { crime_application: } %>
-<%= render partial: 'supporting_evidence', locals: { crime_application: } %>
 
 <% if FeatureFlags.means_journey.enabled? %>
   <%= render partial: 'income_details', locals: { crime_application: } %>
@@ -19,5 +18,7 @@
     <%= render partial: 'capital_details', locals: { crime_application: } %>
   <% end %>
 <% end %>
+
+<%= render partial: 'supporting_evidence', locals: { crime_application: } %>
 
 <%= render partial: 'provider_details', object: crime_application.provider_details %>

--- a/app/views/casework/crime_applications/_overview.html.erb
+++ b/app/views/casework/crime_applications/_overview.html.erb
@@ -37,6 +37,17 @@
           <%= t(overview.client_details.applicant.benefit_type.presence, scope: 'values') || t(:not_asked, scope: 'values') %>
         </dd>
       </div>
+
+      <% if overview.client_details.applicant.benefit_type == 'jsa' %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:date_of_latest_jsa_appointment) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= l overview.client_details.applicant.last_jsa_appointment_date, format: :compact %>
+          </dd>
+        </div>
+      <% end %>
     <% end %>
 
     <div class="govuk-summary-list__row">

--- a/app/views/casework/crime_applications/_overview.html.erb
+++ b/app/views/casework/crime_applications/_overview.html.erb
@@ -38,7 +38,7 @@
         </dd>
       </div>
 
-      <% if overview.client_details.applicant.benefit_type == 'jsa' %>
+      <% if overview.last_jsa_appointment_date? %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             <%= label_text(:date_of_latest_jsa_appointment) %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -99,6 +99,7 @@ en:
     date_client_remanded: When they were remanded
     date_job_lost: When did they lose their job?
     date_of_birth: Date of birth
+    date_of_latest_jsa_appointment: Date of latest JSA appointment
     date_received: 'Date received:'
     dependants: Dependants who live with the client
     details: Details

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -258,4 +258,30 @@ RSpec.describe CrimeApplication do
       it { is_expected.to be true }
     end
   end
+
+  describe '#last_jsa_appointment_date?' do
+    subject(:last_jsa_appointment_date?) { application.last_jsa_appointment_date? }
+
+    let(:last_jsa_date) { nil }
+    let(:attributes) do
+      super().deep_merge('client_details' => { 'applicant' => { 'benefit_type' => 'jsa',
+                                                                'last_jsa_appointment_date' => last_jsa_date } })
+    end
+
+    context 'when applicant has a jsa benefit type' do
+      context 'when applicant has a last jsa appointment date' do
+        let(:last_jsa_date) { 'Fri, 12 Jan 2024' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when applicant does not have a last jsa appointment date' do
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'when application does not have a jsa benefit type' do
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -78,9 +78,11 @@ RSpec.describe 'Viewing an application unassigned, open application' do
       end
 
       context 'when the benefit type is jsa' do
+        # rubocop:disable Layout/LineLength
         let(:application_data) do
-          super().deep_merge('client_details' => { 'applicant' => { 'benefit_type' => 'jsa', 'last_jsa_appointment_date' => 'Fri, 12 Jan 2024 ' } })
+          super().deep_merge('client_details' => { 'applicant' => { 'benefit_type' => 'jsa', 'last_jsa_appointment_date' => 'Fri, 12 Jan 2024' } })
         end
+        # rubocop:enable Layout/LineLength
 
         it 'shows the last jsa appointment date' do
           expect(page).to have_content("Passporting Benefit Income-based Jobseeker's Allowance (JSA)")

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -77,6 +77,17 @@ RSpec.describe 'Viewing an application unassigned, open application' do
         expect(page).to have_content('Passporting Benefit Universal Credit')
       end
 
+      context 'when the benefit type is jsa' do
+        let(:application_data) do
+          super().deep_merge('client_details' => { 'applicant' => { 'benefit_type' => 'jsa', 'last_jsa_appointment_date' => 'Fri, 12 Jan 2024 ' } })
+        end
+
+        it 'shows the last jsa appointment date' do
+          expect(page).to have_content("Passporting Benefit Income-based Jobseeker's Allowance (JSA)")
+          expect(page).to have_content('Date of latest JSA appointment 12/01/2024')
+        end
+      end
+
       context 'when it was not asked at time of application' do
         let(:application_data) do
           super().deep_merge('client_details' => { 'applicant' => { 'benefit_type' => nil } })


### PR DESCRIPTION
## Description of change
Displays last jsa appointment if benefit type is jsa and also if it is present (as for historical applications it was not previously collected)

Also moves supporting evidence section to after the means assessment sections (bug ticket 739)

## Link to relevant ticket
[CRIMAPP-441](https://dsdmoj.atlassian.net/browse/CRIMAPP-441)
[CRIMAPP-739](https://dsdmoj.atlassian.net/browse/CRIMAPP-739)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

** App with JSA with last jsa appointment date**
<img width="1213" alt="Screenshot 2024-04-18 at 12 24 31" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/54a89686-752a-43ca-a252-6940137b8277">

**App with JSA with no last jsa appointment date (historical application)**
<img width="1213" alt="Screenshot 2024-04-18 at 12 24 08" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/3fe684ea-0f41-42e2-8f90-269c7dfcd0a0">

**App with a different passporting benefit (no last jsa appointment date)**
<img width="1213" alt="Screenshot 2024-04-18 at 12 24 21" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/bd253600-5ba1-4d39-a963-6e8e6848ba0c">

**Supporting evidence displayed underneath means**
<img width="1130" alt="Screenshot 2024-04-18 at 12 36 55" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/9f95dd65-51a8-4928-8b9d-2ecc3bb9e1c3">

## How to manually test the feature
**Requires checking out of these [apply](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/776) and [datastore](https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/243) branches to test locally** 

**Scenario 1: JSA with last jsa appointment date**
On apply:

1. Start a means tested application and fill in info until you get to the nino screen
2. Enter a nino 
3. Select the JSA passporting benefit
4. Enter a last jsa appointment date
5. The dwp check should state that you do not receive a passporting benefit, select no to the result being correct, then yes to the details being correct, then select yes you can provide evidence of the passporting benefit 
6. Fill in the rest of the application ensuring you have uploaded evidence (as you will be prevented from submitting)

On review: 
1. Find the application you just submitted in the open applications page
2. Verify that the last jsa appointment date is appearing

**Scenario 2: JSA with no last jsa appointment date**
Checkout to main branch of apply and follow the same steps as scenario one. As the submission and rehydration is missing, the date won't be submitted and you will be able to verify in review that the last jsa appointment date is not shown 

You can also test submitting an app with another passporting benefit and an app with no passporting benefit and verifying that the data appears as expected 

[CRIMAPP-441]: https://dsdmoj.atlassian.net/browse/CRIMAPP-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-739]: https://dsdmoj.atlassian.net/browse/CRIMAPP-739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ