### PR TITLE
[CRIMAPP-776] Display residence type in review

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.0.71'
+    tag: 'v1.0.72'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.0.72'
+    tag: 'v1.0.75'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.0.68'
+    tag: 'v1.0.71'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: a1adca98151c6bf85a1ec002bc5a4d0db90a29e5
-  tag: v1.0.68
+  revision: 74ea259f1c1f086dd1061777fbe760da3b7158af
+  tag: v1.0.71
   specs:
-    laa-criminal-legal-aid-schemas (1.0.68)
+    laa-criminal-legal-aid-schemas (1.0.71)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 2c2cd499556ce9e86f468d5bd3c5e2ee746e32cd
-  tag: v1.0.72
+  revision: 3efafc9d0d4a2a5a7dca9c00a4f6adbc2ce7ab38
+  tag: v1.0.75
   specs:
-    laa-criminal-legal-aid-schemas (1.0.72)
+    laa-criminal-legal-aid-schemas (1.0.75)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 74ea259f1c1f086dd1061777fbe760da3b7158af
-  tag: v1.0.71
+  revision: 2c2cd499556ce9e86f468d5bd3c5e2ee746e32cd
+  tag: v1.0.72
   specs:
-    laa-criminal-legal-aid-schemas (1.0.71)
+    laa-criminal-legal-aid-schemas (1.0.72)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/views/casework/crime_applications/_client_details.html.erb
+++ b/app/views/casework/crime_applications/_client_details.html.erb
@@ -65,10 +65,10 @@
         <% if applicant.residence_type == 'someone_else' %>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-              <%= label_text(:relationship_to_someone_else) %>
+              <%= label_text(:relationship_to_owner_of_usual_home_address) %>
             </dt>
             <dd class="govuk-summary-list__value">
-              <%= applicant.relationship_to_someone_else %>
+              <%= applicant.relationship_to_owner_of_usual_home_address %>
             </dd>
           </div>
         <% end %>

--- a/app/views/casework/crime_applications/_client_details.html.erb
+++ b/app/views/casework/crime_applications/_client_details.html.erb
@@ -53,18 +53,40 @@
           <%= applicant_tel.presence || t(:not_provided, scope: 'values') %>
         </dd>
       </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= label_text(:home_address) %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <% if applicant.home_address %>
-            <%= render 'address', address: applicant.home_address %>
-          <% else %>
-            <%= t(:no_home_address, scope: 'values') %>
-          <% end %>
-        </dd>
-      </div>
+      <% if applicant.residence_type.present? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:residence_type) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= t(applicant.residence_type, scope: 'values.residence_type') %>
+          </dd>
+        </div>
+        <% if applicant.residence_type == 'someone_else' %>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              <%= label_text(:relationship_to_someone_else) %>
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= applicant.relationship_to_someone_else %>
+            </dd>
+          </div>
+        <% end %>
+      <% end %>
+      <% if applicant.residence_type != 'none' %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:home_address) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <% if applicant.home_address %>
+              <%= render 'address', address: applicant.home_address %>
+            <% else %>
+              <%= t(:no_home_address, scope: 'values') %>
+            <% end %>
+          </dd>
+        </div>
+      <% end %>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           <%= label_text(:correspondence_address) %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -209,7 +209,7 @@ en:
     provider_details: Provider details
     provider_email: Email address
     provider_phone_number: Phone
-    relationship_to_someone_else: Relationship to client
+    relationship_to_owner_of_usual_home_address: Relationship to client
     residence_type: Where the client lives
     return_reason_details: We'll share this information with the provider
     return_reason_details_legend: Give further details

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -209,6 +209,8 @@ en:
     provider_details: Provider details
     provider_email: Email address
     provider_phone_number: Phone
+    relationship_to_someone_else: Relationship to client
+    residence_type: Where the client lives
     return_reason_details: We'll share this information with the provider
     return_reason_details_legend: Give further details
     saving_account_balance: Account balance
@@ -350,6 +352,15 @@ en:
       other: "%{count} days"
       last: "Between %{count} and %{limit} days"
     days_passed_range: "Between %{first} and %{last} days"
+    residence_type:
+      rented: In rented accommodation
+      temporary: In temporary accommodation
+      parents: With their parents
+      applicant_owned: In a property they own
+      partner_owned: In a property their partner owns
+      joint_owned: In a property they and their partner both own
+      someone_else: In someone else's home
+      none: They do not have a fixed home address
     review_status:
       submitted: Open
       open: Open

--- a/spec/system/casework/viewing_an_application/address_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/address_details_spec.rb
@@ -19,8 +19,9 @@ RSpec.describe 'Viewing an applications address details' do
 
     context 'when home address question was not asked' do
       let(:application_data) do
-        super().deep_merge('client_details' => { 'applicant' => { 'residence_type' => 'none',
-                                                                  'relationship_to_owner_of_usual_home_address' => nil } })
+        super().deep_merge('client_details' =>
+                             { 'applicant' => { 'residence_type' => 'none',
+                                                'relationship_to_owner_of_usual_home_address' => nil } })
       end
 
       it 'does not show the home address' do

--- a/spec/system/casework/viewing_an_application/address_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/address_details_spec.rb
@@ -9,10 +9,23 @@ RSpec.describe 'Viewing an applications address details' do
   end
 
   describe 'Home address' do
-    subject(:home_address) { page.find('dt', text: 'Home address').find('+dd') }
+    context 'when home address is present' do
+      subject(:home_address) { page.find('dt', text: 'Home address').find('+dd') }
 
-    it 'shows the applicants postal address' do
-      expect(home_address).to have_content('1 Road Village Some nice city SW1A 2AA United Kingdom')
+      it 'shows the applicants postal address' do
+        expect(home_address).to have_content('1 Road Village Some nice city SW1A 2AA United Kingdom')
+      end
+    end
+
+    context 'when home address question was not asked' do
+      let(:application_data) do
+        super().deep_merge('client_details' => { 'applicant' => { 'residence_type' => 'none',
+                                                                  'relationship_to_someone_else' => nil } })
+      end
+
+      it 'does not show the home address' do
+        expect(page).not_to have_content('Home address')
+      end
     end
   end
 

--- a/spec/system/casework/viewing_an_application/address_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/address_details_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Viewing an applications address details' do
     context 'when home address question was not asked' do
       let(:application_data) do
         super().deep_merge('client_details' => { 'applicant' => { 'residence_type' => 'none',
-                                                                  'relationship_to_someone_else' => nil } })
+                                                                  'relationship_to_owner_of_usual_home_address' => nil } })
       end
 
       it 'does not show the home address' do

--- a/spec/system/casework/viewing_an_application/application_details/national_savings_certificates_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/national_savings_certificates_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Viewing the National Savings Certificates of an application' do
         ).ancestor('div.govuk-summary-card')
       end
 
-      it 'shows Iational Savings Certificates details' do # rubocop:disable RSpec/MultipleExpectations
+      it 'shows National Savings Certificates details' do # rubocop:disable RSpec/MultipleExpectations
         within(certificate_card) do |card|
           expect(card).to have_summary_row 'What is the customer number or holder number?', 'A123'
           expect(card).to have_summary_row 'What is the certificate number?', 'B456'

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -415,4 +415,41 @@ RSpec.describe 'Viewing an application unassigned, open application' do
       end
     end
   end
+
+  describe 'displaying the residence type' do
+    context 'when the application has a residence type' do
+      let(:application_data) do
+        super().deep_merge('client_details' => { 'applicant' => { 'residence_type' => 'rented',
+                                                                  'relationship_to_someone_else' => nil } })
+      end
+
+      it 'shows the benefit type' do
+        expect(page).to have_content('Where the client lives In rented accommodation')
+      end
+
+      context 'when the residence type is someone else' do
+        let(:application_data) do
+          super().deep_merge('client_details' => { 'applicant' => { 'residence_type' => 'someone_else',
+                                                                    'relationship_to_someone_else' => 'Friend' } })
+        end
+
+        it 'shows the relationship to client' do
+          expect(page).to have_content("Where the client lives In someone else's home")
+          expect(page).to have_content('Relationship to client Friend')
+        end
+      end
+
+      context 'when it was not asked at time of application' do
+        let(:application_data) do
+          super().deep_merge('client_details' => { 'applicant' => { 'residence_type' => nil,
+                                                                    'relationship_to_someone_else' => nil } })
+        end
+
+        it 'does not display' do
+          expect(page).not_to have_content('Where the client lives')
+          expect(page).not_to have_content('Relationship to client Friend')
+        end
+      end
+    end
+  end
 end

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -424,7 +424,7 @@ RSpec.describe 'Viewing an application unassigned, open application' do
                                                 'relationship_to_owner_of_usual_home_address' => nil } })
       end
 
-      it 'shows the benefit type' do
+      it 'shows the residence type' do
         expect(page).to have_content('Where the client lives In rented accommodation')
       end
 

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -420,7 +420,7 @@ RSpec.describe 'Viewing an application unassigned, open application' do
     context 'when the application has a residence type' do
       let(:application_data) do
         super().deep_merge('client_details' => { 'applicant' => { 'residence_type' => 'rented',
-                                                                  'relationship_to_someone_else' => nil } })
+                                                                  'relationship_to_owner_of_usual_home_address' => nil } })
       end
 
       it 'shows the benefit type' do
@@ -430,7 +430,7 @@ RSpec.describe 'Viewing an application unassigned, open application' do
       context 'when the residence type is someone else' do
         let(:application_data) do
           super().deep_merge('client_details' => { 'applicant' => { 'residence_type' => 'someone_else',
-                                                                    'relationship_to_someone_else' => 'Friend' } })
+                                                                    'relationship_to_owner_of_usual_home_address' => 'Friend' } })
         end
 
         it 'shows the relationship to client' do
@@ -442,7 +442,7 @@ RSpec.describe 'Viewing an application unassigned, open application' do
       context 'when it was not asked at time of application' do
         let(:application_data) do
           super().deep_merge('client_details' => { 'applicant' => { 'residence_type' => nil,
-                                                                    'relationship_to_someone_else' => nil } })
+                                                                    'relationship_to_owner_of_usual_home_address' => nil } })
         end
 
         it 'does not display' do

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -419,8 +419,9 @@ RSpec.describe 'Viewing an application unassigned, open application' do
   describe 'displaying the residence type' do
     context 'when the application has a residence type' do
       let(:application_data) do
-        super().deep_merge('client_details' => { 'applicant' => { 'residence_type' => 'rented',
-                                                                  'relationship_to_owner_of_usual_home_address' => nil } })
+        super().deep_merge('client_details' =>
+                             { 'applicant' => { 'residence_type' => 'rented',
+                                                'relationship_to_owner_of_usual_home_address' => nil } })
       end
 
       it 'shows the benefit type' do
@@ -429,8 +430,9 @@ RSpec.describe 'Viewing an application unassigned, open application' do
 
       context 'when the residence type is someone else' do
         let(:application_data) do
-          super().deep_merge('client_details' => { 'applicant' => { 'residence_type' => 'someone_else',
-                                                                    'relationship_to_owner_of_usual_home_address' => 'Friend' } })
+          super().deep_merge('client_details' =>
+                               { 'applicant' => { 'residence_type' => 'someone_else',
+                                                  'relationship_to_owner_of_usual_home_address' => 'Friend' } })
         end
 
         it 'shows the relationship to client' do
@@ -441,8 +443,9 @@ RSpec.describe 'Viewing an application unassigned, open application' do
 
       context 'when it was not asked at time of application' do
         let(:application_data) do
-          super().deep_merge('client_details' => { 'applicant' => { 'residence_type' => nil,
-                                                                    'relationship_to_owner_of_usual_home_address' => nil } })
+          super().deep_merge('client_details' =>
+                               { 'applicant' => { 'residence_type' => nil,
+                                                  'relationship_to_owner_of_usual_home_address' => nil } })
         end
 
         it 'does not display' do


### PR DESCRIPTION
## Description of change
Displays residence type on review if present
Does not display home address row if residence type is none (as question is not asked in apply)

## Link to relevant ticket
[CRIMAPP-776](https://dsdmoj.atlassian.net/browse/CRIMAPP-776)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

**When question was asked**
<img width="880" alt="Screenshot 2024-04-24 at 19 17 09" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/3ac7917a-ba45-4a70-845c-d52d0ac8d7e4">
<img width="880" alt="Screenshot 2024-04-24 at 19 16 34" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/5c75a8de-80a9-443a-9255-98e8aed71c54">

**For historical apps where question was not asked**

<img width="803" alt="Screenshot 2024-04-24 at 19 17 40" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/b683a0d4-284b-46c0-b37f-40e2272072ea">

## How to manually test the feature


[CRIMAPP-776]: https://dsdmoj.atlassian.net/browse/CRIMAPP-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ