### PR TITLE
[CRIMAPP-753] Means assessment row

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -23,6 +23,18 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication # rubocop:di
     means_passport.include?(Types::MeansPassportType['on_age_under18'])
   end
 
+  def means_passported_on_benefit_check?
+    means_passport.include?(Types::MeansPassportType['on_benefit_check'])
+  end
+
+  def passport_on_evidence?
+    # TODO: Use evidence rules to determine this response
+
+    [nil, 'none'].exclude?(client_details.applicant.benefit_type) &&
+      means_passport.empty? &&
+      supporting_evidence.any?
+  end
+
   def not_means_tested?
     means_passport.include?(Types::MeansPassportType['on_not_means_tested'])
   end

--- a/app/views/casework/crime_applications/_overview.html.erb
+++ b/app/views/casework/crime_applications/_overview.html.erb
@@ -15,13 +15,19 @@
   <% unless overview.pse? %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        <%= label_text(:means_tested) %>
+        <%= label_text(:means_assessment) %>
       </dt>
       <dd class="govuk-summary-list__value">
         <% if overview.not_means_tested? %>
           <%= t('no', scope: 'values') %>
-        <% elsif overview.means_passported? %>
-          <%= govuk_tag(text: t(:passported, scope: 'values'), colour: 'blue') %>
+        <% elsif overview.means_passported_on_age? %>
+          <%= govuk_tag(text: t(:under_18, scope: 'values'), colour: 'blue') %>
+        <% elsif overview.means_passported_on_benefit_check? %>
+          <%= govuk_tag(text: t(:passported_on_benefit_check, scope: 'values'), colour: 'blue') %>
+        <% elsif overview.passport_on_evidence? %>
+          <%= govuk_tag(text: t(:passport_on_evidence, scope: 'values'), colour: 'red') %>
+        <% elsif overview.appeal_no_changes? %>
+          <%= t('appeal_no_changes', scope: 'values') %>
         <%# TODO: This needs product/content design sign off %>
         <% elsif !overview.not_means_tested? && ['none', nil].include?(overview.applicant.benefit_type) %>
           <%= t('yes', scope: 'values') %>

--- a/app/views/casework/crime_applications/_overview.html.erb
+++ b/app/views/casework/crime_applications/_overview.html.erb
@@ -21,14 +21,14 @@
         <% if overview.not_means_tested? %>
           <%= t('no', scope: 'values') %>
         <% elsif overview.means_passported_on_age? %>
-          <%= govuk_tag(text: t(:under_18, scope: 'values'), colour: 'blue') %>
+          <%= govuk_tag(text: t(:under18, scope: 'values'), colour: 'blue') %>
         <% elsif overview.means_passported_on_benefit_check? %>
           <%= govuk_tag(text: t(:passported_on_benefit_check, scope: 'values'), colour: 'blue') %>
         <% elsif overview.passport_on_evidence? %>
           <%= govuk_tag(text: t(:passport_on_evidence, scope: 'values'), colour: 'red') %>
         <% elsif overview.appeal_no_changes? %>
           <%= t('appeal_no_changes', scope: 'values') %>
-        <%# TODO: This needs product/content design sign off %>
+        <%# TODO: Product design to revisit %>
         <% elsif !overview.not_means_tested? && ['none', nil].include?(overview.applicant.benefit_type) %>
           <%= t('yes', scope: 'values') %>
         <% else %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -355,7 +355,7 @@ en:
     expert_examination: Expert cross-examination
     interest_of_another: Interest of another person
     other: Other
-    under_18: Under 18
+    under18: Under 18
     passported_on_benefit_check: Passported on means
     passport_on_evidence: Passport on evidence
     on_age_under18: Not needed because the client is under 18 years old

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -165,7 +165,7 @@ en:
     legal_representative: Legal representative
     lost_job_in_custody: Did they lose their job as a result of being in custody?
     manage_without_income: How do they manage with no income?
-    means_tested: Is application subject to means test?
+    means_assessment: Means assessment
     name: Name
     national_crime_team: CAT 2
     national_insurance_number: National Insurance number
@@ -311,6 +311,7 @@ en:
     does_not_pay: Does not pay
     already_in_crown_court: Trial already in crown court
     appeal_to_crown_court: Appeal to crown court
+    appeal_no_changes: Appeal to Crown Ct - no CIFC
     appeal_to_crown_court_with_changes: Appeal to crown court with changes in financial circumstances
     applicant: Client
     partner: Partner
@@ -354,7 +355,9 @@ en:
     expert_examination: Expert cross-examination
     interest_of_another: Interest of another person
     other: Other
-    passported: Passported
+    under_18: Under 18
+    passported_on_benefit_check: Passported on means
+    passport_on_evidence: Passport on evidence
     on_age_under18: Not needed because the client is under 18 years old
     on_offence: Not needed based on offence
     today: Today

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -47,17 +47,17 @@ RSpec.describe 'Viewing an application unassigned, open application' do
     expect(page).to have_content('Initial application')
   end
 
-  describe 'showing the means tested value' do
-    subject(:means_tested_badge) do
+  describe 'showing the means assessment value' do
+    subject(:means_assessment_badge) do
       find('.govuk-summary-list__key',
-           text: 'Is application subject to means test')
+           text: 'Means assessment')
         .sibling('.govuk-summary-list__value')
     end
 
     context 'when the application is means passported' do
       it 'shows the blue passported badge' do
-        expect(means_tested_badge).to have_content('Passported')
-        expect(means_tested_badge).to have_css('.govuk-tag--blue')
+        expect(means_assessment_badge).to have_content('Passported')
+        expect(means_assessment_badge).to have_css('.govuk-tag--blue')
       end
     end
 
@@ -65,8 +65,8 @@ RSpec.describe 'Viewing an application unassigned, open application' do
       let(:application_data) { super().merge('means_passport' => []) }
 
       it 'shows the red undetermined badge' do
-        expect(means_tested_badge).to have_content('Undetermined')
-        expect(means_tested_badge).to have_css('.govuk-tag--red')
+        expect(means_assessment_badge).to have_content('Undetermined')
+        expect(means_assessment_badge).to have_css('.govuk-tag--red')
       end
     end
   end

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -54,19 +54,60 @@ RSpec.describe 'Viewing an application unassigned, open application' do
         .sibling('.govuk-summary-list__value')
     end
 
-    context 'when the application is means passported' do
+    context 'when the application has a means passport' do
       it 'shows the blue passported badge' do
         expect(means_assessment_badge).to have_content('Passported')
         expect(means_assessment_badge).to have_css('.govuk-tag--blue')
       end
     end
 
-    context 'when the application is not means passported' do
-      let(:application_data) { super().merge('means_passport' => []) }
+    context 'when the application has no means passport' do
+      context 'when the application has a benefit_type and evidence' do
+        let(:application_data) { super().merge('means_passport' => []) }
 
-      it 'shows the red undetermined badge' do
-        expect(means_assessment_badge).to have_content('Undetermined')
-        expect(means_assessment_badge).to have_css('.govuk-tag--red')
+        it 'shows the red passport on evidence badge' do
+          expect(means_assessment_badge).to have_content('Passport on evidence')
+          expect(means_assessment_badge).to have_css('.govuk-tag--red')
+        end
+      end
+
+      context 'when the application has a benefit_type and no evidence' do
+        let(:application_data) { super().merge('means_passport' => [], 'supporting_evidence' => []) }
+
+        it 'shows the red undetermined badge' do
+          expect(means_assessment_badge).to have_content('Undetermined')
+          expect(means_assessment_badge).to have_css('.govuk-tag--red')
+        end
+      end
+
+      context 'when the application has no benefit_type and is not an appeal no changes case type' do
+        let(:application_data) do
+          super().deep_merge(
+            'means_passport' => [],
+            'supporting_evidence' => [],
+            'client_details' => { 'applicant' => { 'benefit_type' => nil } },
+            'case_details' => { 'case_type' => 'appeal_to_crown_court', 'appeal_reference_number' => 'appeal_maat_id' }
+          )
+        end
+
+        it 'shows the red undetermined badge' do
+          expect(page).to have_content('Means assessment Appeal to Crown Ct - no CIFC')
+        end
+      end
+
+      context 'when the application has no benefit type and is means assessed' do
+        let(:application_data) do
+          super().deep_merge(
+            'means_passport' => [],
+            'supporting_evidence' => [],
+            'client_details' => { 'applicant' => { 'benefit_type' => 'none' } },
+            'case_details' => { 'case_type' => 'summary_only' }
+          )
+        end
+
+        it 'shows the red undetermined badge' do
+          expect(page).to have_content('Means assessment Yes')
+        end
       end
     end
   end


### PR DESCRIPTION
## Description of change
Display to the caseworker some helpful information about the passport/means assessment expectations of an application.

Follows these rules discussed with PM/Content/Design https://docs.google.com/spreadsheets/d/1ol92L-kutd-8ksMjrPu5D4sY1PnkIO-eiWUew3Zi-MM/edit#gid=0
v
## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
