### PR TITLE
[CRIMAPP-759] Display trust fund value to 2dp

### DIFF
--- a/app/views/casework/crime_applications/sections/_trust_fund.html.erb
+++ b/app/views/casework/crime_applications/sections/_trust_fund.html.erb
@@ -18,7 +18,7 @@
           <%= label_text(:trust_fund_amount_held) %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= number_to_currency(capital_details.trust_fund_amount_held / 100, unit: '£', separator: '.', delimiter: ',') %>
+          <%= number_to_currency(capital_details.trust_fund_amount_held * 0.01) %>
         </dd>
       </div>
 
@@ -27,7 +27,7 @@
           <%= label_text(:trust_fund_yearly_dividend) %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= number_to_currency(capital_details.trust_fund_yearly_dividend / 100, unit: '£', separator: '.', delimiter: ',') %>
+          <%= number_to_currency(capital_details.trust_fund_yearly_dividend * 0.01) %>
         </dd>
       </div>
     <% end %>


### PR DESCRIPTION
## Description of change
Trust fund value was not displaying the pennies, this has been corrected

## Link to relevant ticket

## Notes for reviewer
We could do with amending the fixure data to include pence in the value so we can test this and get a failing spec if there was a regression

## Screenshots of changes (if applicable)

### Before changes:
<img width="814" alt="Screenshot 2024-04-25 at 15 44 06" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/e44d8327-3dca-456e-a35a-7c421a49ba18">

### After changes:
<img width="814" alt="Screenshot 2024-04-25 at 15 38 13" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/af6f793c-ab66-4586-a8d0-789e8d8696f0">


## How to manually test the feature
