### PR TITLE
[CRIMAPP-649] Show 'other' groups for client/partner

### DIFF
--- a/app/views/casework/crime_applications/_supporting_evidence.html.erb
+++ b/app/views/casework/crime_applications/_supporting_evidence.html.erb
@@ -18,7 +18,7 @@
 
 <!-- Client & Partner evidence -->
 <% [:client, :partner].each do |persona| %>
-  <% [:income, :outgoings, :capital].each do |group| %>
+  <% [:income, :outgoings, :capital, :none].each do |group| %>
     <%= render partial: 'prompt', locals: {
           rules: crime_application.evidence_details.rules_for(group:, persona:),
           persona: persona,

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -112,9 +112,11 @@ en:
     evidence_client_income: Evidence of their client's income
     evidence_client_outgoings: Evidence of their client's outgoings
     evidence_client_capital: Evidence of their client's capital
+    evidence_client_none: Other evidence of your client's income, outgoings or capital
     evidence_partner_income: Evidence of the partners's income
     evidence_partner_outgoings: Evidence of the partner's outgoings
     evidence_partner_capital: Evidence of the partner's capital
+    evidence_partner_none: Other evidence of the partner's income, outgoings or capital
     evidence_other: Other evidence
     extradition: Extradition
     file_name: Files


### PR DESCRIPTION
## Description of change
Shows the 'other' categories for client and partner in addition to the existing 'other'

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-649

## Notes for reviewer
Replicates Apply output

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
