### PR TITLE
[CRIMAPP-840] Update schema to v1.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.0'
+    ref: '7c75d983b82906b0f8fb3ff53b3ebe9fcd51f5b2'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.1'
+    tag: 'v1.1.3'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    ref: '7c75d983b82906b0f8fb3ff53b3ebe9fcd51f5b2'
+    tag: 'v1.1.1'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.0.75'
+    tag: 'v1.1.0'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 22152ee0b6e21034f451dfeb962d29b44ac8e0f0
-  tag: v1.1.1
+  revision: 2e077060151f63fddd728c896032e6da3179ab2c
+  tag: v1.1.3
   specs:
-    laa-criminal-legal-aid-schemas (1.1.1)
+    laa-criminal-legal-aid-schemas (1.1.3)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 49df07dfe100dfaf217c9bc875ad8ce3aac4397a
-  tag: v1.1.0
+  revision: 7c75d983b82906b0f8fb3ff53b3ebe9fcd51f5b2
+  ref: 7c75d983b82906b0f8fb3ff53b3ebe9fcd51f5b2
   specs:
     laa-criminal-legal-aid-schemas (1.1.0)
       dry-schema (~> 1.13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 3efafc9d0d4a2a5a7dca9c00a4f6adbc2ce7ab38
-  tag: v1.0.75
+  revision: 49df07dfe100dfaf217c9bc875ad8ce3aac4397a
+  tag: v1.1.0
   specs:
-    laa-criminal-legal-aid-schemas (1.0.75)
+    laa-criminal-legal-aid-schemas (1.1.0)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 7c75d983b82906b0f8fb3ff53b3ebe9fcd51f5b2
-  ref: 7c75d983b82906b0f8fb3ff53b3ebe9fcd51f5b2
+  revision: 22152ee0b6e21034f451dfeb962d29b44ac8e0f0
+  tag: v1.1.1
   specs:
-    laa-criminal-legal-aid-schemas (1.1.0)
+    laa-criminal-legal-aid-schemas (1.1.1)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/presenters/income_benefits_presenter.rb
+++ b/app/presenters/income_benefits_presenter.rb
@@ -7,13 +7,18 @@ class IncomeBenefitsPresenter < BasePresenter
     )
   end
 
-  def formatted_income_benefits
-    return unless @income_benefits
+  def formatted_income_benefits(ownership_type = 'applicant')
+    return if @income_benefits.blank?
 
+    benefits_by_owner(ownership_type)
     ordered_benefits
   end
 
   private
+
+  def benefits_by_owner(ownership_type)
+    @income_benefits.select! { |income_benefit| income_benefit.ownership_type == ownership_type }
+  end
 
   def ordered_benefits
     return {} if @income_benefits.empty?

--- a/app/presenters/income_benefits_presenter.rb
+++ b/app/presenters/income_benefits_presenter.rb
@@ -8,7 +8,7 @@ class IncomeBenefitsPresenter < BasePresenter
   end
 
   def formatted_income_benefits(ownership_type = 'applicant')
-    return if @income_benefits.blank?
+    return {} if @income_benefits.blank?
 
     benefits_by_owner(ownership_type)
     ordered_benefits

--- a/app/presenters/income_payments_presenter.rb
+++ b/app/presenters/income_payments_presenter.rb
@@ -6,7 +6,7 @@ class IncomePaymentsPresenter < BasePresenter
   end
 
   def formatted_income_payments(ownership_type = 'applicant')
-    return if @income_benefits.blank?
+    return {} if @income_payments.blank?
 
     payments_by_owner(ownership_type)
     ordered_payments

--- a/app/presenters/income_payments_presenter.rb
+++ b/app/presenters/income_payments_presenter.rb
@@ -5,13 +5,18 @@ class IncomePaymentsPresenter < BasePresenter
     )
   end
 
-  def formatted_income_payments
-    return unless @income_payments
+  def formatted_income_payments(ownership_type = 'applicant')
+    return if @income_benefits.blank?
 
+    payments_by_owner(ownership_type)
     ordered_payments
   end
 
   private
+
+  def payments_by_owner(ownership_type)
+    @income_payments.select! { |income_payment| income_payment.ownership_type == ownership_type }
+  end
 
   def ordered_payments
     return {} if @income_payments.empty?

--- a/spec/presenters/income_benefits_presenter_spec.rb
+++ b/spec/presenters/income_benefits_presenter_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe IncomeBenefitsPresenter do
 
   let(:attributes) { JSON.parse(LaaCrimeSchemas.fixture(1.0).read) }
   let(:crime_application) { CrimeApplication.new(attributes) }
+  let(:ownership_type) { 'applicant' }
 
   describe '#formatted_income_benefits' do
-    subject(:formatted_income_benefits) { benefits_presenter.formatted_income_benefits }
+    subject(:formatted_income_benefits) { benefits_presenter.formatted_income_benefits(ownership_type) }
 
     it {
       expect(formatted_income_benefits).to include({ 'child' =>
@@ -18,6 +19,21 @@ RSpec.describe IncomeBenefitsPresenter do
                                               'other' => be_a(LaaCrimeSchemas::Structs::IncomeDetails::IncomeBenefit),
                                               'working_or_child_tax_credit' => nil })
     }
+
+    # rubocop:disable Layout/LineLength
+    context 'when presenting partner income benefits' do
+      let(:ownership_type) { 'partner' }
+
+      it {
+        expect(formatted_income_benefits).to include({ 'child' => nil,
+                                                     'incapacity' => nil,
+                                                     'industrial_injuries_disablement' => nil,
+                                                     'jsa' => nil,
+                                                     'other' => nil,
+                                                     'working_or_child_tax_credit' => be_a(LaaCrimeSchemas::Structs::IncomeDetails::IncomeBenefit) })
+      }
+    end
+    # rubocop:enable Layout/LineLength
 
     context 'with empty income benefits' do
       before do

--- a/spec/presenters/income_payments_presenter_spec.rb
+++ b/spec/presenters/income_payments_presenter_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe IncomePaymentsPresenter do
 
   let(:attributes) { JSON.parse(LaaCrimeSchemas.fixture(1.0).read) }
   let(:crime_application) { CrimeApplication.new(attributes) }
+  let(:ownership_type) { 'applicant' }
 
   describe '#formatted_income_payments' do
-    subject(:formatted_income_payments) { payments_presenter.formatted_income_payments }
+    subject(:formatted_income_payments) { payments_presenter.formatted_income_payments(ownership_type) }
 
     # rubocop:disable RSpec/ExampleLength
     it {
@@ -24,6 +25,25 @@ RSpec.describe IncomePaymentsPresenter do
                                                      'other' =>
                                                        be_a(LaaCrimeSchemas::Structs::IncomeDetails::IncomePayment) })
     }
+
+    context 'when presenting partner income payments' do
+      let(:ownership_type) { 'partner' }
+
+      it {
+        expect(formatted_income_payments).to include({ 'private_pension' => nil,
+                                                       'state_pension' => nil,
+                                                       'maintenance' => nil,
+                                                       'interest_investment' => nil,
+                                                       'student_loan_grant' => nil,
+                                                       'board_from_family' => nil,
+                                                       'rent' =>
+                                                         be_a(LaaCrimeSchemas::Structs::IncomeDetails::IncomePayment),
+                                                       'financial_support_with_access' => nil,
+                                                       'from_friends_relatives' => nil,
+                                                       'other' => nil })
+      }
+    end
+
     # rubocop:enable RSpec/ExampleLength
 
     context 'with empty income payments' do


### PR DESCRIPTION
## Description of change
Updates schema version
Modifies income payments and income benefits presenters to only display payments with an ownership type of applicant ahead of partner work (and to fix specs failing due to fixture updates) 

## Link to relevant ticket
[CRIMAPP-840](https://dsdmoj.atlassian.net/browse/CRIMAPP-840)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-840]: https://dsdmoj.atlassian.net/browse/CRIMAPP-840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ