### PR TITLE
[CRIMAPP-914] Display unemployed client dwp outcome

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    ref: '4256c6fad50a9ded9209943cf235d8ac604d0f00'
+    tag: 'v1.1.4'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.0.75'
+    ref: '4256c6fad50a9ded9209943cf235d8ac604d0f00'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 3efafc9d0d4a2a5a7dca9c00a4f6adbc2ce7ab38
-  tag: v1.0.75
+  revision: 4256c6fad50a9ded9209943cf235d8ac604d0f00
+  ref: 4256c6fad50a9ded9209943cf235d8ac604d0f00
   specs:
-    laa-criminal-legal-aid-schemas (1.0.75)
+    laa-criminal-legal-aid-schemas (1.1.4)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 4256c6fad50a9ded9209943cf235d8ac604d0f00
-  ref: 4256c6fad50a9ded9209943cf235d8ac604d0f00
+  revision: 4e5f343fa5f735c80b619621a138fe36390f1eed
+  tag: v1.1.4
   specs:
     laa-criminal-legal-aid-schemas (1.1.4)
       dry-schema (~> 1.13)

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -23,10 +23,6 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication # rubocop:di
     means_passport.include?(Types::MeansPassportType['on_age_under18'])
   end
 
-  def means_passported_on_benefit?
-    means_passport.include?(Types::MeansPassportType['on_benefit_check'])
-  end
-
   def not_means_tested?
     means_passport.include?(Types::MeansPassportType['on_not_means_tested'])
   end
@@ -172,9 +168,5 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication # rubocop:di
       end
 
     @evidence_details ||= EvidenceDetailsPresenter.present(struct)
-  end
-
-  def display_benefit_section?
-    !applicant.benefit_check_attributes_not_set? || means_passported_on_benefit?
   end
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -23,6 +23,10 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication # rubocop:di
     means_passport.include?(Types::MeansPassportType['on_age_under18'])
   end
 
+  def means_passported_on_benefit?
+    means_passport.include?(Types::MeansPassportType['on_benefit_check'])
+  end
+
   def not_means_tested?
     means_passport.include?(Types::MeansPassportType['on_not_means_tested'])
   end
@@ -168,5 +172,9 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication # rubocop:di
       end
 
     @evidence_details ||= EvidenceDetailsPresenter.present(struct)
+  end
+
+  def display_benefit_section?
+    !applicant.benefit_check_attributes_not_set? || means_passported_on_benefit?
   end
 end

--- a/app/views/casework/crime_applications/_initial.html.erb
+++ b/app/views/casework/crime_applications/_initial.html.erb
@@ -5,6 +5,11 @@
              nino: crime_application.applicant.formatted_applicant_nino,
              applicant_tel: crime_application.applicant.phone_number
            } %>
+<%= render partial: 'passporting_benefit_check',
+           locals: {
+             crime_application: crime_application,
+             applicant: crime_application.applicant
+           } %>
 <%= render partial: 'case_details', object: crime_application.case_details %>
 <%= render partial: 'offences', object: crime_application.case_details.offences %>
 <%= render partial: 'codefendants', object: crime_application.case_details.codefendants %>

--- a/app/views/casework/crime_applications/_passporting_benefit_check.html.erb
+++ b/app/views/casework/crime_applications/_passporting_benefit_check.html.erb
@@ -1,0 +1,58 @@
+<% unless crime_application.means_passported_on_age? || crime_application.not_means_tested? || crime_application.appeal_no_changes? %>
+  <%= govuk_summary_card(title: label_text(:passporting_benefit_check)) do %>
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:passporting_benefit) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(applicant.benefit_type.presence, scope: 'values') || t(:not_asked, scope: 'values') %>
+        </dd>
+      </div>
+
+      <% if crime_application.last_jsa_appointment_date? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:date_of_latest_jsa_appointment) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= l applicant.last_jsa_appointment_date, format: :compact %>
+          </dd>
+        </div>
+      <% end %>
+
+      <% if applicant.benefit_check_status %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:benefit_check_status) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= t(applicant.benefit_check_status, scope: 'values.benefit_check_status') %>
+          </dd>
+        </div>
+
+        <% if applicant.confirm_details %>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              <%= label_text(:confirm_client_details) %>
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= t(applicant.confirm_details, scope: 'values') %>
+            </dd>
+          </div>
+        <% end %>
+
+        <% if applicant.has_benefit_evidence %>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              <%= label_text(:has_benefit_evidence) %>
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= t(applicant.has_benefit_evidence, scope: 'values') %>
+            </dd>
+          </div>
+        <% end  %>
+      <% end %>
+    </dl>
+  <% end %>
+<% end %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -75,6 +75,7 @@ en:
     are_wages_paid_into_account: Are client’s wages or benefits paid into this account?
     assigned_to: 'Assigned to:'
     benefit_child: Child Benefit
+    benefit_check_status: Passporting benefit check outcome
     benefit_working_or_child_tax_credit: Working Tax Credit or Child Tax Credit
     benefit_incapacity: Incapacity Benefit
     benefit_industrial_injuries_disablement: Industrial Injuries Disablement Benefit
@@ -82,7 +83,6 @@ en:
     benefit_other: Other benefits
     benefits_the_client_gets: Benefits your client gets
     capital: Capital
-    case_details: Case details
     case_details: Case details
     case_details_and_offences: Case details and offences
     case_type: Case type
@@ -95,6 +95,7 @@ en:
     codefendants: Co-defendants
     correspondence_address: Correspondence address
     conflict_of_interest: Conflict of interest?
+    confirm_client_details: Confirmed client details correct?
     criminal_applications_team: CAT 1
     criminal_applications_team_2: CAT 2
     date:
@@ -129,6 +130,7 @@ en:
     financial_change_details: Changes in the client’s financial circumstances
     first_court_hearing: First court hearing the case
     first_name: First name
+    has_benefit_evidence: Evidence can be provided?
     has_case_concluded: Has the case concluded?
     further_information: Further information
     further_information_any: Any additional information?
@@ -213,6 +215,7 @@ en:
     partner: Partner
     pays_council_tax: Does client pay Council Tax?
     passporting_benefit: Passporting Benefit
+    passporting_benefit_check: Passporting Benefit Check
     payment_board_from_family: Board from family members living with the client
     payment_financial_support_with_access: Financial support from someone who allows the client access to their assets or money
     payment_from_friends_relatives: Money from friends or family
@@ -463,6 +466,13 @@ en:
       other: Their relationship is not listed
     has_no_other_assets:
       'yes': Confirmed
+    benefit_check_status:
+      confirmed: Confirmed
+      no_check_required: No check required
+      undetermined: No match - check details are correct
+      no_record_found: No record of passporting benefit found
+      checker_unavailable: DWP was unavailable, you can try again
+      no_check_no_nino: No check made as no National Insurance number provided
   calls_to_action:
     abandon_reassign_to_self: No, do not reassign
     assign_to_self: Assign to your list

--- a/spec/system/casework/viewing_an_application/application_details/passporting_benefit_check_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/passporting_benefit_check_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'When viewing the passporting benefit check details' do
       expect(page).to have_content('Passporting Benefit Universal Credit')
     end
 
-    it 'shows the amount held in the fund and the yearly dividend' do
+    it 'shows the passporting benefit check outcome rows' do # rubocop:disable RSpec/MultipleExpectations
       expect(page).to have_content('Passporting benefit check outcome No record of passporting benefit found')
       expect(page).to have_content('Confirmed client details correct? Yes')
       expect(page).to have_content('Evidence can be provided? No')
@@ -28,10 +28,10 @@ RSpec.describe 'When viewing the passporting benefit check details' do
                                                                   'has_benefit_evidence' => nil } })
       end
 
-      it 'does not display benefit check outcome' do
-        expect(page).to_not have_content('Passporting benefit check outcome No record of passporting benefit found')
-        expect(page).to_not have_content('Confirmed client details correct? Yes')
-        expect(page).to_not have_content('Evidence can be provided? No')
+      it 'does not display the passporting benefit check outcome rows' do # rubocop:disable RSpec/MultipleExpectations
+        expect(page).not_to have_content('Passporting benefit check outcome No record of passporting benefit found')
+        expect(page).not_to have_content('Confirmed client details correct? Yes')
+        expect(page).not_to have_content('Evidence can be provided? No')
       end
     end
   end

--- a/spec/system/casework/viewing_an_application/application_details/passporting_benefit_check_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/passporting_benefit_check_spec.rb
@@ -34,5 +34,33 @@ RSpec.describe 'When viewing the passporting benefit check details' do
         expect(page).not_to have_content('Evidence can be provided? No')
       end
     end
+
+    context 'when applicant is under 18' do
+      let(:application_data) { super().merge('means_passport' => ['on_age_under18']) }
+
+      it 'does not show the passporting benefit check section' do
+        expect(page).not_to have_content('Passporting Benefit Check')
+      end
+    end
+
+    context 'when application is not means tested' do
+      let(:application_data) { super().merge('means_passport' => ['on_not_means_tested']) }
+
+      it 'does not show the passporting benefit check section' do
+        expect(page).not_to have_content('Passporting Benefit Check')
+      end
+    end
+
+    context 'when application is appeal no changes' do
+      let(:application_data) do
+        super().deep_merge('case_details' => {
+          'case_type' => 'appeal_to_crown_court',
+          'appeal_reference_number' => '123456' })
+      end
+
+      it 'does not show the passporting benefit check section' do
+        expect(page).not_to have_content('Passporting Benefit Check')
+      end
+    end
   end
 end

--- a/spec/system/casework/viewing_an_application/application_details/passporting_benefit_check_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/passporting_benefit_check_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'When viewing the passporting benefit check details' do
+  include_context 'with stubbed application'
+
+  before do
+    visit crime_application_path(application_id)
+  end
+
+  context 'with passporting benefit check details' do
+    it { expect(page).to have_content('Passporting Benefit Check') }
+
+    it 'shows whether client has a passporting benefit' do
+      expect(page).to have_content('Passporting Benefit Universal Credit')
+    end
+
+    it 'shows the amount held in the fund and the yearly dividend' do
+      expect(page).to have_content('Passporting benefit check outcome No record of passporting benefit found')
+      expect(page).to have_content('Confirmed client details correct? Yes')
+      expect(page).to have_content('Evidence can be provided? No')
+    end
+
+    context 'with no benefit check status' do
+      let(:application_data) do
+        super().deep_merge('client_details' => { 'applicant' => { 'benefit_type' => nil,
+                                                                  'benefit_check_status' => nil,
+                                                                  'confirm_details' => nil,
+                                                                  'has_benefit_evidence' => nil } })
+      end
+
+      it 'does not display benefit check outcome' do
+        expect(page).to_not have_content('Passporting benefit check outcome No record of passporting benefit found')
+        expect(page).to_not have_content('Confirmed client details correct? Yes')
+        expect(page).to_not have_content('Evidence can be provided? No')
+      end
+    end
+  end
+end

--- a/spec/system/casework/viewing_an_application/application_details/passporting_benefit_check_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/passporting_benefit_check_spec.rb
@@ -54,8 +54,9 @@ RSpec.describe 'When viewing the passporting benefit check details' do
     context 'when application is appeal no changes' do
       let(:application_data) do
         super().deep_merge('case_details' => {
-          'case_type' => 'appeal_to_crown_court',
-          'appeal_reference_number' => '123456' })
+                             'case_type' => 'appeal_to_crown_court',
+                             'appeal_reference_number' => '123456'
+                           })
       end
 
       it 'does not show the passporting benefit check section' do


### PR DESCRIPTION
## Description of change
Adds passporting benefit check section to display dwp outcome 

## Link to relevant ticket
[CRIMAPP-914](https://dsdmoj.atlassian.net/browse/CRIMAPP-914)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="973" alt="Screenshot 2024-05-23 at 16 45 48" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/935f9f80-d292-453d-a2de-7212278553ea">
<img width="948" alt="Screenshot 2024-05-23 at 16 46 52" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/d52f3cf6-d76f-4d75-b354-62f452e7577c">
<img width="948" alt="Screenshot 2024-05-23 at 16 46 43" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/3a592ad6-7436-4ba7-bc58-f885f48571df">
<img width="948" alt="Screenshot 2024-05-23 at 16 46 32" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/9d4db047-7cab-4124-8242-254269aaddfa">
<img width="1048" alt="Screenshot 2024-05-23 at 16 46 19" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/9bc32e24-4480-40b5-9d6a-a685e77f5b16">
<img width="1048" alt="Screenshot 2024-05-23 at 16 46 10" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/f360a2bb-b442-4dfe-a5ea-5e5e89d563a2">
<img width="1048" alt="Screenshot 2024-05-23 at 16 45 59" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/1ca74338-d5d2-4b24-acc2-f77ef82447ac">


## How to manually test the feature
Note: Requires [apply](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/867) and [datastore](https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/264) changes

In apply, create and submit applications for each of the scenarios outlined in the [ticket](https://dsdmoj.atlassian.net/browse/CRIMAPP-912)/[figma](https://www.figma.com/design/thkvnDBbQbHlSqzt1TE3lk/Crime-Apply?node-id=10335-85981&t=XHpTZgeMrrckBs4q-0)

Then navigate to review and confirm the view of the passporting benefit check section matches that on apply/ in the designs 

[CRIMAPP-914]: https://dsdmoj.atlassian.net/browse/CRIMAPP-914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ