### PR TITLE
CRIMAPP-875,878-employed-income-rehydration-and-adding-to-data-store and  Employed Income sections to Crime Review

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.8'
+    tag: 'v1.1.9'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.7'
+    tag: 'v1.1.8'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: e0548d4d659d742887a2ad2e5c7f019367ca0b22
-  tag: v1.1.7
+  revision: 09c640c7d87de7309b092b2dd6039ba124d15dc5
+  tag: v1.1.8
   specs:
-    laa-criminal-legal-aid-schemas (1.1.7)
+    laa-criminal-legal-aid-schemas (1.1.8)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 09c640c7d87de7309b092b2dd6039ba124d15dc5
-  tag: v1.1.8
+  revision: 4f198e136fdaccd4ffb198f94b5ebd7514498d77
+  tag: v1.1.9
   specs:
-    laa-criminal-legal-aid-schemas (1.1.8)
+    laa-criminal-legal-aid-schemas (1.1.9)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/presenters/income_payments_presenter.rb
+++ b/app/presenters/income_payments_presenter.rb
@@ -29,6 +29,6 @@ class IncomePaymentsPresenter < BasePresenter
   end
 
   def income_payment_types
-    LaaCrimeSchemas::Types::IncomePaymentType.values - LaaCrimeSchemas::Types::EmploymentIncomePaymentType.values
+    LaaCrimeSchemas::Types::OtherIncomePaymentType.values
   end
 end

--- a/app/presenters/income_payments_presenter.rb
+++ b/app/presenters/income_payments_presenter.rb
@@ -29,6 +29,6 @@ class IncomePaymentsPresenter < BasePresenter
   end
 
   def income_payment_types
-    LaaCrimeSchemas::Types::IncomePaymentType.values
+    LaaCrimeSchemas::Types::IncomePaymentType.values - LaaCrimeSchemas::Types::EmploymentIncomePaymentType.values
   end
 end

--- a/app/views/casework/crime_applications/_income_details.html.erb
+++ b/app/views/casework/crime_applications/_income_details.html.erb
@@ -4,10 +4,10 @@
   <%= label_text(:income_details) %>
 </h2>
 
-<%= render partial: 'casework/crime_applications/sections/employment', locals: { income_details: crime_application.means_details.income_details } %>
 <%= render partial: 'casework/crime_applications/sections/income', locals: { income_details: crime_application.means_details.income_details } %>
 <%= render partial: 'casework/crime_applications/sections/income_payments', locals: { income_details: crime_application.means_details.income_details, income_payments: crime_application.income_payments.formatted_income_payments } %>
 <%= render partial: 'casework/crime_applications/sections/income_benefits', locals: { income_details: crime_application.means_details.income_details, income_benefits: crime_application.income_benefits.formatted_income_benefits } %>
+<%= render partial: 'casework/crime_applications/sections/employments', locals: { income_details: crime_application.means_details.income_details } %>
 
 <%= render(
       partial: 'casework/crime_applications/sections/dependants',

--- a/app/views/casework/crime_applications/_income_details.html.erb
+++ b/app/views/casework/crime_applications/_income_details.html.erb
@@ -4,6 +4,7 @@
   <%= label_text(:income_details) %>
 </h2>
 
+<%= render partial: 'casework/crime_applications/sections/employment', locals: { income_details: crime_application.means_details.income_details } %>
 <%= render partial: 'casework/crime_applications/sections/income', locals: { income_details: crime_application.means_details.income_details } %>
 <%= render partial: 'casework/crime_applications/sections/income_payments', locals: { income_details: crime_application.means_details.income_details, income_payments: crime_application.income_payments.formatted_income_payments } %>
 <%= render partial: 'casework/crime_applications/sections/income_benefits', locals: { income_details: crime_application.means_details.income_details, income_benefits: crime_application.income_benefits.formatted_income_benefits } %>

--- a/app/views/casework/crime_applications/sections/_employments.html.erb
+++ b/app/views/casework/crime_applications/sections/_employments.html.erb
@@ -1,0 +1,55 @@
+<% if income_details.employments.present? %>
+  <h2 class="govuk-heading-l"><%= label_text(:employments_title) %></h2>
+    <%= app_card_list(items: income_details.employments, item_name: label_text('employment_title')) do |card|
+      employment = card.item
+      govuk_summary_list(actions: false) do |list|
+        list.with_row do |row|
+          row.with_key { label_text(:employer_name, scope: 'employments') }
+          row.with_value { simple_format(employment.employer_name) }
+        end
+
+        unless employment.address.nil?
+          list.with_row do |row|
+            row.with_key { label_text(:address, scope: 'employments') }
+            row.with_value { render 'address', address: employment.address }
+          end
+        end
+
+        list.with_row do |row|
+          row.with_key { label_text(:job_title, scope: 'employments') }
+          row.with_value { simple_format(employment.job_title) }
+        end
+
+        list.with_row do |row|
+          row.with_key { label_text(:amount, scope: 'employments') }
+          row.with_value { simple_format(t('values.payment_with_frequency', amount: number_to_currency(employment.amount * 0.01), frequency: t(employment.frequency, scope: [:values, :frequency]))) }
+        end
+
+        list.with_row do |row|
+          row.with_key { label_text(:metadata, scope: 'employments') }
+          row.with_value { simple_format(t(employment.metadata.before_or_after_tax['value'], scope: 'values.before_or_after_tax')) }
+        end
+
+        if employment.has_no_deductions == 'yes'
+          list.with_row do |row|
+            row.with_key { label_text(:has_no_deductions, scope: 'employments') }
+            row.with_value { value_text('none') }
+          end
+        else
+          employment.deductions.each do |deduction|
+            list.with_row do |row|
+              row.with_key { label_text(deduction.deduction_type, scope: 'deductions.deduction_type') }
+              row.with_value { simple_format(t('values.payment_with_frequency', amount: number_to_currency(deduction.amount * 0.01), frequency: t(deduction.frequency, scope: [:values, :frequency]))) }
+            end
+
+            next if deduction.details.blank?
+
+            list.with_row do |row|
+              row.with_key { label_text(:details, scope: 'deductions') }
+              row.with_value { simple_format(deduction.details) }
+            end
+          end
+        end
+      end
+    end %>
+<% end %>

--- a/app/views/casework/crime_applications/sections/_employments.html.erb
+++ b/app/views/casework/crime_applications/sections/_employments.html.erb
@@ -22,12 +22,7 @@
 
             list.with_row do |row|
               row.with_key { label_text(:amount, scope: 'employments') }
-              row.with_value { simple_format(t('values.payment_with_frequency', amount: number_to_currency(employment.amount * 0.01), frequency: t(employment.frequency, scope: [:values, :frequency]))) }
-            end
-
-            list.with_row do |row|
-              row.with_key { label_text(:metadata, scope: 'employments') }
-              row.with_value { simple_format(t(employment.metadata.before_or_after_tax['value'], scope: 'values.before_or_after_tax')) }
+              row.with_value { simple_format(t('values.payment_with_frequency_and_tax_status', amount: number_to_currency(employment.amount * 0.01), frequency: t(employment.frequency, scope: [:values, :frequency]), tax_status: t(employment.metadata.before_or_after_tax['value'], scope: 'values.before_or_after_tax'))) }
             end
 
             if employment.has_no_deductions == 'yes'

--- a/app/views/casework/crime_applications/sections/_employments.html.erb
+++ b/app/views/casework/crime_applications/sections/_employments.html.erb
@@ -1,55 +1,55 @@
 <% if income_details.employments.present? %>
   <h2 class="govuk-heading-l"><%= label_text(:employments_title) %></h2>
     <%= app_card_list(items: income_details.employments, item_name: label_text('employment_title')) do |card|
-      employment = card.item
-      govuk_summary_list(actions: false) do |list|
-        list.with_row do |row|
-          row.with_key { label_text(:employer_name, scope: 'employments') }
-          row.with_value { simple_format(employment.employer_name) }
-        end
-
-        unless employment.address.nil?
-          list.with_row do |row|
-            row.with_key { label_text(:address, scope: 'employments') }
-            row.with_value { render 'address', address: employment.address }
-          end
-        end
-
-        list.with_row do |row|
-          row.with_key { label_text(:job_title, scope: 'employments') }
-          row.with_value { simple_format(employment.job_title) }
-        end
-
-        list.with_row do |row|
-          row.with_key { label_text(:amount, scope: 'employments') }
-          row.with_value { simple_format(t('values.payment_with_frequency', amount: number_to_currency(employment.amount * 0.01), frequency: t(employment.frequency, scope: [:values, :frequency]))) }
-        end
-
-        list.with_row do |row|
-          row.with_key { label_text(:metadata, scope: 'employments') }
-          row.with_value { simple_format(t(employment.metadata.before_or_after_tax['value'], scope: 'values.before_or_after_tax')) }
-        end
-
-        if employment.has_no_deductions == 'yes'
-          list.with_row do |row|
-            row.with_key { label_text(:has_no_deductions, scope: 'employments') }
-            row.with_value { value_text('none') }
-          end
-        else
-          employment.deductions.each do |deduction|
+          employment = card.item
+          govuk_summary_list(actions: false) do |list|
             list.with_row do |row|
-              row.with_key { label_text(deduction.deduction_type, scope: 'deductions.deduction_type') }
-              row.with_value { simple_format(t('values.payment_with_frequency', amount: number_to_currency(deduction.amount * 0.01), frequency: t(deduction.frequency, scope: [:values, :frequency]))) }
+              row.with_key { label_text(:employer_name, scope: 'employments') }
+              row.with_value { simple_format(employment.employer_name) }
             end
 
-            next if deduction.details.blank?
+            unless employment.address.nil?
+              list.with_row do |row|
+                row.with_key { label_text(:address, scope: 'employments') }
+                row.with_value { render 'address', address: employment.address }
+              end
+            end
 
             list.with_row do |row|
-              row.with_key { label_text(:details, scope: 'deductions') }
-              row.with_value { simple_format(deduction.details) }
+              row.with_key { label_text(:job_title, scope: 'employments') }
+              row.with_value { simple_format(employment.job_title) }
+            end
+
+            list.with_row do |row|
+              row.with_key { label_text(:amount, scope: 'employments') }
+              row.with_value { simple_format(t('values.payment_with_frequency', amount: number_to_currency(employment.amount * 0.01), frequency: t(employment.frequency, scope: [:values, :frequency]))) }
+            end
+
+            list.with_row do |row|
+              row.with_key { label_text(:metadata, scope: 'employments') }
+              row.with_value { simple_format(t(employment.metadata.before_or_after_tax['value'], scope: 'values.before_or_after_tax')) }
+            end
+
+            if employment.has_no_deductions == 'yes'
+              list.with_row do |row|
+                row.with_key { label_text(:has_no_deductions, scope: 'employments') }
+                row.with_value { value_text('none') }
+              end
+            else
+              employment.deductions.each do |deduction|
+                list.with_row do |row|
+                  row.with_key { label_text(deduction.deduction_type, scope: 'deductions.deduction_type') }
+                  row.with_value { simple_format(t('values.payment_with_frequency', amount: number_to_currency(deduction.amount * 0.01), frequency: t(deduction.frequency, scope: [:values, :frequency]))) }
+                end
+
+                next if deduction.details.blank?
+
+                list.with_row do |row|
+                  row.with_key { label_text(:details, scope: 'deductions') }
+                  row.with_value { simple_format(deduction.details) }
+                end
+              end
             end
           end
-        end
-      end
-    end %>
+        end %>
 <% end %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -450,6 +450,7 @@ en:
       shareholder: Shareholder in a private company
       not_working: Not working
     payment_with_frequency: "%{amount} every %{frequency}"
+    payment_with_frequency_and_tax_status: "%{amount} every %{frequency} %{tax_status}"
     housing_payments:
       board_and_lodging: Board and lodgings
       mortgage: Mortgage
@@ -493,8 +494,8 @@ en:
       checker_unavailable: DWP was unavailable, you can try again
       no_check_no_nino: No check made as no National Insurance number provided
     before_or_after_tax:
-      before_tax: Before tax
-      after_tax: After tax
+      before_tax: before tax
+      after_tax: after tax
   calls_to_action:
     abandon_reassign_to_self: No, do not reassign
     assign_to_self: Assign to your list

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -444,7 +444,7 @@ en:
       other: Other
     employment_type:
       employed: Employed
-      self-employed: Self-employed
+      self_employed: Self-employed
       business_partnership: In a business partnership
       director: Company directory in a private company
       shareholder: Shareholder in a private company

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -155,6 +155,24 @@ en:
     income: Income
     income_more_than: Income more than £12,475?
     income_details: Your client's income
+    employments_title: Jobs
+    employment_title: Job
+    employments:
+      employer_name: Employer's name
+      address: Address
+      job_title: Job title
+      amount: Salary or wage
+      frequency: Frequency
+      metadata: Before or after tax?
+      has_no_deductions: Deductions
+    deductions:
+      amount: Amount
+      frequency: Frequency
+      details: Details of other deductions
+      deduction_type:
+        income_tax: Income Tax
+        national_insurance: National Insurance
+        other: Other deductions total
     income_tax_rate_above_threshold: In the last 2 years, has client paid the 40% income tax rate?
     interests_of_justice: Justification for legal aid
     interests_of_justice_type: Criteria
@@ -474,6 +492,9 @@ en:
       no_record_found: No record of passporting benefit found
       checker_unavailable: DWP was unavailable, you can try again
       no_check_no_nino: No check made as no National Insurance number provided
+    before_or_after_tax:
+      before_tax: Before tax
+      after_tax: After tax
   calls_to_action:
     abandon_reassign_to_self: No, do not reassign
     assign_to_self: Assign to your list

--- a/spec/system/casework/viewing_an_application/application_details/employments_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/employments_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe 'Viewing the employments of an application' do
           page.find('h2.govuk-summary-card__title', text: 'Job 1').ancestor('div.govuk-summary-card')
         end
 
-        it 'shows jobs details with deductions' do
+        it 'shows jobs details with deductions' do # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
           within(job_card) do |card|
             expect(card).to have_summary_row "Employer's name", 'Joe Goodwin'
             expect(card).to have_summary_row 'Address',
                                              'address_line_one_y address_line_two_y city_y postcode_y country_y'
             expect(card).to have_summary_row 'Job title', 'Supervisor'
-            expect(card).to have_summary_row 'Salary or wage', '£250.00 every year'
+            expect(card).to have_summary_row 'Salary or wage', '£250.00 every year before tax'
             expect(card).to have_summary_row 'Income Tax', '£10.00 every week'
             expect(card).to have_summary_row 'National Insurance', '£20.00 every 2 weeks'
             expect(card).to have_summary_row 'Other deductions total', '£30.00 every year'
@@ -47,13 +47,13 @@ RSpec.describe 'Viewing the employments of an application' do
           page.find('h2.govuk-summary-card__title', text: 'Job 2').ancestor('div.govuk-summary-card')
         end
 
-        it 'shows jobs details without deductions' do
+        it 'shows jobs details without deductions' do # rubocop:disable RSpec/MultipleExpectations
           within(job_card) do |card|
             expect(card).to have_summary_row "Employer's name", 'Teegan Ayala'
             expect(card).to have_summary_row 'Address',
                                              'address_line_one_x address_line_two_x city_x postcode_x country_x'
             expect(card).to have_summary_row 'Job title', 'Manager'
-            expect(card).to have_summary_row 'Salary or wage', '£350.00 every year'
+            expect(card).to have_summary_row 'Salary or wage', '£350.00 every year after tax'
             expect(card).to have_summary_row 'Deductions', 'None'
           end
         end

--- a/spec/system/casework/viewing_an_application/application_details/employments_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/employments_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing the employments of an application' do
+  include_context 'with stubbed application'
+
+  before do
+    visit crime_application_path(application_id)
+  end
+
+  context 'when client has employments' do
+    let(:means_details) { JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'means').read) }
+
+    let(:application_data) do
+      super().deep_merge('means_details' => means_details)
+    end
+
+    it 'shows the employments section' do
+      expect(page).to have_css('h2.govuk-heading-l', text: 'Jobs')
+    end
+
+    it 'shows the jobs with correct title' do
+      expect(page).to have_css('h2.govuk-summary-card__title', text: 'Job')
+    end
+
+    describe 'a jobs card' do
+      context 'with deductions' do
+        subject(:job_card) do
+          page.find('h2.govuk-summary-card__title', text: 'Job 1').ancestor('div.govuk-summary-card')
+        end
+
+        it 'shows jobs details with deductions' do
+          within(job_card) do |card|
+            expect(card).to have_summary_row "Employer's name", 'Joe Goodwin'
+            expect(card).to have_summary_row 'Address',
+                                             'address_line_one_y address_line_two_y city_y postcode_y country_y'
+            expect(card).to have_summary_row 'Job title', 'Supervisor'
+            expect(card).to have_summary_row 'Salary or wage', '£250.00 every year'
+            expect(card).to have_summary_row 'Income Tax', '£10.00 every week'
+            expect(card).to have_summary_row 'National Insurance', '£20.00 every 2 weeks'
+            expect(card).to have_summary_row 'Other deductions total', '£30.00 every year'
+          end
+        end
+      end
+
+      context 'without deductions' do
+        subject(:job_card) do
+          page.find('h2.govuk-summary-card__title', text: 'Job 2').ancestor('div.govuk-summary-card')
+        end
+
+        it 'shows jobs details without deductions' do
+          within(job_card) do |card|
+            expect(card).to have_summary_row "Employer's name", 'Teegan Ayala'
+            expect(card).to have_summary_row 'Address',
+                                             'address_line_one_x address_line_two_x city_x postcode_x country_x'
+            expect(card).to have_summary_row 'Job title', 'Manager'
+            expect(card).to have_summary_row 'Salary or wage', '£350.00 every year'
+            expect(card).to have_summary_row 'Deductions', 'None'
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Show employment and deductions in application details page

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-878
https://dsdmoj.atlassian.net/browse/CRIMAPP-875

## Notes for reviewer
> [!IMPORTANT]  
> Currently we are rehydrating only Employments loop with deductions. Standalone pages (`Employment income`, `Self assessment tax bill `and `other work benefits`) are still pending for rehydration which will be addresses in separate PR

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="740" alt="Screenshot 2024-06-05 at 15 29 22" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/195928/7b71cb37-468f-48ae-b31d-aaea45083dd4">



## How to manually test the feature
http://localhost:3001/applications/:id
