### PR TITLE
CRIMAPP-945-add-partner-wages-qestion

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.5'
+    tag: 'v1.1.7'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 5611273483540ebd003965e70aef47e08c6e6612
-  tag: v1.1.5
+  revision: e0548d4d659d742887a2ad2e5c7f019367ca0b22
+  tag: v1.1.7
   specs:
-    laa-criminal-legal-aid-schemas (1.1.5)
+    laa-criminal-legal-aid-schemas (1.1.7)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/views/casework/crime_applications/sections/_savings.html.erb
+++ b/app/views/casework/crime_applications/sections/_savings.html.erb
@@ -35,6 +35,13 @@
               row.with_key { label_text(:are_wages_paid_into_account) }
               row.with_value { value_text(card.item.are_wages_paid_into_account) }
             end
+
+            if card.item.are_partners_wages_paid_into_account
+              list.with_row do |row|
+                row.with_key { label_text(:are_partners_wages_paid_into_account) }
+                row.with_value { value_text(card.item.are_partners_wages_paid_into_account) }
+              end
+            end
             list.with_row do |row|
               row.with_key { label_text(:saving_account_holder) }
               row.with_value { value_text(card.item.ownership_type) }

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -72,7 +72,8 @@ en:
     application_start_date: Date stamp
     application_status: Status
     application_type: Application type
-    are_wages_paid_into_account: Are client’s wages or benefits paid into this account?
+    are_partners_wages_paid_into_account: Partner’s wages or benefits paid into this account?
+    are_wages_paid_into_account: Client’s wages or benefits paid into this account?
     assigned_to: 'Assigned to:'
     benefit_child: Child Benefit
     benefit_check_status: Passporting benefit check outcome

--- a/spec/system/casework/viewing_an_application/application_details/savings_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/savings_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe 'Viewing the savings of an application' do
         page.find('h2.govuk-summary-card__title', text: 'Bank account').ancestor('div.govuk-summary-card')
       end
 
+      let(:partner_wages_text) { 'Partner’s wages or benefits paid into this account?' }
+
       it 'shows savings details' do # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
         within(saving_card) do |card|
           expect(card).to have_summary_row 'Name of bank, building society or other holder of the savings', 'Halifax'
@@ -34,8 +36,23 @@ RSpec.describe 'Viewing the savings of an application' do
           expect(card).to have_summary_row 'Account number', '12345678'
           expect(card).to have_summary_row 'Account balance', '£2.00'
           expect(card).to have_summary_row 'Is the account overdrawn?', 'Yes'
-          expect(card).to have_summary_row 'Are client’s wages or benefits paid into this account?', 'Yes'
+          expect(card).to have_summary_row 'Client’s wages or benefits paid into this account?', 'Yes'
           expect(card).to have_summary_row 'Name the account is in', 'Client'
+          expect(card).not_to have_content partner_wages_text
+        end
+      end
+
+      context 'when partner wages information is given' do
+        let(:means_details) do
+          saving = super().dig('capital_details', 'savings').first
+          saving['are_partners_wages_paid_into_account'] = 'no'
+          super().deep_merge('capital_details' => { 'savings' => [saving] })
+        end
+
+        it 'shows savings details' do
+          within(saving_card) do |card|
+            expect(card).to have_summary_row partner_wages_text, 'No'
+          end
         end
       end
     end


### PR DESCRIPTION
## Description of change

Show the 'Partner’s wages or benefits paid into this account?' answer in the saving card if given.

## Link to relevant ticket

[CRIMAPP-945](https://dsdmoj.atlassian.net/browse/CRIMAPP-945)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

<img width="1036" alt="Screenshot 2024-06-05 at 16 23 49" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/4ba80180-c96f-462d-8af9-e23b47ff9276">

### After changes:

<img width="1113" alt="Screenshot 2024-06-05 at 16 23 30" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/4a948b3e-3c81-46c7-9105-853433d2403e">


## How to manually test the feature


[CRIMAPP-945]: https://dsdmoj.atlassian.net/browse/CRIMAPP-945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ