### PR TITLE
Fix bugs displaying partner section

### DIFF
--- a/app/views/casework/crime_applications/_appeal_no_changes.html.erb
+++ b/app/views/casework/crime_applications/_appeal_no_changes.html.erb
@@ -5,15 +5,6 @@
              nino: crime_application.applicant.formatted_nino,
              applicant_tel: crime_application.applicant.phone_number
            } %>
-<% if FeatureFlags.partner_journey.enabled? %>
-  <%= render partial: 'partner_details',
-             locals: {
-               crime_application: crime_application,
-               applicant: crime_application.client_details.applicant,
-               partner: crime_application.client_details.partner,
-               nino: crime_application.partner.formatted_nino,
-             } %>
-<% end %>
 <%= render partial: 'case_details', object: crime_application.case_details %>
 <%= render partial: 'offences', object: crime_application.case_details.offences %>
 <%= render partial: 'codefendants', object: crime_application.case_details.codefendants %>

--- a/app/views/casework/crime_applications/_initial.html.erb
+++ b/app/views/casework/crime_applications/_initial.html.erb
@@ -10,8 +10,7 @@
              locals: {
                crime_application: crime_application,
                applicant: crime_application.client_details.applicant,
-               partner: crime_application.client_details.partner,
-               nino: crime_application.partner.formatted_nino,
+               partner: crime_application.client_details.partner
              } %>
 <% end %>
 

--- a/app/views/casework/crime_applications/_partner_details.html.erb
+++ b/app/views/casework/crime_applications/_partner_details.html.erb
@@ -46,7 +46,7 @@
           <%= label_text(:national_insurance_number) %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= nino.presence || t(:not_provided, scope: 'values') %>
+          <%= crime_application.partner.formatted_nino.presence || t(:not_provided, scope: 'values') %>
         </dd>
       </div>
       <div class="govuk-summary-list__row">


### PR DESCRIPTION
## Description of change
Fixes error with displaying the partner section when there is no partner due to the way the nino is being passed into the partial which errors when partner is nil
Also removes the partner details from the appeal no changes partial as partner questions are not asked when the case type is appeal no changes

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
