### PR TITLE
CRIMAPP-1106 combine partner and client premium bonds

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,9 +70,10 @@ module ApplicationHelper
     end
   end
 
-  def partner_subject?
+  def partner_included_in_means?
     return false if current_crime_application.partner.blank?
 
     current_crime_application.partner.is_included_in_means_assessment
   end
+  alias partner_subject? partner_included_in_means?
 end

--- a/app/views/casework/crime_applications/_capital_details.html.erb
+++ b/app/views/casework/crime_applications/_capital_details.html.erb
@@ -14,10 +14,11 @@
       locals: { capital_details: crime_application.means_details.capital_details }
     ) %>
 
-<%= render(partial: 'casework/crime_applications/sections/premium_bonds', locals: { details: crime_application.means_details.capital_details }) %>
-<% if FeatureFlags.partner_journey.enabled? %>
+<% if FeatureFlags.partner_journey.enabled? && partner_included_in_means? %>
     <%= render(partial: 'casework/crime_applications/sections/premium_bonds_partner', locals: { details: crime_application.means_details.capital_details }) %>
-<% end %>
+  <% else %>
+    <%= render(partial: 'casework/crime_applications/sections/premium_bonds', locals: { details: crime_application.means_details.capital_details }) %>
+  <% end %>
 
 <%= render(
       partial: 'casework/crime_applications/sections/national_savings_certificates',

--- a/app/views/casework/crime_applications/sections/_premium_bonds.html.erb
+++ b/app/views/casework/crime_applications/sections/_premium_bonds.html.erb
@@ -1,5 +1,5 @@
 <% unless details.has_premium_bonds.nil? %>
-  <%= govuk_summary_card(title: label_text(:premium_bonds_client)) do %>
+  <%= govuk_summary_card(title: label_text(:premium_bonds)) do %>
     <%= govuk_summary_list(actions: false) do |list|
           list.with_row do |row|
             row.with_key { label_text(:has_premium_bonds) }

--- a/app/views/casework/crime_applications/sections/_premium_bonds_partner.html.erb
+++ b/app/views/casework/crime_applications/sections/_premium_bonds_partner.html.erb
@@ -1,20 +1,35 @@
-<% unless details.partner_has_premium_bonds.nil? %>
-  <%= govuk_summary_card(title: label_text(:premium_bonds_partner)) do %>
+<% unless details.has_premium_bonds.nil? && details.partner_has_premium_bonds.nil? %>
+  <%= govuk_summary_card(title: label_text(:premium_bonds)) do %>
     <%= govuk_summary_list(actions: false) do |list|
           list.with_row do |row|
-            row.with_key { label_text(:has_premium_bonds) }
+            row.with_key { label_text(:has_premium_bonds_client) }
+            row.with_value { value_text(details.has_premium_bonds) }
+          end
+
+          if details.has_premium_bonds == 'yes'
+            list.with_row do |row|
+              row.with_key { label_text(:premium_bonds_holder_number_client) }
+              row.with_value { details.premium_bonds_holder_number }
+            end
+          end
+
+          list.with_row do |row|
+            row.with_key { label_text(:has_premium_bonds_partner) }
             row.with_value { value_text(details.partner_has_premium_bonds) }
           end
 
           if details.partner_has_premium_bonds == 'yes'
             list.with_row do |row|
-              row.with_key { label_text(:premium_bonds_holder_number) }
+              row.with_key { label_text(:premium_bonds_holder_number_partner) }
               row.with_value { details.partner_premium_bonds_holder_number }
             end
+          end
 
+          if details.has_premium_bonds == 'yes' || details.partner_has_premium_bonds == 'yes'
             list.with_row do |row|
+              value = details.premium_bonds_total_value.to_i + details.partner_premium_bonds_total_value.to_i
               row.with_key { label_text(:premium_bonds_total_value) }
-              row.with_value { number_to_currency(details.partner_premium_bonds_total_value * 0.01) }
+              row.with_value { number_to_currency(value * 0.01) }
             end
           end
         end %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -144,7 +144,9 @@ en:
     has_dependants: Has dependants?
     has_frozen_income_or_assets: Income, savings or assets under a restraint or freezing order
     has_no_other_assets: Has no other assets or capital?
-    has_premium_bonds: Any Premium Bonds?
+    has_premium_bonds: Premium Bonds
+    has_premium_bonds_client: 'Premium Bonds: client'
+    has_premium_bonds_partner: 'Premium Bonds: partner'
     has_savings: Has savings or investments?
     has_same_address_as_client: Lives at same address as client?
     hearing_date: Date of next hearing
@@ -258,9 +260,10 @@ en:
     payments_the_client_makes: Payments your %{subject} makes
     payments_the_partner_gets: Payments the partner gets
     post_submission_evidence: Post submission evidence
-    premium_bonds_client: 'Premium Bonds: client'
+    premium_bonds: 'Premium Bonds'
     premium_bonds_holder_number: Holder number
-    premium_bonds_partner: 'Premium Bonds: partner'
+    premium_bonds_holder_number_client: 'Holder number: client'
+    premium_bonds_holder_number_partner: 'Holder number: partner'
     premium_bonds_total_value: Total value
     preorder_work_date: When you or your firm were first instructed
     preorder_work_details: Details about the urgency of the work

--- a/spec/shared_contexts/with_stubbed_application.rb
+++ b/spec/shared_contexts/with_stubbed_application.rb
@@ -1,11 +1,16 @@
-RSpec.shared_context 'with stubbed application' do
+RSpec.shared_context 'with stubbed application' do # rubocop:disable RSpec/MultipleMemoizedHelpers
   let(:application_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
   let(:income_details) { {} }
   let(:outgoings_details) { {} }
   let(:capital_details) { {} }
   let(:means_details) { { income_details:, outgoings_details:, capital_details: } }
+  let(:partner_included?) { false }
+
   let(:application_data) do
-    JSON.parse(LaaCrimeSchemas.fixture(1.0).read).deep_merge('means_details' => means_details.deep_stringify_keys)
+    JSON.parse(LaaCrimeSchemas.fixture(1.0).read).deep_merge(
+      'client_details' => { 'partner' => { 'is_included_in_means_assessment' => partner_included? } },
+      'means_details' => means_details.deep_stringify_keys
+    )
   end
 
   before do

--- a/spec/system/casework/viewing_an_application/application_details/premium_bonds_partner_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/premium_bonds_partner_spec.rb
@@ -2,64 +2,84 @@ require 'rails_helper'
 
 RSpec.describe 'Viewing the Premium Bond details of the partner' do
   include_context 'with stubbed application'
-  let(:means_details) { JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'means').read) }
+
+  let(:partner_included?) { true }
 
   before do
     visit crime_application_path(application_id)
   end
 
-  context 'when the partner has premium bonds' do
-    # rubocop:disable Layout/LineLength
-    let(:application_data) do
-      super().deep_merge('means_details' => { 'capital_details' => { 'has_premium_bonds' => 'no',
-                                                                     'premium_bonds_total_value' => nil,
-                                                                     'premium_bonds_holder_number' => nil,
-                                                                     'partner_has_premium_bonds' => 'yes',
-                                                                     'partner_premium_bonds_total_value' => 200_000,
-                                                                     'partner_premium_bonds_holder_number' => '89548A' } })
-    end
-    # rubocop:enable Layout/LineLength
-
-    it 'shows the partner premium bonds card' do
-      expect(page).to have_css('h2.govuk-summary-card__title', text: 'Premium Bonds: partner')
+  context 'when the partner has premium bonds but the client does not' do
+    subject(:premium_bonds_card) do
+      page.find('h2.govuk-summary-card__title', text: 'Premium Bonds').ancestor('div.govuk-summary-card')
     end
 
-    describe 'a premium bonds card' do
-      subject(:premium_bonds_card) do
-        page.find('h2.govuk-summary-card__title', text: 'Premium Bonds: partner').ancestor('div.govuk-summary-card')
-      end
+    let(:capital_details) do
+      {
+        'has_premium_bonds' => 'no',
+        'premium_bonds_total_value' => nil,
+        'premium_bonds_holder_number' => nil,
+        'partner_has_premium_bonds' => 'yes',
+        'partner_premium_bonds_total_value' => 200_000,
+        'partner_premium_bonds_holder_number' => '89548A'
+      }
+    end
 
-      it 'shows the Premium bonds details' do # rubocop:disable RSpec/MultipleExpectations
-        within(premium_bonds_card) do |card|
-          expect(card).to have_summary_row 'Any Premium Bonds?', 'Yes'
-          expect(card).to have_summary_row 'Total value', '£2,000.00'
-          expect(card).to have_summary_row 'Holder number', '89548A'
-        end
+    it 'shows the Premium bonds details' do # rubocop:disable RSpec/MultipleExpectations
+      within(premium_bonds_card) do |card|
+        expect(card).to have_summary_row 'Premium Bonds: client', 'No'
+        expect(card).to have_summary_row 'Premium Bonds: partner', 'Yes'
+        expect(card).to have_summary_row 'Holder number: partner', '89548A'
+        expect(card).to have_summary_row 'Total value', '£2,000.00'
       end
     end
   end
 
-  context 'when the partner has no premium bonds' do
-    let(:means_details) { super().deep_merge('capital_details' => { 'partner_has_premium_bonds' => 'no' }) }
-
-    let(:application_data) do
-      super().deep_merge('means_details' => means_details)
+  context 'when both partner and client have premium bonds' do
+    subject(:premium_bonds_card) do
+      page.find('h2.govuk-summary-card__title', text: 'Premium Bonds').ancestor('div.govuk-summary-card')
     end
 
-    it 'shows the partner premium bonds card' do
-      expect(page).to have_css('h2.govuk-summary-card__title', text: 'Premium Bonds: partner')
+    let(:capital_details) do
+      {
+        'partner_has_premium_bonds' => 'yes',
+        'partner_premium_bonds_total_value' => 200_001,
+        'partner_premium_bonds_holder_number' => '89548A'
+      }
     end
 
-    describe 'a premium bonds card' do
-      subject(:premium_bonds_card) do
-        page.find('h2.govuk-summary-card__title', text: 'Premium Bonds: partner').ancestor('div.govuk-summary-card')
+    it 'shows the Premium bonds details' do # rubocop:disable RSpec/MultipleExpectations
+      within(premium_bonds_card) do |card|
+        expect(card).to have_summary_row 'Premium Bonds: client', 'Yes'
+        expect(card).to have_summary_row 'Holder number: client', '123568A'
+        expect(card).to have_summary_row 'Premium Bonds: partner', 'Yes'
+        expect(card).to have_summary_row 'Holder number: partner', '89548A'
+        expect(card).to have_summary_row 'Total value', '£3,000.01'
       end
+    end
+  end
 
-      it 'only shows the first question' do
-        within(premium_bonds_card) do |card|
-          expect(card).to have_summary_row 'Any Premium Bonds?', 'No'
-          expect(card.all('dd').size).to be 1
-        end
+  context 'when neither the partner or the client have premium bonds' do
+    subject(:premium_bonds_card) do
+      page.find('h2.govuk-summary-card__title', text: 'Premium Bonds').ancestor('div.govuk-summary-card')
+    end
+
+    let(:capital_details) do
+      {
+        'has_premium_bonds' => 'no',
+        'premium_bonds_total_value' => nil,
+        'premium_bonds_holder_number' => nil,
+        'partner_has_premium_bonds' => 'no',
+        'partner_premium_bonds_total_value' => 200_000,
+        'partner_premium_bonds_holder_number' => '89548A'
+      }
+    end
+
+    it 'only shows the first question' do # rubocop:disable RSpec/MultipleExpectations
+      within(premium_bonds_card) do |card|
+        expect(card).to have_summary_row 'Premium Bonds: client', 'No'
+        expect(card).to have_summary_row 'Premium Bonds: partner', 'No'
+        expect(card.all('dd').size).to be 2
       end
     end
   end

--- a/spec/system/casework/viewing_an_application/application_details/premium_bonds_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/premium_bonds_spec.rb
@@ -2,17 +2,12 @@ require 'rails_helper'
 
 RSpec.describe 'Viewing the Premium Bond details' do
   include_context 'with stubbed application'
-  let(:means_details) { JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'means').read) }
 
   before do
     visit crime_application_path(application_id)
   end
 
   context 'when client has premium bonds' do
-    let(:application_data) do
-      super().deep_merge('means_details' => means_details)
-    end
-
     it 'shows the Premium Bonds card' do
       expect(page).to have_css('h2.govuk-summary-card__title', text: 'Premium Bonds')
     end
@@ -24,7 +19,7 @@ RSpec.describe 'Viewing the Premium Bond details' do
 
       it 'shows the Premium bonds details' do # rubocop:disable RSpec/MultipleExpectations
         within(premium_bonds_card) do |card|
-          expect(card).to have_summary_row 'Any Premium Bonds?', 'Yes'
+          expect(card).to have_summary_row 'Premium Bonds', 'Yes'
           expect(card).to have_summary_row 'Total value', '£1,000.00'
           expect(card).to have_summary_row 'Holder number', '123568A'
         end
@@ -33,11 +28,7 @@ RSpec.describe 'Viewing the Premium Bond details' do
   end
 
   context 'when client has no premium bonds' do
-    let(:means_details) { super().deep_merge('capital_details' => { 'has_premium_bonds' => 'no' }) }
-
-    let(:application_data) do
-      super().deep_merge('means_details' => means_details)
-    end
+    let(:capital_details) { { 'has_premium_bonds' => 'no' } }
 
     it 'shows the Premium Bonds card' do
       expect(page).to have_css('h2.govuk-summary-card__title', text: 'Premium Bonds')
@@ -50,7 +41,7 @@ RSpec.describe 'Viewing the Premium Bond details' do
 
       it 'only shows the first question' do
         within(premium_bonds_card) do |card|
-          expect(card).to have_summary_row 'Any Premium Bonds?', 'No'
+          expect(card).to have_summary_row 'Premium Bonds', 'No'
           expect(card.all('dd').size).to be 1
         end
       end


### PR DESCRIPTION
## Description of change

Combines partner an client premium bonds into a single card where appropriate.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-1106

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1244" alt="Screenshot 2024-06-24 at 17 15 49" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/1ac1e684-430e-428c-a829-0e19f1567102">


### After changes:

<img width="1112" alt="Screenshot 2024-06-24 at 16 14 05" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/2bdb89cb-ec0a-49ea-befa-7305a8626180">
<img width="1154" alt="Screenshot 2024-06-24 at 16 20 06" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/c13e0ac3-2711-478c-86d8-003d350698f0">
<img width="1262" alt="Screenshot 2024-06-24 at 16 28 31" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/34935/3bf938fc-726c-4f98-9d8c-bb0e008a5168">

## How to manually test the feature
