### PR TITLE
CRIMAPP-1029: Add Employed Income parter to Crime Review

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.19'
+    tag: 'v1.1.20'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: e84161da477f2b96ed0e6a233d4c597afa85197c
-  tag: v1.1.19
+  revision: 48abb067ba41b98d5d829c4f79d8eca8f40cace7
+  tag: v1.1.20
   specs:
-    laa-criminal-legal-aid-schemas (1.1.19)
+    laa-criminal-legal-aid-schemas (1.1.20)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -133,6 +133,18 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication # rubocop:di
     @dependants ||= DependantsPresenter.present(self[:means_details].income_details&.dependants)
   end
 
+  def employments
+    self[:means_details].income_details.employments
+  end
+
+  def applicant_employments
+    @applicant_employments ||= employments.select{|e| e.ownership_type == 'applicant'}
+  end
+
+  def partner_employments
+    @partner_employments ||= employments.select{|e| e.ownership_type == 'partner'}
+  end
+
   def income_benefits
     @income_benefits ||= IncomeBenefitsPresenter.present(self[:means_details].income_details&.income_benefits)
   end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -138,11 +138,11 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication # rubocop:di
   end
 
   def applicant_employments
-    @applicant_employments ||= employments.select{|e| e.ownership_type == 'applicant'}
+    @applicant_employments ||= employments.select { |e| e.ownership_type == 'applicant' }
   end
 
   def partner_employments
-    @partner_employments ||= employments.select{|e| e.ownership_type == 'partner'}
+    @partner_employments ||= employments.select { |e| e.ownership_type == 'partner' }
   end
 
   def income_benefits

--- a/app/presenters/income_payments_presenter.rb
+++ b/app/presenters/income_payments_presenter.rb
@@ -21,19 +21,27 @@ class IncomePaymentsPresenter < BasePresenter
   end
 
   def applicant_employment_income
-    @income_payments&.detect { |income_payment| income_payment.payment_type == 'employment' && income_payment.ownership_type == 'applicant' }
+    @income_payments&.detect do |income_payment|
+      income_payment.payment_type == 'employment' && income_payment.ownership_type == 'applicant'
+    end
   end
 
   def partner_employment_income
-    @income_payments&.detect { |income_payment| income_payment.payment_type == 'employment' && income_payment.ownership_type == 'partner' }
+    @income_payments&.detect do |income_payment|
+      income_payment.payment_type == 'employment' && income_payment.ownership_type == 'partner'
+    end
   end
 
   def applicant_other_work_benefits
-    @income_payments&.detect { |income_payment| income_payment.payment_type == 'work_benefits' && income_payment.ownership_type == 'applicant'  }
+    @income_payments&.detect do |income_payment|
+      income_payment.payment_type == 'work_benefits' && income_payment.ownership_type == 'applicant'
+    end
   end
 
   def partner_other_work_benefits
-    @income_payments&.detect { |income_payment| income_payment.payment_type == 'work_benefits' && income_payment.ownership_type == 'partner' }
+    @income_payments&.detect do |income_payment|
+      income_payment.payment_type == 'work_benefits' && income_payment.ownership_type == 'partner'
+    end
   end
 
   private

--- a/app/presenters/income_payments_presenter.rb
+++ b/app/presenters/income_payments_presenter.rb
@@ -20,12 +20,20 @@ class IncomePaymentsPresenter < BasePresenter
     ordered_payments(owners_payments)
   end
 
-  def employment_income
-    @income_payments&.detect { |income_payment| income_payment.payment_type == 'employment' }
+  def applicant_employment_income
+    @income_payments&.detect { |income_payment| income_payment.payment_type == 'employment' && income_payment.ownership_type == 'applicant' }
   end
 
-  def other_work_benefits
-    @income_payments&.detect { |income_payment| income_payment.payment_type == 'work_benefits' }
+  def partner_employment_income
+    @income_payments&.detect { |income_payment| income_payment.payment_type == 'employment' && income_payment.ownership_type == 'partner' }
+  end
+
+  def applicant_other_work_benefits
+    @income_payments&.detect { |income_payment| income_payment.payment_type == 'work_benefits' && income_payment.ownership_type == 'applicant'  }
+  end
+
+  def partner_other_work_benefits
+    @income_payments&.detect { |income_payment| income_payment.payment_type == 'work_benefits' && income_payment.ownership_type == 'partner' }
   end
 
   private

--- a/app/views/casework/crime_applications/_income_details.html.erb
+++ b/app/views/casework/crime_applications/_income_details.html.erb
@@ -9,10 +9,10 @@
 <%= render partial: 'casework/crime_applications/sections/income_payments', locals: { income_details: crime_application.means_details.income_details, income_payments: crime_application.income_payments.applicant_income_payments } %>
 <%= render partial: 'casework/crime_applications/sections/income_benefits', locals: { income_details: crime_application.means_details.income_details, income_benefits: crime_application.income_benefits.applicant_income_benefits } %>
 <% if FeatureFlags.employment_journey.enabled? %>
-  <%= render partial: 'casework/crime_applications/sections/employments', locals: { income_details: crime_application.means_details.income_details } %>
-  <%= render partial: 'casework/crime_applications/sections/employment_income', locals: { employment_income: crime_application.income_payments.employment_income } %>
+  <%= render partial: 'casework/crime_applications/sections/employment_income', locals: { employment_income: crime_application.income_payments.applicant_employment_income } %>
+  <%= render partial: 'casework/crime_applications/sections/employments', locals: { employments: crime_application.applicant_employments } %>
   <%= render partial: 'casework/crime_applications/sections/applicant_self_assessment_tax_bill', locals: { income_details: crime_application.means_details.income_details } %>
-  <%= render partial: 'casework/crime_applications/sections/applicant_other_work_benefits', locals: { income_details: crime_application.means_details.income_details, other_work_benefits: crime_application.income_payments.other_work_benefits } %>
+  <%= render partial: 'casework/crime_applications/sections/applicant_other_work_benefits', locals: { income_details: crime_application.means_details.income_details, other_work_benefits: crime_application.income_payments.applicant_other_work_benefits } %>
 <% end %>
 
 <%= render(
@@ -23,8 +23,17 @@
       }
     ) %>
 <% if FeatureFlags.partner_journey.enabled? %>
+  <h3 class="govuk-heading-m">
+    <%= label_text(:income_details_partner) %>
+  </h3>
+  <%= render partial: 'casework/crime_applications/sections/partner_employment', locals: { income_details: crime_application.means_details.income_details } %>
+  <% if FeatureFlags.employment_journey.enabled? %>
+    <%= render partial: 'casework/crime_applications/sections/employment_income', locals: { employment_income: crime_application.income_payments.partner_employment_income } %>
+    <%= render partial: 'casework/crime_applications/sections/employments', locals: { employments: crime_application.partner_employments } %>
+    <%= render partial: 'casework/crime_applications/sections/partner_self_assessment_tax_bill', locals: { income_details: crime_application.means_details.income_details } %>
+    <%= render partial: 'casework/crime_applications/sections/partner_other_work_benefits', locals: { income_details: crime_application.means_details.income_details, other_work_benefits: crime_application.income_payments.partner_other_work_benefits } %>
+  <% end %>
   <%= render partial: 'casework/crime_applications/sections/income_payments_partner', locals: { income_details: crime_application.means_details.income_details, income_payments: crime_application.income_payments.partner_income_payments } %>
   <%= render partial: 'casework/crime_applications/sections/income_benefits_partner', locals: { income_details: crime_application.means_details.income_details, income_benefits: crime_application.income_benefits.partner_income_benefits } %>
-  <%= render partial: 'casework/crime_applications/sections/partner_employment', locals: { income_details: crime_application.means_details.income_details } %>
 <% end %>
 <%= render partial: 'casework/crime_applications/sections/other_income_details', locals: { income_details: crime_application.means_details.income_details } %>

--- a/app/views/casework/crime_applications/sections/_employments.html.erb
+++ b/app/views/casework/crime_applications/sections/_employments.html.erb
@@ -1,6 +1,6 @@
-<% if income_details.employments.present? %>
+<% if employments.present? %>
   <h2 class="govuk-heading-l"><%= label_text(:employments_title) %></h2>
-    <%= app_card_list(items: income_details.employments, item_name: label_text('employment_title')) do |card|
+    <%= app_card_list(items: employments, item_name: label_text('employment_title')) do |card|
           employment = card.item
           govuk_summary_list(actions: false) do |list|
             list.with_row do |row|

--- a/app/views/casework/crime_applications/sections/_partner_other_work_benefits.html.erb
+++ b/app/views/casework/crime_applications/sections/_partner_other_work_benefits.html.erb
@@ -1,0 +1,24 @@
+<%if income_details.partner_other_work_benefit_received.present? %>
+  <%= govuk_summary_card(title: label_text(:work_benefits)) do %>
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:partner_other_work_benefit_received) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(income_details.partner_other_work_benefit_received, scope: 'values') %>
+        </dd>
+      </div>
+      <% if income_details.partner_other_work_benefit_received == 'yes' %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:partner_other_work_benefit_received_amount) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= simple_format(t('values.payment_with_frequency', amount: number_to_currency(other_work_benefits.amount * 0.01), frequency: t(other_work_benefits.frequency, scope: [:values, :frequency]))) %>
+          </dd>
+        </div>
+      <% end %>
+    </dl>
+  <% end %>
+<% end %>

--- a/app/views/casework/crime_applications/sections/_partner_self_assessment_tax_bill.html.erb
+++ b/app/views/casework/crime_applications/sections/_partner_self_assessment_tax_bill.html.erb
@@ -1,0 +1,26 @@
+<% if income_details.partner_self_assessment_tax_bill.present? %>
+  <%= govuk_summary_card(title: label_text(:self_assessment_tax_bill)) do %>
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:partner_self_assessment_tax_bill) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(income_details.partner_self_assessment_tax_bill, scope: 'values') %>
+        </dd>
+      </div>
+      <% if income_details.partner_self_assessment_tax_bill == 'yes' %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:partner_self_assessment_tax_bill_amount) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= simple_format(t('values.payment_with_frequency',
+                                amount: number_to_currency(income_details.partner_self_assessment_tax_bill_amount * 0.01),
+                                frequency: t(income_details.partner_self_assessment_tax_bill_frequency, scope: [:values, :frequency]))) %>
+          </dd>
+        </div>
+      <% end %>
+    </dl>
+  <% end %>
+<% end %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -157,6 +157,7 @@ en:
     income: Income
     income_more_than: Income more than £12,475?
     income_details: Income
+    income_details_partner: Partner's income
     employments_title: Jobs
     employment_title: Job
     employments:

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -341,9 +341,13 @@ en:
     work_benefits: Other work benefits
     applicant_other_work_benefit_received: Does your client receive any other benefits from work?
     applicant_other_work_benefit_received_amount: Total value every year
+    partner_other_work_benefit_received: Does their partner receive any other benefits from work?
+    partner_other_work_benefit_received_amount: Total value every year
     self_assessment_tax_bill: Self Assessment tax
     applicant_self_assessment_tax_bill: Does the client pay a Self Assessment tax bill?
     applicant_self_assessment_tax_bill_amount: Amount
+    partner_self_assessment_tax_bill: Does the their partner pay a Self Assessment tax bill?
+    partner_self_assessment_tax_bill_amount: Amount
 
   table_headings: &TABLE_HEADINGS
     applicant_name: Applicant's name

--- a/spec/system/casework/viewing_an_application/application_details/employments_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/employments_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'Viewing the employments of an application' do
             end
           end
         end
-        context 'job_card 1' do
+        context 'job_card 2' do
           subject(:partner_job_card) do
             page.all('h2.govuk-summary-card__title', text: 'Job 2')[1].ancestor('div.govuk-summary-card')
           end

--- a/spec/system/casework/viewing_an_application/application_details/employments_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/employments_spec.rb
@@ -24,37 +24,76 @@ RSpec.describe 'Viewing the employments of an application' do
 
     describe 'a jobs card' do
       context 'with deductions' do
-        subject(:job_card) do
-          page.find('h2.govuk-summary-card__title', text: 'Job 1').ancestor('div.govuk-summary-card')
+        context 'job_card 1' do
+          subject(:applicant_job_card) do
+            page.all('h2.govuk-summary-card__title', text: 'Job 1')[0].ancestor('div.govuk-summary-card')
+          end
+
+          it 'shows jobs details with deductions' do # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
+            within(applicant_job_card) do |card|
+              expect(card).to have_summary_row "Employer's name", 'Joe Goodwin'
+              expect(card).to have_summary_row 'Address',
+                                               'address_line_one_y address_line_two_y city_y postcode_y country_y'
+              expect(card).to have_summary_row 'Job title', 'Supervisor'
+              expect(card).to have_summary_row 'Salary or wage', '£250.00 every year before tax'
+              expect(card).to have_summary_row 'Income Tax', '£10.00 every week'
+              expect(card).to have_summary_row 'National Insurance', '£20.00 every 2 weeks'
+              expect(card).to have_summary_row 'Other deductions total', '£30.00 every year'
+            end
+          end
         end
 
-        it 'shows jobs details with deductions' do # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
-          within(job_card) do |card|
-            expect(card).to have_summary_row "Employer's name", 'Joe Goodwin'
-            expect(card).to have_summary_row 'Address',
-                                             'address_line_one_y address_line_two_y city_y postcode_y country_y'
-            expect(card).to have_summary_row 'Job title', 'Supervisor'
-            expect(card).to have_summary_row 'Salary or wage', '£250.00 every year before tax'
-            expect(card).to have_summary_row 'Income Tax', '£10.00 every week'
-            expect(card).to have_summary_row 'National Insurance', '£20.00 every 2 weeks'
-            expect(card).to have_summary_row 'Other deductions total', '£30.00 every year'
+        context 'job_card 2' do
+          subject(:partner_job_card) do
+            page.all('h2.govuk-summary-card__title', text: 'Job 1')[1].ancestor('div.govuk-summary-card')
+          end
+
+          it 'shows jobs details with deductions' do # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
+            within(partner_job_card) do |card|
+              expect(card).to have_summary_row "Employer's name", 'Andy Murray'
+              expect(card).to have_summary_row 'Address',
+                                               'address_line_one_a address_line_two_a city_a postcode_a country_a'
+              expect(card).to have_summary_row 'Job title', 'Manager'
+              expect(card).to have_summary_row 'Salary or wage', '£150.00 every year before tax'
+              expect(card).to have_summary_row 'Income Tax', '£20.00 every week'
+              expect(card).to have_summary_row 'National Insurance', '£30.00 every 2 weeks'
+              expect(card).to have_summary_row 'Other deductions total', '£40.00 every year'
+            end
           end
         end
       end
 
       context 'without deductions' do
-        subject(:job_card) do
-          page.find('h2.govuk-summary-card__title', text: 'Job 2').ancestor('div.govuk-summary-card')
-        end
+        context 'job_card 1' do
+          subject(:applicant_job_card) do
+            page.all('h2.govuk-summary-card__title', text: 'Job 2')[0].ancestor('div.govuk-summary-card')
+          end
 
-        it 'shows jobs details without deductions' do # rubocop:disable RSpec/MultipleExpectations
-          within(job_card) do |card|
-            expect(card).to have_summary_row "Employer's name", 'Teegan Ayala'
-            expect(card).to have_summary_row 'Address',
-                                             'address_line_one_x address_line_two_x city_x postcode_x country_x'
-            expect(card).to have_summary_row 'Job title', 'Manager'
-            expect(card).to have_summary_row 'Salary or wage', '£350.00 every year after tax'
-            expect(card).to have_summary_row 'Deductions', 'None'
+          it 'shows jobs details without deductions' do # rubocop:disable RSpec/MultipleExpectations
+            within(applicant_job_card) do |card|
+              expect(card).to have_summary_row "Employer's name", 'Teegan Ayala'
+              expect(card).to have_summary_row 'Address',
+                                               'address_line_one_x address_line_two_x city_x postcode_x country_x'
+              expect(card).to have_summary_row 'Job title', 'Manager'
+              expect(card).to have_summary_row 'Salary or wage', '£350.00 every year after tax'
+              expect(card).to have_summary_row 'Deductions', 'None'
+            end
+          end
+        end
+        context 'job_card 1' do
+          subject(:partner_job_card) do
+            page.all('h2.govuk-summary-card__title', text: 'Job 2')[1].ancestor('div.govuk-summary-card')
+          end
+
+          it 'shows jobs details without deductions' do # rubocop:disable RSpec/MultipleExpectations
+            within(partner_job_card) do |card|
+              expect(card).to have_summary_row "Employer's name", 'Joe Goodwin'
+              expect(card).to have_summary_row 'Address',
+                                               'address_line_one_z address_line_two_z city_z postcode_z country_z'
+              expect(card).to have_summary_row 'Job title', 'Manager'
+              expect(card).to have_summary_row 'Salary or wage', '£250.00 every year after tax'
+              expect(card).to have_summary_row 'Deductions', 'None'
+            end
           end
         end
       end

--- a/spec/system/casework/viewing_an_application/application_details/employments_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/employments_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Viewing the employments of an application' do
     visit crime_application_path(application_id)
   end
 
-  context 'when client has employments' do
+  context 'when client/partner has employments' do
     let(:means_details) { JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'means').read) }
 
     let(:application_data) do
@@ -22,14 +22,15 @@ RSpec.describe 'Viewing the employments of an application' do
       expect(page).to have_css('h2.govuk-summary-card__title', text: 'Job')
     end
 
+    # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength, RSpec/NestedGroups
     describe 'a jobs card' do
       context 'with deductions' do
-        context 'job_card 1' do
+        context 'with job_card 1' do
           subject(:applicant_job_card) do
             page.all('h2.govuk-summary-card__title', text: 'Job 1')[0].ancestor('div.govuk-summary-card')
           end
 
-          it 'shows jobs details with deductions' do # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
+          it 'shows jobs details with deductions' do
             within(applicant_job_card) do |card|
               expect(card).to have_summary_row "Employer's name", 'Joe Goodwin'
               expect(card).to have_summary_row 'Address',
@@ -43,12 +44,12 @@ RSpec.describe 'Viewing the employments of an application' do
           end
         end
 
-        context 'job_card 2' do
+        context 'with job_card 2' do
           subject(:partner_job_card) do
             page.all('h2.govuk-summary-card__title', text: 'Job 1')[1].ancestor('div.govuk-summary-card')
           end
 
-          it 'shows jobs details with deductions' do # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
+          it 'shows jobs details with deductions' do
             within(partner_job_card) do |card|
               expect(card).to have_summary_row "Employer's name", 'Andy Murray'
               expect(card).to have_summary_row 'Address',
@@ -64,12 +65,12 @@ RSpec.describe 'Viewing the employments of an application' do
       end
 
       context 'without deductions' do
-        context 'job_card 1' do
+        context 'with job_card 1' do
           subject(:applicant_job_card) do
             page.all('h2.govuk-summary-card__title', text: 'Job 2')[0].ancestor('div.govuk-summary-card')
           end
 
-          it 'shows jobs details without deductions' do # rubocop:disable RSpec/MultipleExpectations
+          it 'shows jobs details without deductions' do
             within(applicant_job_card) do |card|
               expect(card).to have_summary_row "Employer's name", 'Teegan Ayala'
               expect(card).to have_summary_row 'Address',
@@ -80,12 +81,13 @@ RSpec.describe 'Viewing the employments of an application' do
             end
           end
         end
-        context 'job_card 2' do
+
+        context 'with job_card 2' do
           subject(:partner_job_card) do
             page.all('h2.govuk-summary-card__title', text: 'Job 2')[1].ancestor('div.govuk-summary-card')
           end
 
-          it 'shows jobs details without deductions' do # rubocop:disable RSpec/MultipleExpectations
+          it 'shows jobs details without deductions' do
             within(partner_job_card) do |card|
               expect(card).to have_summary_row "Employer's name", 'Joe Goodwin'
               expect(card).to have_summary_row 'Address',
@@ -98,5 +100,6 @@ RSpec.describe 'Viewing the employments of an application' do
         end
       end
     end
+    # rubocop:enable RSpec/MultipleExpectations, RSpec/ExampleLength, RSpec/NestedGroups
   end
 end


### PR DESCRIPTION
## Description of change
Add partner income details
- partner employments
- partner work benefits
- partner self assessment tax bill

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1029

## Notes for reviewer

## Screenshots 
### Before changes:

### After changes:
<img width="904" alt="Screenshot 2024-06-24 at 18 33 34" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/195928/ac800528-9cd9-44a2-8fc1-69e85fdf2dc3">
f changes (if applicable)


## How to manually test the feature
http://localhost:3001/applications/:id
