### PR TITLE
Show declaration section, conditionally showing partner rows

### DIFF
--- a/app/views/casework/crime_applications/_declarations.html.erb
+++ b/app/views/casework/crime_applications/_declarations.html.erb
@@ -1,0 +1,37 @@
+<h2 class="govuk-heading-l">
+  <%= label_text(:declarations) %>
+</h2>
+
+<%= govuk_summary_card(title: label_text(:declarations)) do %>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label_text(:client_declaration) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes
+      </dd>
+    </div>
+    <% if provider_details.legal_rep_has_partner_declaration %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:partner_declaration) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(provider_details.legal_rep_has_partner_declaration.presence, scope: 'values') %>
+        </dd>
+      </div>
+    <% end %>
+    <% if provider_details.legal_rep_has_partner_declaration == 'no' &&
+      provider_details.legal_rep_no_partner_declaration_reason %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:no_partner_declaration_reason) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= provider_details.legal_rep_no_partner_declaration_reason %>
+        </dd>
+      </div>
+    <% end %>
+  </dl>
+<% end %>

--- a/app/views/casework/crime_applications/_initial.html.erb
+++ b/app/views/casework/crime_applications/_initial.html.erb
@@ -34,4 +34,5 @@
 
 <%= render partial: 'supporting_evidence', locals: { crime_application: } %>
 <%= render partial: 'further_information', locals: { crime_application: } %>
+<%= render partial: 'declarations', locals: { provider_details: crime_application.provider_details } %>
 <%= render partial: 'provider_details', object: crime_application.provider_details %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -351,6 +351,10 @@ en:
     applicant_self_assessment_tax_bill_amount: Amount
     partner_self_assessment_tax_bill: Does the their partner pay a Self Assessment tax bill?
     partner_self_assessment_tax_bill_amount: Amount
+    declarations: Declarations
+    client_declaration: Declaration from client?
+    partner_declaration: Declaration from partner?
+    no_partner_declaration_reason: Reason for no partner declaration
 
   table_headings: &TABLE_HEADINGS
     applicant_name: Applicant's name

--- a/spec/system/casework/viewing_an_application/application_details/declarations_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/declarations_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing the decarations on an application' do
+  include_context 'with stubbed application'
+
+  before do
+    visit crime_application_path(application_id)
+  end
+
+  context 'when application has no partner declaration details' do
+    let(:application_data) do
+      super().deep_merge('provider_details' => { 'legal_rep_has_partner_declaration' => nil,
+                                                  'legal_rep_no_partner_declaration_reason' => nil })
+    end
+
+    it 'shows the Declarations section with correct title' do
+      expect(page).to have_css('h2.govuk-heading-l', text: 'Declarations')
+    end
+
+    it 'shows the Declarations card with correct title' do
+      expect(page).to have_css('h2.govuk-summary-card__title', text: 'Declarations')
+    end
+
+    describe 'a Declarations card' do
+      subject(:declarations_card) do
+        page.find(
+          'h2.govuk-summary-card__title',
+          text: 'Declarations'
+        ).ancestor('div.govuk-summary-card')
+      end
+
+      it 'shows Declarations details' do # rubocop:disable RSpec/MultipleExpectations
+        within(declarations_card) do |card|
+          expect(card).to have_summary_row 'Declaration from client?', 'Yes'
+          expect(card).to have_no_css('dt.govuk-summary-list__key', text: 'Declaration from partner?')
+          expect(card).to have_no_css('dt.govuk-summary-list__key', text: 'Reason for no partner declaration')
+        end
+      end
+    end
+  end
+
+  context 'when application does have partner declaration details' do
+    let(:application_data) do
+      super().deep_merge('provider_details' => { 'legal_rep_has_partner_declaration' => 'no',
+                                                  'no_partner_declaration_reason' => 'A reason' })
+    end
+
+    it 'shows the National Savings Certificates with correct title' do
+      expect(page).to have_css('h2.govuk-summary-card__title', text: 'Declarations')
+    end
+
+    describe 'a Declarations card' do
+      subject(:declarations_card) do
+        page.find(
+          'h2.govuk-summary-card__title',
+          text: 'Declarations'
+        ).ancestor('div.govuk-summary-card')
+      end
+
+      it 'shows Declarations details' do # rubocop:disable RSpec/MultipleExpectations
+        within(declarations_card) do |card|
+          expect(card).to have_summary_row 'Declaration from client?', 'Yes'
+          expect(card).to have_summary_row 'Declaration from partner?', 'No'
+          expect(card).to have_summary_row 'Reason for no partner declaration', 'A reason'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Show declaration section, conditionally showing partner rows
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1088
## Design
![image](https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/928a9987-58c5-48ce-83cc-67d06ff49e34)

## Notes for reviewer
Any application that is submitted is default signed by provider declaring that they have the client's declaration, so that is default and hardcoded as Yes

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="850" alt="image" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/0c95d91b-445d-4867-a96f-9749cc290180">

## How to manually test the feature
SCENARIO 1:
Create an application on Apply main
Add a partner
Fill in declaration at the end with 'no' and some reason 
Submit
Check in Review the row show correctly

SCENARIO 2:
Create an application on Apply main
Add a partner
Fill in declaration at the end with 'yes'
Submit
Check in Review the rows show correctly

SCENARIO 3:
Create an application on Apply main
DO NOT add a partner
Shouldn't see partner declaration on Apply submission
Submit
Check in Review only the one row shows and partner rows are not there