### PR TITLE
only show partner benefit check with no conflict

### DIFF
--- a/app/views/casework/crime_applications/sections/_passporting_benefit_check_partner.html.erb
+++ b/app/views/casework/crime_applications/sections/_passporting_benefit_check_partner.html.erb
@@ -1,4 +1,4 @@
-<% if crime_application.applicant.has_partner == 'yes' %>
+<% if partner&.is_included_in_means_assessment %>
   <%= govuk_summary_card(title: label_text(:passporting_benefit_check_partner)) do %>
     <dl class="govuk-summary-list">
       <% if partner.benefit_type %>

--- a/spec/system/casework/viewing_an_application/application_details/passporting_benefit_check_partner_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/passporting_benefit_check_partner_spec.rb
@@ -1,57 +1,70 @@
 require 'rails_helper'
 
 RSpec.describe "When viewing the partner's passporting benefit check details" do
+  subject(:partner_card) do
+    page.find('h2.govuk-summary-card__title', text: title).ancestor('div.govuk-summary-card')
+  end
+
   include_context 'with stubbed application'
 
   before do
     visit crime_application_path(application_id)
   end
 
+  let(:title) { 'Passporting benefit check: partner' }
+
   context 'with passporting benefit check details' do
-    it { expect(page).to have_content('Passporting benefit check: partner') }
+    let(:application_data) do
+      super().deep_merge('client_details' => { 'partner' => { 'is_included_in_means_assessment' => true,
+                                                              'benefit_type' => 'universal_credit',
+                                                              'benefit_check_status' => 'undetermined',
+                                                              'confirm_details' => 'yes',
+                                                              'has_benefit_evidence' => 'no' } })
+    end
+
+    it { expect(page).to have_content(title) }
 
     context 'when the benefit check was performed on the partner' do
-      let(:application_data) do
-        super().deep_merge('client_details' => { 'applicant' => { 'has_partner' => 'yes',
-                                                                  'benefit_type' => 'none',
-                                                                  'benefit_check_status' => 'no_check_required',
-                                                                  'confirm_details' => nil,
-                                                                  'has_benefit_evidence' => nil },
-                                                 'partner' => { 'benefit_type' => 'universal_credit',
-                                                                'benefit_check_status' => 'undetermined',
-                                                                'confirm_details' => 'yes',
-                                                                'has_benefit_evidence' => 'no' } })
-      end
-
       it 'shows whether partner has a passporting benefit' do
-        expect(page).to have_content('Passporting Benefit Universal Credit')
+        within(partner_card) do
+          expect(page).to have_content('Passporting Benefit Universal Credit')
+        end
       end
 
       it 'shows the passporting benefit check outcome rows' do # rubocop:disable RSpec/MultipleExpectations
-        expect(page).to have_content('Passporting benefit check outcome No match - check details are correct')
-        expect(page).to have_content('Confirmed details correct? Yes')
-        expect(page).to have_content('Evidence can be provided? No')
+        within(partner_card) do
+          expect(page).to have_content('Passporting benefit check outcome No match - check details are correct')
+          expect(page).to have_content('Confirmed details correct? Yes')
+          expect(page).to have_content('Evidence can be provided? No')
+        end
       end
     end
 
     context 'when partner did not go through benefit check' do
       let(:application_data) do
-        super().deep_merge('client_details' => { 'applicant' => { 'has_partner' => 'yes',
-                                                                  'benefit_type' => 'universal_credit' },
-                                                 'partner' => { 'benefit_type' => nil,
+        super().deep_merge('client_details' => { 'partner' => { 'is_included_in_means_assessment' => true,
+                                                                'benefit_type' => nil,
                                                                 'benefit_check_status' => 'no_check_required' } })
       end
 
       it 'displays the benefit check outcome as no check required' do
-        expect(page).to have_content('Passporting benefit check outcome No check required')
+        within(partner_card) do
+          expect(page).to have_content('Passporting benefit check outcome No check required')
+        end
       end
     end
 
     context 'when applicant does not have partner' do
-      let(:application_data) { super().deep_merge('client_details' => { 'applicant' => { 'has_partner' => 'no' } }) }
+      let(:application_data) do
+        super().deep_merge(
+          'client_details' => {
+            'partner' => { 'is_included_in_means_assessment' => false }
+          }
+        )
+      end
 
       it 'does not show the partner passporting benefit check section' do
-        expect(page).to have_no_content('Passporting Benefit Check: partner')
+        expect(page).to have_no_content(title)
       end
     end
   end


### PR DESCRIPTION
## Description of change

Only show partner benefit details if partnerincluded in means assessment

## Link to relevant ticket

CRIMAPP-1115

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
