### PR TITLE
[EXPERIMENTAL] Update CA bundle, remove MAINTAINER

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:3.2.2-alpine3.19
-MAINTAINER LAA Crime Apply Team
+LABEL maintainer="LAA Crime Apply Team"
 
 RUN apk --no-cache add --virtual build-deps \
   build-base \
@@ -53,8 +53,8 @@ RUN chown -R appuser:appgroup log tmp db
 # Download RDS certificates bundle -- needed for SSL verification
 # We set the path to the bundle in the ENV, and use it in `/config/database.yml`
 #
-ENV RDS_COMBINED_CA_BUNDLE /usr/src/app/config/rds-combined-ca-bundle.pem
-ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem $RDS_COMBINED_CA_BUNDLE
+ENV RDS_COMBINED_CA_BUNDLE /usr/src/app/config/global-bundle.pem
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem $RDS_COMBINED_CA_BUNDLE
 RUN chmod +r $RDS_COMBINED_CA_BUNDLE
 
 ARG APP_BUILD_DATE


### PR DESCRIPTION
## Description of change
Use up-to-date AWS CA bundle for RDS for secure connectivity between application server and RDS

Replaces deprecated `MAINTAINER` with `LABEL` instruction

## Link to relevant ticket
N/A
