### PR TITLE
[CRIMAPP-1068] Display self employed businesses

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -145,6 +145,18 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication # rubocop:di
     @partner_employments ||= employments.select { |e| e.ownership_type == 'partner' }
   end
 
+  def businesses
+    self[:means_details].income_details.businesses
+  end
+
+  def applicant_businesses
+    @applicant_businesses ||= businesses.select { |e| e.ownership_type == 'applicant' }
+  end
+
+  def partner_businesses
+    @partner_businesses ||= businesses.select { |e| e.ownership_type == 'partner' }
+  end
+
   def income_benefits
     @income_benefits ||= IncomeBenefitsPresenter.present(self[:means_details].income_details&.income_benefits)
   end

--- a/app/views/casework/crime_applications/_income_details.html.erb
+++ b/app/views/casework/crime_applications/_income_details.html.erb
@@ -15,6 +15,10 @@
   <%= render partial: 'casework/crime_applications/sections/applicant_other_work_benefits', locals: { income_details: crime_application.means_details.income_details, other_work_benefits: crime_application.income_payments.applicant_other_work_benefits } %>
 <% end %>
 
+<% if FeatureFlags.self_employed_journey.enabled? %>
+  <%= render partial: 'casework/crime_applications/sections/businesses', locals: { businesses: crime_application.applicant_businesses } %>
+<% end %>
+
 <%= render(
       partial: 'casework/crime_applications/sections/dependants',
       locals: {
@@ -32,6 +36,10 @@
     <%= render partial: 'casework/crime_applications/sections/employments', locals: { employments: crime_application.partner_employments } %>
     <%= render partial: 'casework/crime_applications/sections/partner_self_assessment_tax_bill', locals: { income_details: crime_application.means_details.income_details } %>
     <%= render partial: 'casework/crime_applications/sections/partner_other_work_benefits', locals: { income_details: crime_application.means_details.income_details, other_work_benefits: crime_application.income_payments.partner_other_work_benefits } %>
+  <% end %>
+
+  <% if FeatureFlags.self_employed_journey.enabled? %>
+    <%= render partial: 'casework/crime_applications/sections/businesses', locals: { businesses: crime_application.partner_businesses } %>
   <% end %>
   <%= render partial: 'casework/crime_applications/sections/income_payments_partner', locals: { income_details: crime_application.means_details.income_details, income_payments: crime_application.income_payments.partner_income_payments } %>
   <%= render partial: 'casework/crime_applications/sections/income_benefits_partner', locals: { income_details: crime_application.means_details.income_details, income_benefits: crime_application.income_benefits.partner_income_benefits } %>

--- a/app/views/casework/crime_applications/sections/_businesses.html.erb
+++ b/app/views/casework/crime_applications/sections/_businesses.html.erb
@@ -1,66 +1,66 @@
 <% if businesses.present? %>
   <% businesses.group_by(&:business_type).each do |item_type, group| %>
     <%= app_card_list(items: group, item_name: label_text(item_type, scope: :business_type)) do |card|
-      govuk_summary_list(actions: false) do |list|
-        list.with_row do |row|
-          row.with_key { label_text(:trading_name, scope: 'businesses') }
-          row.with_value { simple_format(card.item.trading_name) }
-        end
+          govuk_summary_list(actions: false) do |list|
+            list.with_row do |row|
+              row.with_key { label_text(:trading_name, scope: 'businesses') }
+              row.with_value { simple_format(card.item.trading_name) }
+            end
 
-        list.with_row do |row|
-          row.with_key { label_text(:address, scope: 'businesses') }
-          row.with_value { render 'address', address: card.item.address }
-        end
+            list.with_row do |row|
+              row.with_key { label_text(:address, scope: 'businesses') }
+              row.with_value { render 'address', address: card.item.address }
+            end
 
-        list.with_row do |row|
-          row.with_key { label_text(:description, scope: 'businesses') }
-          row.with_value { simple_format(card.item.description) }
-        end
+            list.with_row do |row|
+              row.with_key { label_text(:description, scope: 'businesses') }
+              row.with_value { simple_format(card.item.description) }
+            end
 
-        list.with_row do |row|
-          row.with_key { label_text(:trading_start_date, scope: 'businesses') }
-          row.with_value { l card.item.trading_start_date }
-        end
+            list.with_row do |row|
+              row.with_key { label_text(:trading_start_date, scope: 'businesses') }
+              row.with_value { l card.item.trading_start_date }
+            end
 
-        list.with_row do |row|
-          row.with_key { label_text(:has_additional_owners, scope: 'businesses') }
-          row.with_value { value_text(card.item.has_additional_owners) }
-        end
+            list.with_row do |row|
+              row.with_key { label_text(:has_additional_owners, scope: 'businesses') }
+              row.with_value { value_text(card.item.has_additional_owners) }
+            end
 
-        if card.item.has_additional_owners == 'yes'
-          list.with_row do |row|
-            row.with_key { label_text(:additional_owners, scope: 'businesses') }
-            row.with_value { simple_format(card.item.additional_owners) }
+            if card.item.has_additional_owners == 'yes'
+              list.with_row do |row|
+                row.with_key { label_text(:additional_owners, scope: 'businesses') }
+                row.with_value { simple_format(card.item.additional_owners) }
+              end
+            end
+
+            list.with_row do |row|
+              row.with_key { label_text(:has_employees, scope: 'businesses') }
+              row.with_value { value_text(card.item.has_employees) }
+            end
+
+            if card.item.has_employees == 'yes'
+              list.with_row do |row|
+                row.with_key { label_text(:number_of_employees, scope: 'businesses') }
+                row.with_value { simple_format(card.item.number_of_employees.to_s) }
+              end
+            end
+
+            list.with_row do |row|
+              row.with_key { label_text(:turnover, scope: 'businesses') }
+              row.with_value { simple_format(t('values.payment_with_frequency', amount: number_to_currency(card.item.turnover.amount * 0.01), frequency: t(card.item.turnover.frequency, scope: [:values, :frequency]))) }
+            end
+
+            list.with_row do |row|
+              row.with_key { label_text(:drawings, scope: 'businesses') }
+              row.with_value { simple_format(t('values.payment_with_frequency', amount: number_to_currency(card.item.drawings.amount * 0.01), frequency: t(card.item.drawings.frequency, scope: [:values, :frequency]))) }
+            end
+
+            list.with_row do |row|
+              row.with_key { label_text(:profit, scope: 'businesses') }
+              row.with_value { simple_format(t('values.payment_with_frequency', amount: number_to_currency(card.item.profit.amount * 0.01), frequency: t(card.item.profit.frequency, scope: [:values, :frequency]))) }
+            end
           end
-        end
-
-        list.with_row do |row|
-          row.with_key { label_text(:has_employees, scope: 'businesses') }
-          row.with_value { value_text(card.item.has_employees) }
-        end
-
-        if card.item.has_employees == 'yes'
-          list.with_row do |row|
-            row.with_key { label_text(:number_of_employees, scope: 'businesses') }
-            row.with_value { simple_format(card.item.number_of_employees.to_s) }
-          end
-        end
-
-        list.with_row do |row|
-          row.with_key { label_text(:turnover, scope: 'businesses') }
-          row.with_value { simple_format(t('values.payment_with_frequency', amount: number_to_currency(card.item.turnover.amount * 0.01), frequency: t(card.item.turnover.frequency, scope: [:values, :frequency]))) }
-        end
-
-        list.with_row do |row|
-          row.with_key { label_text(:drawings, scope: 'businesses') }
-          row.with_value { simple_format(t('values.payment_with_frequency', amount: number_to_currency(card.item.drawings.amount * 0.01), frequency: t(card.item.drawings.frequency, scope: [:values, :frequency]))) }
-        end
-
-        list.with_row do |row|
-          row.with_key { label_text(:profit, scope: 'businesses') }
-          row.with_value { simple_format(t('values.payment_with_frequency', amount: number_to_currency(card.item.profit.amount * 0.01), frequency: t(card.item.profit.frequency, scope: [:values, :frequency]))) }
-        end
-      end
-    end %>
+        end %>
   <% end %>
 <% end %>

--- a/app/views/casework/crime_applications/sections/_businesses.html.erb
+++ b/app/views/casework/crime_applications/sections/_businesses.html.erb
@@ -1,0 +1,66 @@
+<% if businesses.present? %>
+  <% businesses.group_by(&:business_type).each do |item_type, group| %>
+    <%= app_card_list(items: group, item_name: label_text(item_type, scope: :business_type)) do |card|
+      govuk_summary_list(actions: false) do |list|
+        list.with_row do |row|
+          row.with_key { label_text(:trading_name, scope: 'businesses') }
+          row.with_value { simple_format(card.item.trading_name) }
+        end
+
+        list.with_row do |row|
+          row.with_key { label_text(:address, scope: 'businesses') }
+          row.with_value { render 'address', address: card.item.address }
+        end
+
+        list.with_row do |row|
+          row.with_key { label_text(:description, scope: 'businesses') }
+          row.with_value { simple_format(card.item.description) }
+        end
+
+        list.with_row do |row|
+          row.with_key { label_text(:trading_start_date, scope: 'businesses') }
+          row.with_value { l card.item.trading_start_date }
+        end
+
+        list.with_row do |row|
+          row.with_key { label_text(:has_additional_owners, scope: 'businesses') }
+          row.with_value { value_text(card.item.has_additional_owners) }
+        end
+
+        if card.item.has_additional_owners == 'yes'
+          list.with_row do |row|
+            row.with_key { label_text(:additional_owners, scope: 'businesses') }
+            row.with_value { simple_format(card.item.additional_owners) }
+          end
+        end
+
+        list.with_row do |row|
+          row.with_key { label_text(:has_employees, scope: 'businesses') }
+          row.with_value { value_text(card.item.has_employees) }
+        end
+
+        if card.item.has_employees == 'yes'
+          list.with_row do |row|
+            row.with_key { label_text(:number_of_employees, scope: 'businesses') }
+            row.with_value { simple_format(card.item.number_of_employees.to_s) }
+          end
+        end
+
+        list.with_row do |row|
+          row.with_key { label_text(:turnover, scope: 'businesses') }
+          row.with_value { simple_format(t('values.payment_with_frequency', amount: number_to_currency(card.item.turnover.amount * 0.01), frequency: t(card.item.turnover.frequency, scope: [:values, :frequency]))) }
+        end
+
+        list.with_row do |row|
+          row.with_key { label_text(:drawings, scope: 'businesses') }
+          row.with_value { simple_format(t('values.payment_with_frequency', amount: number_to_currency(card.item.drawings.amount * 0.01), frequency: t(card.item.drawings.frequency, scope: [:values, :frequency]))) }
+        end
+
+        list.with_row do |row|
+          row.with_key { label_text(:profit, scope: 'businesses') }
+          row.with_value { simple_format(t('values.payment_with_frequency', amount: number_to_currency(card.item.profit.amount * 0.01), frequency: t(card.item.profit.frequency, scope: [:values, :frequency]))) }
+        end
+      end
+    end %>
+  <% end %>
+<% end %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -84,6 +84,26 @@ en:
     benefit_other: Other benefits
     benefits_the_client_gets: Benefits your client gets
     benefits_the_partner_gets: Benefits the partner gets
+    business_title: Test
+    businesses:
+      trading_name: Trading name of business
+      address: Business address
+      description: Nature of business
+      trading_start_date: Date began trading
+      has_additional_owners: In business with anyone else
+      additional_owners: Name of others in business
+      has_employees: Employees?
+      number_of_employees: Number of employees
+      turnover: Total turnover
+      drawings: Total drawings
+      profit: Total profit
+      salary: Salary or remuneration
+      total_income_share_sales: Income from share sales
+      percentage_profit_share: Share of profits
+    business_type:
+      self_employed: Self-employed business
+      partnership: Business partnership
+      director_or_shareholder: Company director or shareholder
     capital: Capital
     case_details: Case details
     case_details_and_offences: Case details and offences

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,7 +19,10 @@ feature_flags:
     local: true
     staging: true
     production: true
-
+  self_employed_journey:
+    local: true
+    staging: false
+    production: false
 # For settings that vary by HostEnv name
 host_env_settings:
   phase_banner_tag:

--- a/spec/system/casework/viewing_an_application/application_details/businesses_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/businesses_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing the businesses of an application' do
+  include_context 'with stubbed application'
+
+  before do
+    visit crime_application_path(application_id)
+  end
+
+  context 'when client has savings' do
+    let(:has_additional_owners) { 'no' }
+    let(:additional_owners) { nil }
+    let(:has_employees) { 'no' }
+    let(:number_of_employees) { nil }
+
+    let(:self_employed_business) do
+      {
+        'ownership_type' => 'applicant',
+        'business_type' => 'self_employed',
+        'trading_name' => 'Self employed business 1',
+        'address' => {
+          'address_line_one' => 'address_line_one_x',
+          'address_line_two' => 'address_line_two_x',
+          'city' => 'city_x',
+          'postcode' => 'postcode_x',
+          'country' => 'country_x'
+        },
+        'description' => 'A cafe',
+        'trading_start_date' => 'Sat, 12 Jun 2021',
+        'has_additional_owners' => has_additional_owners,
+        'additional_owners' => additional_owners,
+        'has_employees' => has_employees,
+        'number_of_employees' => number_of_employees,
+        'turnover' => {
+          'amount' => 78_600,
+          'frequency' => 'week'
+        },
+        'drawings' => {
+          'amount' => 93_000,
+          'frequency' => 'four_weeks'
+        },
+        'profit' => {
+          'amount' => 12_100,
+          'frequency' => 'week'
+        },
+        'salary' => nil,
+        'total_income_share_sales' => nil,
+        'percentage_profit_share' => nil,
+      }
+    end
+
+    let(:application_data) do
+      super().deep_merge('means_details' => { 'income_details' => { 'businesses' => [self_employed_business] } })
+    end
+
+    it 'shows the business with correct title' do
+      expect(page).to have_css('h2.govuk-summary-card__title', text: 'Self-employed business')
+    end
+
+    describe 'a business card' do
+      subject(:business_card) do
+        page.find('h2.govuk-summary-card__title', text: 'Self-employed business').ancestor('div.govuk-summary-card')
+      end
+
+      it 'shows business details' do # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
+        within(business_card) do |card|
+          expect(card).to have_summary_row 'Trading name of business', 'Self employed business 1'
+          expect(card).to have_summary_row 'Business address',
+                                           'address_line_one_x address_line_two_x city_x postcode_x country_x'
+          expect(card).to have_summary_row 'Nature of business', 'A cafe'
+          expect(card).to have_summary_row 'Date began trading', '12 Jun 2021'
+          expect(card).to have_summary_row 'In business with anyone else', 'No'
+          expect(card).to have_no_content 'Name of others in business'
+          expect(card).to have_summary_row 'Employees?', 'No'
+          expect(card).to have_no_content 'Number of employees'
+          expect(card).to have_summary_row 'Total turnover', '£786.00 every week'
+          expect(card).to have_summary_row 'Total drawings', '£930.00 every 4 weeks'
+          expect(card).to have_summary_row 'Total profit', '£121.00 every week'
+        end
+      end
+
+      context 'when number of employees information is given' do
+        let(:has_employees) { 'yes' }
+        let(:number_of_employees) { 9 }
+
+        it 'shows number of employees details' do
+          within(business_card) do |card|
+            expect(card).to have_summary_row 'Number of employees', '9'
+          end
+        end
+      end
+
+      context 'when additional owner information is given' do
+        let(:has_additional_owners) { 'yes' }
+        let(:additional_owners) { 'Jon Smith' }
+
+        it 'shows number of employees details' do
+          within(business_card) do |card|
+            expect(card).to have_summary_row 'Name of others in business', 'Jon Smith'
+          end
+        end
+      end
+    end
+  end
+
+  context 'when client does not have any businesses' do
+    let(:application_data) do
+      super().deep_merge('means_details' => { 'income_details' => { 'businesses' => [] } })
+    end
+
+    it 'does not display any businesses' do
+      expect(page).to have_no_css('h2.govuk-summary-card__title', text: 'Self-employed business')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Display client and partner businesses if present 

## Link to relevant ticket
[CRIMAPP-1068](https://dsdmoj.atlassian.net/browse/CRIMAPP-1068)

## Notes for reviewer
Note: self employed is not yet available on Crime Apply so if testing locally, you will need to pull down and test via [this branch](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/1008)

Note: there are a couple of screens yet to be implemented in the self employed flow so this implements only what is available on the branch listed above.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1077" alt="Screenshot 2024-07-04 at 16 57 02" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/e85ea573-b6a9-440a-a678-e2597f572ab6">
<img width="1077" alt="Screenshot 2024-07-04 at 16 57 10" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/51047911/f8bb6933-a96d-4461-a130-0b7ff693aa6b">

## How to manually test the feature


[CRIMAPP-1068]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ