### PR TITLE
CRIMAPP-1180 - Retrieve before_or_after_tax value as string and fix translation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    ref: '58cf09d922ac0eeb64084201184955fda58c82ca'
+    ref: '4655c9b8283dd75ac9362d0df159d25502359d56'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.22'
+    ref: '58cf09d922ac0eeb64084201184955fda58c82ca'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 58cf09d922ac0eeb64084201184955fda58c82ca
-  ref: 58cf09d922ac0eeb64084201184955fda58c82ca
+  revision: 4655c9b8283dd75ac9362d0df159d25502359d56
+  ref: 4655c9b8283dd75ac9362d0df159d25502359d56
   specs:
     laa-criminal-legal-aid-schemas (1.1.23)
       dry-schema (~> 1.13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 755664244cb7920bc4481ace3d8dae22574c4d7b
-  tag: v1.1.22
+  revision: 58cf09d922ac0eeb64084201184955fda58c82ca
+  ref: 58cf09d922ac0eeb64084201184955fda58c82ca
   specs:
-    laa-criminal-legal-aid-schemas (1.1.22)
+    laa-criminal-legal-aid-schemas (1.1.23)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/views/casework/crime_applications/sections/_employment_income.html.erb
+++ b/app/views/casework/crime_applications/sections/_employment_income.html.erb
@@ -6,7 +6,7 @@
           <%= label_text(:employment_income_amount) %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= simple_format(t('values.payment_with_frequency_and_tax_status', amount: number_to_currency(employment_income.amount * 0.01), frequency: t(employment_income.frequency, scope: [:values, :frequency]), tax_status: t(employment_income.metadata.before_or_after_tax['value'], scope: 'values.before_or_after_tax'))) %>
+          <%= simple_format(t('values.payment_with_frequency_and_tax_status', amount: number_to_currency(employment_income.amount * 0.01), frequency: t(employment_income.frequency, scope: [:values, :frequency]), tax_status: t(employment_income.metadata.before_or_after_tax, scope: 'values.before_or_after_tax'))) %>
         </dd>
       </div>
   </dl>

--- a/app/views/casework/crime_applications/sections/_employments.html.erb
+++ b/app/views/casework/crime_applications/sections/_employments.html.erb
@@ -22,7 +22,7 @@
 
             list.with_row do |row|
               row.with_key { label_text(:amount, scope: 'employments') }
-              row.with_value { simple_format(t('values.payment_with_frequency_and_tax_status', amount: number_to_currency(employment.amount * 0.01), frequency: t(employment.frequency, scope: [:values, :frequency]), tax_status: t(employment.metadata.before_or_after_tax['value'], scope: 'values.before_or_after_tax'))) }
+              row.with_value { simple_format(t('values.payment_with_frequency_and_tax_status', amount: number_to_currency(employment.amount * 0.01), frequency: t(employment.frequency, scope: [:values, :frequency]), tax_status: t(employment.metadata.before_or_after_tax, scope: 'values.before_or_after_tax'))) }
             end
 
             if employment.has_no_deductions == 'yes'


### PR DESCRIPTION
## Description of change

Update Schema https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/pull/179 to accept correct metadata value

INCORRECT
```
means_details > income_details > income_payments[] > {"metadata"=>{"before_or_after_tax"=> { "value" => "after_tax"}}}
means_details > income_details > employments[] > {"metadata"=>{"before_or_after_tax"=>{"value"=>"after_tax"}}}
```
CORRECT

```
means_details > income_details > income_payments[] > {"metadata"=>{"before_or_after_tax"=>"after_tax"}}
means_details > income_details > employments[] > {"metadata"=>{"before_or_after_tax"=>"after_tax"}}
```

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1180

## Notes for reviewer
> [!NOTE]  
> To update schema version after schema approval https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/pull/179


## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
