### PR TITLE
CRIMAPP-1162-1159 Fix display issues on Application page

### DIFF
--- a/app/views/casework/crime_applications/_income_details.html.erb
+++ b/app/views/casework/crime_applications/_income_details.html.erb
@@ -6,8 +6,6 @@
 
 <%= render partial: 'casework/crime_applications/sections/employment', locals: { income_details: crime_application.means_details.income_details } %>
 <%= render partial: 'casework/crime_applications/sections/income', locals: { income_details: crime_application.means_details.income_details } %>
-<%= render partial: 'casework/crime_applications/sections/income_payments', locals: { income_details: crime_application.means_details.income_details, income_payments: crime_application.income_payments.applicant_income_payments } %>
-<%= render partial: 'casework/crime_applications/sections/income_benefits', locals: { income_details: crime_application.means_details.income_details, income_benefits: crime_application.income_benefits.applicant_income_benefits } %>
 <% if FeatureFlags.employment_journey.enabled? %>
   <%= render partial: 'casework/crime_applications/sections/employment_income', locals: { employment_income: crime_application.income_payments.applicant_employment_income } %>
   <%= render partial: 'casework/crime_applications/sections/employments', locals: { employments: crime_application.applicant_employments } %>
@@ -19,6 +17,9 @@
   <%= render partial: 'casework/crime_applications/sections/businesses', locals: { businesses: crime_application.applicant_businesses } %>
 <% end %>
 
+<%= render partial: 'casework/crime_applications/sections/income_payments', locals: { income_details: crime_application.means_details.income_details, income_payments: crime_application.income_payments.applicant_income_payments } %>
+<%= render partial: 'casework/crime_applications/sections/income_benefits', locals: { income_details: crime_application.means_details.income_details, income_benefits: crime_application.income_benefits.applicant_income_benefits } %>
+
 <%= render(
       partial: 'casework/crime_applications/sections/dependants',
       locals: {
@@ -27,9 +28,6 @@
       }
     ) %>
 <% if FeatureFlags.partner_journey.enabled? %>
-  <h3 class="govuk-heading-m">
-    <%= label_text(:income_details_partner) %>
-  </h3>
   <%= render partial: 'casework/crime_applications/sections/partner_employment', locals: { income_details: crime_application.means_details.income_details } %>
   <% if FeatureFlags.employment_journey.enabled? %>
     <%= render partial: 'casework/crime_applications/sections/employment_income', locals: { employment_income: crime_application.income_payments.partner_employment_income } %>

--- a/app/views/casework/crime_applications/sections/_employment.html.erb
+++ b/app/views/casework/crime_applications/sections/_employment.html.erb
@@ -12,14 +12,16 @@
         </div>
       <% end %>
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= label_text(:ended_employment_within_three_months) %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= t(income_details.ended_employment_within_three_months, scope: 'values') %>
-        </dd>
-      </div>
+      <% unless income_details.ended_employment_within_three_months.nil? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:ended_employment_within_three_months) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= t(income_details.ended_employment_within_three_months, scope: 'values') %>
+          </dd>
+        </div>
+      <% end %>
       <% unless income_details.lost_job_in_custody.nil? %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">

--- a/app/views/casework/crime_applications/sections/_employments.html.erb
+++ b/app/views/casework/crime_applications/sections/_employments.html.erb
@@ -1,5 +1,4 @@
 <% if employments.present? %>
-  <h2 class="govuk-heading-l"><%= label_text(:employments_title) %></h2>
     <%= app_card_list(items: employments, item_name: label_text('employment_title')) do |card|
           employment = card.item
           govuk_summary_list(actions: false) do |list|

--- a/spec/system/casework/viewing_an_application/application_details/employments_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/employments_spec.rb
@@ -14,10 +14,6 @@ RSpec.describe 'Viewing the employments of an application' do
       super().deep_merge('means_details' => means_details)
     end
 
-    it 'shows the employments section' do
-      expect(page).to have_css('h2.govuk-heading-l', text: 'Jobs')
-    end
-
     it 'shows the jobs with correct title' do
       expect(page).to have_css('h2.govuk-summary-card__title', text: 'Job')
     end


### PR DESCRIPTION
## Description of change

* Remove 'partner income' heading
* Fix unemployed 'when did your client end employment' question showing unless they are unemployed
* Fix ordering of income and jobs sections to match Apply

## Link to relevant ticket

[CRIMAPP-1162](https://dsdmoj.atlassian.net/browse/CRIMAPP-1162)
[CRIMAPP-1159](https://dsdmoj.atlassian.net/browse/CRIMAPP-1159)
[CRIMAPP-1157](https://dsdmoj.atlassian.net/browse/CRIMAPP-1157)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
![Screenshot 2024-07-10 at 10 23 40](https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/15728561/f1f0f3a9-1a42-471f-976e-67145d1e137e)
<img width="1220" alt="Screenshot 2024-07-10 at 10 23 28" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/15728561/57800c91-4475-4b62-a393-9098240edca8">

### After changes:
<img width="1394" alt="Screenshot 2024-07-10 at 10 23 13" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/15728561/9cd64cdb-f1bd-43fc-8555-e9bebd612e83">

## How to manually test the feature


[CRIMAPP-1162]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-1159]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CRIMAPP-1157]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ