### PR TITLE
Always show case details attributes unless PSE

### DIFF
--- a/app/views/casework/crime_applications/_case_details.html.erb
+++ b/app/views/casework/crime_applications/_case_details.html.erb
@@ -3,16 +3,18 @@
 </h2>
 
 <%= govuk_summary_card(title: label_text(:case_details)) do %>
-  <% if case_details.case_type.present? %>
+  <% unless crime_application.pse? %>
     <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= label_text(:case_type) %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= t(case_details.case_type, scope: 'values') %>
-        </dd>
-      </div>
+      <% if case_details.case_type.present? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:case_type) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= t(case_details.case_type, scope: 'values') %>
+          </dd>
+        </div>
+      <% end %>
       <% if case_details.appeal? %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">

--- a/app/views/casework/crime_applications/_initial.html.erb
+++ b/app/views/casework/crime_applications/_initial.html.erb
@@ -18,7 +18,8 @@
            locals: { crime_application: crime_application, applicant: crime_application.applicant } %>
 <%= render partial: 'casework/crime_applications/sections/passporting_benefit_check_partner',
            locals: { crime_application: crime_application, partner: crime_application.partner } %>
-<%= render partial: 'case_details', object: crime_application.case_details %>
+<%= render partial: 'case_details',
+           locals: { crime_application: crime_application, case_details: crime_application.case_details } %>
 <%= render partial: 'offences', object: crime_application.case_details.offences %>
 <%= render partial: 'codefendants', object: crime_application.case_details.codefendants %>
 <%= render partial: 'interests_of_justice', locals: { crime_application: } %>


### PR DESCRIPTION
## Description of change
Conditional to show case details section was on whether there was a case type. There is no case type, but are other case details present on non-means applicaitons. 

The only application type with no case details is  PSE, so conditional now base on that.

Case type row hidden for non-means
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1194
## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
![image](https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/daf73fc1-15d7-4e5e-89cd-2654bd998da6)

### After changes:<img width="1254" alt="image" src="https://github.com/ministryofjustice/laa-review-criminal-legal-aid/assets/45827968/7e655913-69d7-4dcd-9591-2b0dbcbefd20">
## How to manually test the feature
