### PR TITLE
[CRIMAPP-1195] Calculate non means status with `is_means_tested` attribute

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.29'
+    tag: 'v1.1.30'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: d43e9d63929985fe57885c163b8e0af1ad150b87
-  tag: v1.1.29
+  revision: 815495127c56a901b4c9269690858ba59244765d
+  tag: v1.1.30
   specs:
-    laa-criminal-legal-aid-schemas (1.1.29)
+    laa-criminal-legal-aid-schemas (1.1.30)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -24,7 +24,7 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication # rubocop:di
   end
 
   def not_means_tested?
-    means_passport.include?(Types::MeansPassportType['on_not_means_tested'])
+    is_means_tested == 'no'
   end
 
   def relevant_ioj_passport

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -338,4 +338,28 @@ RSpec.describe CrimeApplication do
       it { is_expected.to eq 'on_offence' }
     end
   end
+
+  describe '#not_means_tested?' do
+    subject(:not_means_tested?) { application.not_means_tested? }
+
+    context 'when `is_means_tested` is nil' do
+      let(:attributes) do
+        super().deep_merge('is_means_tested' => nil)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the application is not means tested' do
+      let(:attributes) do
+        super().deep_merge('is_means_tested' => 'no')
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the application is means tested' do
+      it { is_expected.to be false }
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
Refactors `#non_means_tested` to calculate apps non means status with the `is_means_tested` attribute rather than the means passport value. This is to prevent inaccuracies in the event that an application is resubmitted and the means passport value has not been updated

Also updates schema version to v1.1.30

## Link to relevant ticket
[CRIMAPP-1195](https://dsdmoj.atlassian.net/browse/CRIMAPP-1195)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Follow steps in ticket

[CRIMAPP-1195]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ