### PR TITLE
CRIMAPP-1211-1210 Fix order of employment sections

### DIFF
--- a/app/views/casework/crime_applications/_income_details.html.erb
+++ b/app/views/casework/crime_applications/_income_details.html.erb
@@ -9,15 +9,18 @@
 <% if FeatureFlags.employment_journey.enabled? %>
   <%= render partial: 'casework/crime_applications/sections/employment_income', locals: { employment_income: crime_application.income_payments.applicant_employment_income } %>
   <%= render partial: 'casework/crime_applications/sections/employments', locals: { employments: crime_application.applicant_employments } %>
-  <%= render partial: 'casework/crime_applications/sections/applicant_self_assessment_tax_bill', locals: { income_details: crime_application.means_details.income_details } %>
-  <%= render partial: 'casework/crime_applications/sections/applicant_other_work_benefits', locals: { income_details: crime_application.means_details.income_details, other_work_benefits: crime_application.income_payments.applicant_other_work_benefits } %>
 <% end %>
 
 <% if FeatureFlags.self_employed_journey.enabled? %>
   <%= render partial: 'casework/crime_applications/sections/businesses', locals: { businesses: crime_application.applicant_businesses } %>
 <% end %>
 
-<%= render partial: 'casework/crime_applications/sections/income_payments', locals: { income_details: crime_application.means_details.income_details, income_payments: crime_application.income_payments.applicant_income_payments } %>
+<% if FeatureFlags.employment_journey.enabled? || FeatureFlags.self_employed_journey.enabled? %>
+  <%= render partial: 'casework/crime_applications/sections/applicant_self_assessment_tax_bill', locals: { income_details: crime_application.means_details.income_details } %>
+  <%= render partial: 'casework/crime_applications/sections/applicant_other_work_benefits', locals: { income_details: crime_application.means_details.income_details, other_work_benefits: crime_application.income_payments.applicant_other_work_benefits } %>
+<% end %>
+
+  <%= render partial: 'casework/crime_applications/sections/income_payments', locals: { income_details: crime_application.means_details.income_details, income_payments: crime_application.income_payments.applicant_income_payments } %>
 <%= render partial: 'casework/crime_applications/sections/income_benefits', locals: { income_details: crime_application.means_details.income_details, income_benefits: crime_application.income_benefits.applicant_income_benefits } %>
 
 <%= render(

--- a/app/views/casework/crime_applications/sections/_income.html.erb
+++ b/app/views/casework/crime_applications/sections/_income.html.erb
@@ -1,14 +1,20 @@
-<% if income_details.present? %>
+<% if income_details.present? &&
+  (income_details.income_above_threshold.present? ||
+    income_details.has_frozen_income_or_assets.present? ||
+    income_details.client_owns_property.present? ||
+    income_details.has_savings.present?) %>
   <%= govuk_summary_card(title: label_text(:income)) do %>
     <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= label_text(:income_more_than) %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= t(income_details.income_above_threshold, scope: 'values') %>
-        </dd>
-      </div>
+      <% unless income_details.income_above_threshold.nil? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:income_more_than) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= t(income_details.income_above_threshold, scope: 'values') %>
+          </dd>
+        </div>
+      <% end %>
       <% unless income_details.has_frozen_income_or_assets.nil? %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">


### PR DESCRIPTION
## Description of change

Hide income threshold section for self-employed journey
Move self-assessment tax bill and other work benefits sections to below self-employed sections

## Link to relevant ticket

[CRIMAPP-1211](https://dsdmoj.atlassian.net/browse/CRIMAPP-1211)
[CRIMAPP-1210](https://dsdmoj.atlassian.net/browse/CRIMAPP-1210)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1211]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-1210]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ