### PR TITLE
CRIMAPP-1228:  Fix employment status display for client and partner

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -169,6 +169,10 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication # rubocop:di
     @income_payments ||= IncomePaymentsPresenter.present(self[:means_details].income_details&.income_payments)
   end
 
+  def income_details
+    @income_details ||= IncomeDetailsPresenter.present(self[:means_details].income_details)
+  end
+
   def outgoing_payments
     @outgoing_payments ||= OutgoingPaymentsPresenter.present(self[:means_details].outgoings_details&.outgoings)
   end

--- a/app/presenters/income_details_presenter.rb
+++ b/app/presenters/income_details_presenter.rb
@@ -1,0 +1,17 @@
+require 'laa_crime_schemas'
+
+class IncomeDetailsPresenter < BasePresenter
+  def initialize(income_details)
+    super(
+      @income_details = income_details
+    )
+  end
+
+  def formatted_employment_type
+    @income_details.employment_type.join('_and_')
+  end
+
+  def formatted_partner_employment_type
+    @income_details.partner_employment_type.join('_and_')
+  end
+end

--- a/app/views/casework/crime_applications/_income_details.html.erb
+++ b/app/views/casework/crime_applications/_income_details.html.erb
@@ -4,7 +4,7 @@
   <%= label_text(:income_details) %>
 </h2>
 
-<%= render partial: 'casework/crime_applications/sections/employment', locals: { income_details: crime_application.means_details.income_details } %>
+<%= render partial: 'casework/crime_applications/sections/employment', locals: { income_details: crime_application.income_details } %>
 <%= render partial: 'casework/crime_applications/sections/income', locals: { income_details: crime_application.means_details.income_details } %>
 <% if FeatureFlags.employment_journey.enabled? %>
   <%= render partial: 'casework/crime_applications/sections/employment_income', locals: { employment_income: crime_application.income_payments.applicant_employment_income } %>
@@ -28,7 +28,7 @@
       }
     ) %>
 <% if FeatureFlags.partner_journey.enabled? %>
-  <%= render partial: 'casework/crime_applications/sections/partner_employment', locals: { income_details: crime_application.means_details.income_details } %>
+  <%= render partial: 'casework/crime_applications/sections/partner_employment', locals: { income_details: crime_application.income_details } %>
   <% if FeatureFlags.employment_journey.enabled? %>
     <%= render partial: 'casework/crime_applications/sections/employment_income', locals: { employment_income: crime_application.income_payments.partner_employment_income } %>
     <%= render partial: 'casework/crime_applications/sections/employments', locals: { employments: crime_application.partner_employments } %>

--- a/app/views/casework/crime_applications/sections/_employment.html.erb
+++ b/app/views/casework/crime_applications/sections/_employment.html.erb
@@ -1,17 +1,14 @@
 <% if income_details.present? %>
   <%= govuk_summary_card(title: label_text(:employment)) do %>
     <dl class="govuk-summary-list">
-      <% income_details.employment_type.each do |et| %>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            <%= label_text(:employment_type) %>
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <%= t(et, scope: 'values.employment_type')  %>
-          </dd>
-        </div>
-      <% end %>
-
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:employment_type) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(income_details.formatted_employment_type, scope: 'values.employment_type')  %>
+        </dd>
+      </div>
       <% unless income_details.ended_employment_within_three_months.nil? %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">

--- a/app/views/casework/crime_applications/sections/_income.html.erb
+++ b/app/views/casework/crime_applications/sections/_income.html.erb
@@ -1,6 +1,7 @@
 <% if income_details.present? %>
   <%= govuk_summary_card(title: label_text(:income)) do %>
     <dl class="govuk-summary-list">
+      <% unless income_details.income_above_threshold.nil? %>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           <%= label_text(:income_more_than) %>
@@ -9,6 +10,7 @@
           <%= t(income_details.income_above_threshold, scope: 'values') %>
         </dd>
       </div>
+      <% end %>
       <% unless income_details.has_frozen_income_or_assets.nil? %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">

--- a/app/views/casework/crime_applications/sections/_income.html.erb
+++ b/app/views/casework/crime_applications/sections/_income.html.erb
@@ -1,7 +1,6 @@
 <% if income_details.present? %>
   <%= govuk_summary_card(title: label_text(:income)) do %>
     <dl class="govuk-summary-list">
-      <% unless income_details.income_above_threshold.nil? %>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           <%= label_text(:income_more_than) %>
@@ -10,7 +9,6 @@
           <%= t(income_details.income_above_threshold, scope: 'values') %>
         </dd>
       </div>
-      <% end %>
       <% unless income_details.has_frozen_income_or_assets.nil? %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">

--- a/app/views/casework/crime_applications/sections/_partner_employment.html.erb
+++ b/app/views/casework/crime_applications/sections/_partner_employment.html.erb
@@ -1,16 +1,14 @@
 <% if income_details.partner_employment_type.present? %>
   <%= govuk_summary_card(title: label_text(:partner_employment)) do %>
     <dl class="govuk-summary-list">
-      <% income_details.partner_employment_type.each do |et| %>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            <%= label_text(:partner_employment_type) %>
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <%= t(et, scope: 'values.employment_type')  %>
-          </dd>
-        </div>
-      <% end %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:partner_employment_type) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(income_details.formatted_partner_employment_type, scope: 'values.employment_type')  %>
+        </dd>
+      </div>
     </dl>
   <% end %>
 <% end %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -502,6 +502,7 @@ en:
     employment_type:
       employed: Employed
       self_employed: Self-employed
+      employed_and_self_employed: Employed and Self-employed
       business_partnership: In a business partnership
       director: Company directory in a private company
       shareholder: Shareholder in a private company


### PR DESCRIPTION
## Description of change
Fix employment status text for Client and Partner

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1228

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="915" alt="Screenshot 2024-07-17 at 14 14 11" src="https://github.com/user-attachments/assets/1341d3ba-0379-4c68-a2d8-ca70821452cf">


### After changes:
![Screenshot 2024-07-17 at 14 14 27](https://github.com/user-attachments/assets/883a4e2c-21ba-46bb-88d4-fdceb495c855)

## How to manually test the feature
