### PR TITLE
CRIMAPP-1242 fix downloads of files with comma in name

### DIFF
--- a/app/services/datastore/documents/download.rb
+++ b/app/services/datastore/documents/download.rb
@@ -30,7 +30,7 @@ module Datastore
 
       def response_content_disposition
         # To force download of file rather than opening in another window
-        "attachment; filename=#{@document.filename}"
+        %(attachment; filename="#{@document.filename}")
       end
     end
   end

--- a/spec/shared_contexts/when_downloading_a_document.rb
+++ b/spec/shared_contexts/when_downloading_a_document.rb
@@ -4,7 +4,7 @@ RSpec.shared_context 'when downloading a document' do
 
   let(:expected_query) do
     { object_key: %r{123/.*}, s3_opts: { expires_in: Datastore::Documents::Download::PRESIGNED_URL_EXPIRES_IN,
-                                         response_content_disposition:  "attachment; filename=#{filename}" } }
+                                         response_content_disposition:  "attachment; filename=\"#{filename}\"" } }
   end
 
   let(:presign_download_url) do


### PR DESCRIPTION
## Description of change

Ensure download disposition filename is wrapped in double quotes.

## Link to relevant ticket

[CRIMAPP-1242](https://dsdmoj.atlassian.net/browse/CRIMAPP-1242)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
