### PR TITLE
CRIMAPP-1225: Fix income label

### DIFF
--- a/app/views/casework/crime_applications/sections/_income.html.erb
+++ b/app/views/casework/crime_applications/sections/_income.html.erb
@@ -8,7 +8,7 @@
       <% unless income_details.income_above_threshold.nil? %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            <%= label_text(:income_more_than) %>
+            <%= label_text(:income_more_than, prefix: (partner_included_in_means? ? 'Joint annual income' : 'Income')) %>
           </dt>
           <dd class="govuk-summary-list__value">
             <%= t(income_details.income_above_threshold, scope: 'values') %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -176,7 +176,7 @@ en:
     how_much_rent: Amount paid for rent, after taking away Housing Benefit
     how_much_mortgage: Amount paid towards mortgage
     income: Income
-    income_more_than: Income more than £12,475?
+    income_more_than: "%{prefix} more than £12,475?"
     income_details: Income
     income_details_partner: Partner's income
     employments_title: Jobs

--- a/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
@@ -8,8 +8,20 @@ RSpec.describe 'Viewing the income details of an application' do
   end
 
   context 'with income details' do
-    it 'shows income above threshold' do
-      expect(page).to have_content('Income more than £12,475? No')
+    context 'when partner is included in means' do
+      before do
+        allow_any_instance_of(ActionView::Base).to receive(:partner_included_in_means?).and_return(true)
+      end
+
+      it 'shows income above threshold' do
+        expect(page).to have_content('Joint annual income more than £12,475? No')
+      end
+    end
+
+    context 'when partner is not included in means' do
+      it 'shows income above threshold' do
+        expect(page).to have_content('Income more than £12,475? No')
+      end
     end
 
     it 'shows has income savings assets' do

--- a/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'Viewing the income details of an application' do
 
   context 'with income details' do
     context 'when partner is included in means' do
-      before do
-        allow_any_instance_of(ActionView::Base).to receive(:partner_included_in_means?).and_return(true)
+      let(:application_data) do
+        super().deep_merge('client_details' => { 'partner' => { 'is_included_in_means_assessment' => true } })
       end
 
       it 'shows income above threshold' do


### PR DESCRIPTION
## Description of change
Fix 'income_above_threshold' text in 'Application details' section based on the following:

When partner is included show "Joint income more than £12,475 a year before tax?"
When partner is not included show "Income more than £12,475 a year before tax?"

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1225

## Notes for reviewer

## Screenshots of changes (if applicable)

### When partner is included 

### Before changes:
<img width="902" alt="Screenshot 2024-07-22 at 16 18 26" src="https://github.com/user-attachments/assets/4a5e205f-3817-435b-bbca-a3d8ba070991">

### After changes:
<img width="895" alt="Screenshot 2024-07-22 at 16 18 07" src="https://github.com/user-attachments/assets/373668dd-0cc9-4003-9fcb-b5f92ec99a5c">

## How to manually test the feature
http://localhost:3001/applications/:id
