### PR TITLE
CRIMAPP-963: Update schema version to v1.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.2.0'
+    tag: 'v1.2.1'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: ee8a3aa0c43c4ac1bfca20fbb8d87351e5f2a61c
-  tag: v1.2.0
+  revision: 1ae303e88d01904ab1439dea45c60dd644a20f7b
+  tag: v1.2.1
   specs:
-    laa-criminal-legal-aid-schemas (1.2.0)
+    laa-criminal-legal-aid-schemas (1.2.1)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)


### PR DESCRIPTION
## Description of change
Bump schema version to v1.2.1

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-963

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
