### PR TITLE
[CRIMAPP-1254] Update means test row

### DIFF
--- a/app/views/casework/crime_applications/_overview.html.erb
+++ b/app/views/casework/crime_applications/_overview.html.erb
@@ -37,22 +37,14 @@
 
     <% unless overview.pse? %>
       <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= label_text(:means_tested) %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <% if overview.not_means_tested? %>
-            <%= t('no', scope: 'values') %>
-          <% elsif overview.means_passported? %>
-            <%= govuk_tag(text: t(:passported, scope: 'values'), colour: 'blue') %>
-          <%# TODO: This needs product/content design sign off %>
-          <% elsif !overview.not_means_tested? && ['none', nil].include?(overview.applicant.benefit_type) %>
-            <%= t('yes', scope: 'values') %>
-          <% else %>
-            <%# Those with a selected benefit type, but DWP negative result would end up here (inc ppt ben evidence) %>
-            <%= govuk_tag(text: label_text('undetermined'), colour: 'red') %>
-          <% end %>
-        </dd>
+        <% if overview.is_means_tested %>
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:means_tested) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= t(overview.is_means_tested, scope: 'values') %>
+          </dd>
+        <% end %>
       </div>
 
       <% unless overview.means_passported_on_age? || overview.not_means_tested? || overview.appeal_no_changes? %>

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -84,19 +84,17 @@ RSpec.describe 'Viewing an application unassigned, open application' do
         .sibling('.govuk-summary-list__value')
     end
 
-    context 'when the application is means passported' do
+    context 'when the application is subject to the means test' do
       it 'shows the blue passported badge' do
-        expect(means_tested_badge).to have_content('Passported')
-        expect(means_tested_badge).to have_css('.govuk-tag--blue')
+        expect(means_tested_badge).to have_content('Yes')
       end
     end
 
-    context 'when the application is not means passported' do
-      let(:application_data) { super().merge('means_passport' => []) }
+    context 'when the application is not subject to the means test' do
+      let(:application_data) { super().merge('is_means_tested' => 'no') }
 
       it 'shows the red undetermined badge' do
-        expect(means_tested_badge).to have_content('Undetermined')
-        expect(means_tested_badge).to have_css('.govuk-tag--red')
+        expect(means_tested_badge).to have_content('No')
       end
     end
   end


### PR DESCRIPTION
## Description of change
Updates the logic displaying the means test status of an application on review

Now the question to ask providers whether an application is subject to the means test has been added to apply, new applications will have a value (`yes`/`no`) and this value will display. For historical applications where there is no value for this question, the row will not be displayed. 

This changes previous behaviour where a passported badge would display if the dwp check was successful and an undetermined badge would display if the dwp check was undetermined. Due to the changes in how the benefit check result is displayed, this is now handled in the passporting benefit check section. 

This change has been agreed with design who will also look into the overview section and how it can be updated at some point

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-1254

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="990" alt="Screenshot 2024-07-29 at 13 12 44" src="https://github.com/user-attachments/assets/177b6577-3be7-42a6-84c1-3c17888d9cd1">

### After changes:

**Application is subject to means test**
<img width="1116" alt="Screenshot 2024-07-29 at 12 47 31" src="https://github.com/user-attachments/assets/2a7ed108-623a-49f6-9260-a4664a45d587">

**Application is not subject to means test**
<img width="1116" alt="Screenshot 2024-07-29 at 12 59 22" src="https://github.com/user-attachments/assets/a93c5c13-83ee-4356-bdd0-db6fcc7dde35">

**Historical application (no means test value)**
<img width="1116" alt="Screenshot 2024-07-29 at 12 59 02" src="https://github.com/user-attachments/assets/ae043cbd-1555-4a46-b651-8e93a9a498dc">


## How to manually test the feature
