### PR TITLE
CRIMAPP-345 fix pod crash loop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     base64 (0.2.0)
     bcrypt (3.1.20)
-    better_html (2.0.2)
+    better_html (2.1.1)
       actionview (>= 6.0)
       activesupport (>= 6.0)
       ast (~> 2.0)
@@ -155,7 +155,7 @@ GEM
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crack (1.0.0)
       bigdecimal
@@ -217,14 +217,14 @@ GEM
     dumb_delegator (1.0.0)
     email_validator (2.2.4)
       activemodel
-    erb_lint (0.5.0)
+    erb_lint (0.6.0)
       activesupport
       better_html (>= 2.0.1)
       parser (>= 2.7.1.4)
       rainbow
-      rubocop
+      rubocop (>= 1)
       smart_properties
-    erubi (1.12.0)
+    erubi (1.13.0)
     faraday (2.9.2)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-follow_redirects (0.3.0)
@@ -312,7 +312,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
-    minitest (5.24.1)
+    minitest (5.25.1)
     moj-simple-jwt-auth (0.1.0)
       json
       jwt
@@ -330,10 +330,10 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
-    nokogiri (1.16.5)
+    nokogiri (1.16.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.16.5-x86_64-linux)
+    nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)
       jwt (>= 1.5, < 3)
@@ -362,8 +362,8 @@ GEM
       webfinger (~> 2.0)
     orm_adapter (0.5.0)
     pagy (6.5.0)
-    parallel (1.25.1)
-    parser (3.3.3.0)
+    parallel (1.26.3)
+    parser (3.3.4.2)
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
@@ -377,7 +377,7 @@ GEM
     public_suffix (5.1.1)
     puma (6.4.2)
       nio4r (~> 2.0)
-    racc (1.8.0)
+    racc (1.8.1)
     rack (2.2.9)
     rack-oauth2 (2.2.1)
       activesupport
@@ -448,7 +448,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.2)
+    rexml (3.3.6)
       strscan
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
@@ -467,7 +467,7 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.1)
-    rubocop (1.65.0)
+    rubocop (1.65.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -478,7 +478,7 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.3)
+    rubocop-ast (1.32.1)
       parser (>= 3.3.1.0)
     rubocop-performance (1.21.1)
       rubocop (>= 1.48.1, < 2.0)

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -43,18 +43,18 @@ spec:
                 value: https
               - name: X-Forwarded-Ssl
                 value: "on"
-          initialDelaySeconds: 15
+          initialDelaySeconds: 20 
           periodSeconds: 10
         livenessProbe:
           httpGet:
-            path: /health
+            path: /ping.json
             port: 3000
             httpHeaders:
               - name: X-Forwarded-Proto
                 value: https
               - name: X-Forwarded-Ssl
                 value: "on"
-          initialDelaySeconds: 30
+          initialDelaySeconds: 0
           periodSeconds: 10
         envFrom:
           - configMapRef:

--- a/spec/controllers/concerns/work_streamable_spec.rb
+++ b/spec/controllers/concerns/work_streamable_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-# rubocop:disable RSpec/RSpec/SpecFilePathFormat
+# rubocop:disable RSpec/SpecFilePathFormat
 
 RSpec.describe ApplicationController do
   controller do
@@ -81,4 +81,4 @@ RSpec.describe ApplicationController do
   end
 end
 
-# rubocop:enable RSpec/RSpec/SpecFilePathFormat
+# rubocop:enable RSpec/SpecFilePathFormat


### PR DESCRIPTION
## Description of change
- use ping for Liveness probe
- remove initial delay on liveness probe
- extend delay on readyness probe


## Link to relevant ticket

## Notes for reviewer

### NB Change is for testing on staging only

The liveness probe was previously using the same endpoint as the readiness probe, which included a database connection check. We suspect that when the liveness probe takes too long due to database latency, it triggers unnecessary container restarts.

This update removes the database check from the liveness probe and also removes liveness initial delay, which should prevent restarts caused by temporary database connection issues.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
