### PR TITLE
[CRIMAPP-1300] Upgrade schema to v1.2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.2.5'
+    tag: 'v1.2.7'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 81a00f994281d0c7759a11b0affd8eec5d3c7a86
-  tag: v1.2.5
+  revision: bb45aafb5f1233fbb025c9939454110a6800b576
+  tag: v1.2.7
   specs:
-    laa-criminal-legal-aid-schemas (1.2.5)
+    laa-criminal-legal-aid-schemas (1.2.7)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)


### PR DESCRIPTION
## Description of change
Upgrade `laa-criminal-legal-aid-schemas` to `v1.2.7` which adds attributes `client_in_armed_forces` and `partner_in_armed_forces`.

## Link to relevant ticket
[CRIMAPP-1300](https://dsdmoj.atlassian.net/browse/CRIMAPP-1300)

[CRIMAPP-1300]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ