### PR TITLE
Health end point activates db connection

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -24,7 +24,7 @@ class HealthcheckController < BareApplicationController
   end
 
   def database_connected?
-    ActiveRecord::Base.connection.active?
+    ActiveRecord::Base.connection.execute('SELECT 1').present?
   rescue StandardError
     false
   end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -5,15 +5,13 @@ Rails.application.configure do
   config.lograge.logger = ActiveSupport::Logger.new($stdout)
   config.lograge.formatter = Lograge::Formatters::Logstash.new
 
-
-  # Commenting out ignoring of healthcheck to aid with debugging
-  # # Reduce noise in the logs by ignoring the healthcheck actions
-  # config.lograge.ignore_actions = %w[
-  #   HealthcheckController#show
-  #   HealthcheckController#ping
-  #   DatastoreApi::HealthEngine::HealthcheckController#show
-  #   DatastoreApi::HealthEngine::HealthcheckController#ping
-  # ]
+  # Reduce noise in the logs by ignoring the healthcheck actions
+  config.lograge.ignore_actions = %w[
+    HealthcheckController#show
+    HealthcheckController#ping
+    DatastoreApi::HealthEngine::HealthcheckController#show
+    DatastoreApi::HealthEngine::HealthcheckController#ping
+  ]
 
   config.lograge.custom_options = lambda do |event|
     request = event.payload[:request]

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -43,8 +43,8 @@ spec:
                 value: https
               - name: X-Forwarded-Ssl
                 value: "on"
-          initialDelaySeconds: 5
-          periodSeconds: 5
+          initialDelaySeconds: 11
+          periodSeconds: 10
         livenessProbe:
           httpGet:
             path: /ping

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Healthcheck endpoint' do
     end
 
     it 'can report a failure' do
-      allow(ActiveRecord::Base.connection).to receive(:active?)
+      allow(ActiveRecord::Base.connection).to receive(:execute)
         .and_raise(StandardError)
 
       get '/health'


### PR DESCRIPTION
## Description of change
Use simple query for health check

## Link to relevant ticket

[CRIMAPP-345](https://dsdmoj.atlassian.net/browse/CRIMAPP-345)

## Notes for reviewer

`ActiveRecord::Base.connection.active?` was not returning `true` for the health check, which was resulting in the readiness probe failing. This changes the check to use a simple query, to ensure the connection is active.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-345]: https://dsdmoj.atlassian.net/browse/CRIMAPP-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ