### PR TITLE
CRIMAPP-345 add startup probe to production deploy

### DIFF
--- a/config/kubernetes/production/deployment.tpl
+++ b/config/kubernetes/production/deployment.tpl
@@ -43,18 +43,29 @@ spec:
                 value: https
               - name: X-Forwarded-Ssl
                 value: "on"
-          initialDelaySeconds: 15
+          initialDelaySeconds: 11
           periodSeconds: 10
         livenessProbe:
           httpGet:
-            path: /health
+            path: /ping
             port: 3000
             httpHeaders:
               - name: X-Forwarded-Proto
                 value: https
               - name: X-Forwarded-Ssl
                 value: "on"
-          initialDelaySeconds: 30
+          failureThreshold: 1
+          periodSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /ping
+            port: 3000
+            httpHeaders:
+              - name: X-Forwarded-Proto
+                value: https
+              - name: X-Forwarded-Ssl
+                value: "on"
+          failureThreshold: 20
           periodSeconds: 10
         envFrom:
           - configMapRef:


### PR DESCRIPTION
## Description of change

Add startupProbe to production deployment

## Link to relevant ticket

[CRIMAPP-345](https://dsdmoj.atlassian.net/browse/CRIMAPP-345)

## Notes for reviewer

This configuration has been confirmed to work on staging

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-345]: https://dsdmoj.atlassian.net/browse/CRIMAPP-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ