### PR TITLE
Increase sample period for 5xx and 4xx alerts

### DIFF
--- a/config/kubernetes/staging/prometheus.yml
+++ b/config/kubernetes/staging/prometheus.yml
@@ -83,7 +83,7 @@ spec:
 
     - alert: CrimeApplyReview-Ingress4XX
       expr: >-
-        avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace=~"^laa-review-criminal-legal-aid.*", status=~"4.."}[1m]) * 60 > 0)
+        sum(rate(nginx_ingress_controller_requests{exported_namespace=~"^laa-review-criminal-legal-aid.*", status=~"4.."}[5m]) * 60 > 5)
         by (exported_namespace)
       for: 1m
       labels:
@@ -94,7 +94,7 @@ spec:
 
     - alert: CrimeApplyReview-Ingress5XX
       expr: >-
-        avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace=~"^laa-review-criminal-legal-aid.*", status=~"5.."}[1m]) * 60 > 0)
+        sum(rate(nginx_ingress_controller_requests{exported_namespace=~"^laa-review-criminal-legal-aid.*", status=~"5.."}[5m]) * 60 > 5)
         by (exported_namespace)
       for: 1m
       labels:


### PR DESCRIPTION
## Description of change

Increase the sampling period for 4xx and 5xx prometheus alerts.

## Link to relevant ticket

## Notes for reviewer

Updates the alerts to triggers if the total rate exceeds 5 errors per minute, but averaged over a 5-minute period to hopefully reduce number of unnecessary alerts.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
