### PR TITLE
CRIMAPP-1320 available reviewer actions can be configured

### DIFF
--- a/app/aggregates/reviewing/available_reviewer_actions.rb
+++ b/app/aggregates/reviewing/available_reviewer_actions.rb
@@ -1,0 +1,56 @@
+module Reviewing
+  class AvailableReviewerActions
+    AVAILABLE_ACTIONS = {
+      means: {
+        open: [:mark_as_ready, :send_back],
+        marked_as_ready: [:complete, :send_back],
+      },
+      non_means: {
+        open: [:complete, :send_back],
+        marked_as_ready: [:complete, :send_back] # TODO: remove once all non-means in this state processed
+      },
+      pse: {
+        open: [:complete]
+      }
+    }.freeze
+
+    def initialize(state:, application_type:, work_stream:)
+      @application_type = application_type
+      @state = state
+      @work_stream = work_stream
+    end
+
+    attr_reader :state, :application_type, :work_stream
+
+    def actions
+      AVAILABLE_ACTIONS.dig(review_type, state) || []
+    end
+
+    private
+
+    def review_type
+      return Types::ReviewType[:pse] if pse?
+      return Types::ReviewType[:non_means] if non_means?
+
+      Types::ReviewType[:means]
+    end
+
+    def pse?
+      application_type == Types::ApplicationType['post_submission_evidence']
+    end
+
+    def non_means?
+      work_stream == Types::WorkStreamType['non_means_tested']
+    end
+
+    class << self
+      def for(reviewable)
+        new(
+          state: reviewable.state,
+          application_type: reviewable.application_type || Types::ApplicationType['initial'],
+          work_stream: reviewable.work_stream
+        ).actions
+      end
+    end
+  end
+end

--- a/app/aggregates/reviewing/review.rb
+++ b/app/aggregates/reviewing/review.rb
@@ -69,7 +69,7 @@ module Reviewing
     end
 
     on ApplicationReceived do |event|
-      @state = :open
+      @state = Types::ReviewState[:open]
       @received_at = event.timestamp
       @submitted_at = event.data[:submitted_at]
       @parent_id = event.data[:parent_id]
@@ -78,7 +78,7 @@ module Reviewing
     end
 
     on SentBack do |event|
-      @state = :sent_back
+      @state = Types::ReviewState[:sent_back]
       @return_reason = event.data.fetch(:reason, nil)
       @reviewer_id = event.data.fetch(:user_id)
       @reviewed_at = event.timestamp
@@ -90,13 +90,13 @@ module Reviewing
     end
 
     on Completed do |event|
-      @state = :completed
+      @state = Types::ReviewState[:completed]
       @reviewer_id = event.data.fetch(:user_id)
       @reviewed_at = event.timestamp
     end
 
     on MarkedAsReady do |_event|
-      @state = :marked_as_ready
+      @state = Types::ReviewState[:marked_as_ready]
     end
 
     def reviewed?
@@ -117,6 +117,10 @@ module Reviewing
       return nil unless @reviewed_at
 
       @reviewed_at.in_time_zone('London').to_date
+    end
+
+    def available_reviewer_actions
+      AvailableReviewerActions.for(self)
     end
   end
 end

--- a/app/components/review_action_component.rb
+++ b/app/components/review_action_component.rb
@@ -1,0 +1,41 @@
+class ReviewActionComponent < ViewComponent::Base
+  def initialize(review_action:, application:)
+    @application = application
+    @action = review_action
+
+    super
+  end
+
+  attr_reader :application, :action
+
+  def call
+    govuk_button_to(button_text, target, method:, warning:)
+  end
+
+  private
+
+  def button_text
+    I18n.t(action, scope: 'calls_to_action')
+  end
+
+  def target
+    case action
+    when :complete
+      complete_crime_application_path(application)
+    when :send_back
+      new_crime_application_return_path(application)
+    when :mark_as_ready
+      ready_crime_application_path(application)
+    end
+  end
+
+  def method
+    return :get if action == :send_back
+
+    :put
+  end
+
+  def warning
+    action == :send_back
+  end
+end

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -14,4 +14,10 @@ module ComponentsHelper
   def conflict_of_interest(codefendant)
     render ConflictOfInterestComponent.new(codefendant:)
   end
+
+  def reviewing_actions(application)
+    render ReviewActionComponent.with_collection(
+      application.available_reviewer_actions, application:
+    )
+  end
 end

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -32,6 +32,10 @@ module Types
     *REVIEW_STATUS_GROUPS.keys
   )
 
+  ReviewState = Symbol.default(:open).enum(*%i[open sent_back completed marked_as_ready])
+
+  ReviewType = Symbol.enum(*%i[means non_means pse])
+
   CASEWORKER_ROLE = 'caseworker'.freeze
   SUPERVISOR_ROLE = 'supervisor'.freeze
   DATA_ANALYST_ROLE = 'data_analyst'.freeze

--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -4,7 +4,7 @@ module Reviewable
   end
 
   delegate :reviewed_at, :reviewer_id, :reviewed?, :superseded_by, :superseded_at,
-           :business_day, to: :review
+           :business_day, :available_reviewer_actions, to: :review
 
   def review_status
     review.state

--- a/app/views/casework/crime_applications/show.html.erb
+++ b/app/views/casework/crime_applications/show.html.erb
@@ -28,23 +28,8 @@
   <div class="govuk-grid-column-full">
     <% if @crime_application.reviewable_by?(current_user_id) %>
       <div class="govuk-button-group govuk-!-margin-bottom-6">
-        <% if @crime_application.status?(:marked_as_ready) || @crime_application.pse? %>
-        <%= button_to t('calls_to_action.mark_complete'),
-                      complete_crime_application_path(@crime_application),
-                      method: :put,
-                      class: 'govuk-button govuk-button' %>
-        <% else %>
-        <%= button_to t('calls_to_action.mark_as_ready'),
-                      ready_crime_application_path(@crime_application),
-                      method: :put,
-                      class: 'govuk-button govuk-button' %>
-        <% end %>
-        <% unless @crime_application.pse? %>
-          <%= button_to t('calls_to_action.send_back'),
-                        new_crime_application_return_path(@crime_application),
-                        method: :get,
-                        class: 'govuk-button govuk-button--warning' %>
-        <% end %>
+        <%= reviewing_actions(@crime_application) %>
+
         <%= button_to t('calls_to_action.unassign_from_self'),
                       assigned_application_path(@crime_application),
                       method: :delete,

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -588,6 +588,7 @@ en:
     view_daily_count: Check when applications were received
     view_closed_on_count: Check when applications were closed
     mark_complete: Mark as completed
+    complete: Mark as completed
     send_back: Send back to provider
     mark_as_ready: Mark as ready for MAAT
     sign_out: Sign out

--- a/spec/aggregates/reviewing/available_reviewer_actions_spec.rb
+++ b/spec/aggregates/reviewing/available_reviewer_actions_spec.rb
@@ -1,0 +1,154 @@
+require 'rails_helper'
+
+RSpec.describe Reviewing::AvailableReviewerActions do
+  describe '#actions' do
+    subject(:actions) do
+      described_class.new(state:, application_type:, work_stream:).actions
+    end
+
+    context 'when state "open"' do
+      let(:state) { Types::ReviewState[:open] }
+
+      context 'when a means tested initial application' do
+        let(:application_type) { Types::ApplicationType['initial'] }
+        let(:work_stream) { WorkStream.new('criminal_applications_team') }
+
+        it { is_expected.to eq %i[mark_as_ready send_back] }
+      end
+
+      context 'when a non-means tested initial application' do
+        let(:application_type) { Types::ApplicationType['initial'] }
+        let(:work_stream) { WorkStream.new('non_means_tested') }
+
+        it { is_expected.to eq %i[complete send_back] }
+      end
+
+      context 'when PSE' do
+        let(:application_type) { Types::ApplicationType['post_submission_evidence'] }
+        let(:work_stream) { WorkStream.new('non_means_tested') }
+
+        it { is_expected.to eq %i[complete] }
+      end
+
+      context 'when CIFC' do
+        let(:application_type) { Types::ApplicationType['change_in_financial_circumstances'] }
+        let(:work_stream) { WorkStream.new('criminal_applications_team') }
+
+        it { is_expected.to eq %i[mark_as_ready send_back] }
+      end
+    end
+
+    context 'when state "sent_back"' do
+      let(:state) { Types::ReviewState[:sent_back] }
+
+      context 'when a means tested initial application' do
+        let(:application_type) { Types::ApplicationType['initial'] }
+        let(:work_stream) { WorkStream.new('criminal_applications_team') }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'when a non-means tested initial application' do
+        let(:application_type) { Types::ApplicationType['initial'] }
+        let(:work_stream) { WorkStream.new('non_means_tested') }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'when CIFC' do
+        let(:application_type) { Types::ApplicationType['change_in_financial_circumstances'] }
+        let(:work_stream) { WorkStream.new('criminal_applications_team') }
+
+        it { is_expected.to be_empty }
+      end
+    end
+
+    context 'when state "marked_as_ready"' do
+      let(:state) { Types::ReviewState[:marked_as_ready] }
+
+      context 'when a means tested initial application' do
+        let(:application_type) { Types::ApplicationType['initial'] }
+        let(:work_stream) { WorkStream.new('criminal_applications_team') }
+
+        it { is_expected.to eq %i[complete send_back] }
+      end
+
+      context 'when a non-means tested initial application' do
+        # NOTE: Support for legacy Non-means applications marked_as_read
+        let(:application_type) { Types::ApplicationType['initial'] }
+        let(:work_stream) { WorkStream.new('non_means_tested') }
+
+        it { is_expected.to eq %i[complete send_back] }
+      end
+
+      context 'when CIFC' do
+        let(:application_type) { Types::ApplicationType['change_in_financial_circumstances'] }
+        let(:work_stream) { WorkStream.new('criminal_applications_team') }
+
+        it { is_expected.to eq %i[complete send_back] }
+      end
+    end
+
+    context 'when state "completed"' do
+      let(:state) { Types::ReviewState[:completed] }
+
+      context 'when a means tested initial application' do
+        let(:application_type) { Types::ApplicationType['initial'] }
+        let(:work_stream) { WorkStream.new('criminal_applications_team') }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'when a non-means tested initial application' do
+        let(:application_type) { Types::ApplicationType['initial'] }
+        let(:work_stream) { WorkStream.new('non_means_tested') }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'when PSE' do
+        let(:application_type) { Types::ApplicationType['post_submission_evidence'] }
+        let(:work_stream) { WorkStream.new('non_means_tested') }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'when CIFC' do
+        let(:application_type) { Types::ApplicationType['change_in_financial_circumstances'] }
+        let(:work_stream) { WorkStream.new('criminal_applications_team') }
+
+        it { is_expected.to be_empty }
+      end
+    end
+
+    describe '.for(reviewable)' do
+      let(:reviewable) do
+        instance_double(
+          Reviewing::Review,
+          state: :open,
+          application_type: 'post_submission_evidence',
+          work_stream: 'criminal_applications_team'
+        )
+      end
+
+      it 'returns an array of available actions' do
+        expect(described_class.for(reviewable)).to eq %i[complete]
+      end
+
+      context 'when reviewable application_type is nil' do
+        let(:reviewable) do
+          instance_double(
+            Reviewing::Review,
+            state: :open,
+            application_type: nil,
+            work_stream: :criminal_applications_team
+          )
+        end
+
+        it 'sets the application_type to initial' do
+          expect(described_class.for(reviewable)).to eq %i[mark_as_ready send_back]
+        end
+      end
+    end
+  end
+end

--- a/spec/system/accessibility_spec.rb
+++ b/spec/system/accessibility_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Accessibility' do
+RSpec.describe 'Accessibility', :accessibility do
   include_context 'with an existing user'
   include_context 'with an existing application'
   include_context 'with a stubbed mailer'

--- a/spec/system/casework/reviewing/a_cifc_application_spec.rb
+++ b/spec/system/casework/reviewing/a_cifc_application_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'Reviewing a CIFC application' do
+  include_context 'with stubbed application'
+
+  let(:application_id) { '98ab235c-f125-4dcb-9604-19e81782e53b' }
+  let(:application_data) { JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'change_in_financial_circumstances').read) }
+
+  before do
+    allow(DatastoreApi::Requests::UpdateApplication).to receive(:new).and_return(
+      instance_double(DatastoreApi::Requests::UpdateApplication, call: {})
+    )
+
+    visit crime_application_path(application_id)
+    click_button 'Assign to your list'
+  end
+
+  it 'can be completed by the caseworker' do
+    expect(page).to have_content('Change in financial circumstances')
+    click_button 'Mark as ready for MAAT'
+    click_button 'Mark as completed'
+    expect(page).to have_content('You marked the application as complete')
+  end
+end

--- a/spec/system/casework/reviewing/a_non_means_application_spec.rb
+++ b/spec/system/casework/reviewing/a_non_means_application_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'Reviewing a Non-means application' do
+  include_context 'with stubbed application' do
+    let(:application_data) do
+      JSON.parse(LaaCrimeSchemas.fixture(1.0).read).merge(
+        'is_means_tested' => 'no',
+        'work_stream' => 'non_means_tested'
+      )
+    end
+
+    before do
+      allow(DatastoreApi::Requests::UpdateApplication).to receive(:new).and_return(
+        instance_double(DatastoreApi::Requests::UpdateApplication, call: {})
+      )
+
+      visit crime_application_path(application_id)
+      click_button 'Assign to your list'
+    end
+
+    it 'can be completed by the caseworker' do
+      expect(page).to have_button('Send back to provider')
+
+      click_button 'Mark as completed'
+
+      expect(page).to have_content('You marked the application as complete')
+    end
+  end
+end

--- a/spec/system/casework/reviewing/a_pse_application_spec.rb
+++ b/spec/system/casework/reviewing/a_pse_application_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'Reviewing a PSE application' do
+  include_context 'with stubbed application'
+
+  let(:application_id) { '21c37e3e-520f-46f1-bd1f-5c25ffc57d70' }
+
+  let(:application_data) { JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'post_submission_evidence').read) }
+
+  before do
+    allow(DatastoreApi::Requests::UpdateApplication).to receive(:new).and_return(
+      instance_double(DatastoreApi::Requests::UpdateApplication, call: {})
+    )
+
+    visit crime_application_path(application_id)
+    click_button 'Assign to your list'
+  end
+
+  it 'can be completed by the caseworker' do
+    expect(page).not_to have_button('Send back to provider')
+    click_button 'Mark as completed'
+    expect(page).to have_content('You marked the application as complete')
+  end
+end


### PR DESCRIPTION
## Description of change

Actions available to the reviewer can be configured

## Link to relevant ticket

[CRIMAPP-1320](https://dsdmoj.atlassian.net/browse/CRIMAPP-1320)

## Notes for reviewer

Refactor to allow actions available to a reviewer to be configured based on the state of the review, the type of application being reviewed, and the type of assessment required.

In addition to the refactor this PR also removes the redundant ready_for_assessment action for Non-means applications.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

This refactor is covered by the system specs.


[CRIMAPP-1320]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ