### PR TITLE
[CRIMAPP-249] Prevent Date Stamp Context output for old apps

### DIFF
--- a/app/presenters/date_stamp_context_presenter.rb
+++ b/app/presenters/date_stamp_context_presenter.rb
@@ -13,18 +13,21 @@ class DateStampContextPresenter < BasePresenter
 
   def first_name_changed?
     return false unless @applicant
+    return false if @date_stamp_context&.first_name.blank?
 
     @applicant.first_name != @date_stamp_context.first_name
   end
 
   def last_name_changed?
     return false unless @applicant
+    return false if @date_stamp_context&.last_name.blank?
 
     @applicant.last_name != @date_stamp_context.last_name
   end
 
   def date_of_birth_changed?
     return false unless @applicant
+    return false if @date_stamp_context&.date_of_birth.blank?
 
     @applicant.date_of_birth != @date_stamp_context.date_of_birth
   end

--- a/spec/presenters/date_stamp_context_presenter_spec.rb
+++ b/spec/presenters/date_stamp_context_presenter_spec.rb
@@ -67,5 +67,31 @@ RSpec.describe DateStampContextPresenter do
         it { is_expected.to be true }
       end
     end
+
+    context 'with missing date stamp context' do
+      let(:attributes) do
+        attrs = super()
+        attrs['date_stamp_context'] = nil
+        attrs
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'with corrupted date stamp context' do
+      let(:attributes) do
+        attrs = super()
+
+        # Missing last_name, date_of_birth, etc
+        attrs['date_stamp_context'] = {
+          'date_stamp' => Date.new(2022, 10, 24).to_s,
+          'first_name' => 'Kitten',
+        }
+
+        attrs
+      end
+
+      it { is_expected.to be true }
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Prevents output of new date stamp details panel for older applications

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-249

## Notes for reviewer
N/A

## Screenshots of changes (if applicable)

### Before changes:


### After changes:
<img width="752" alt="Screenshot 2024-10-02 at 12 20 11" src="https://github.com/user-attachments/assets/f09b366e-dff4-420c-8ca4-fc8dac7cf67b">

#### Missing panel because date stamp context is empty
<img width="749" alt="Screenshot 2024-10-02 at 12 26 24" src="https://github.com/user-attachments/assets/6857487d-24f1-4e56-8317-9d689fe7c075">




## How to manually test the feature
Create a new application - during the application enter client details, proceed until date stamp, then change client details. Complete application and submit. Review as caseworker. As caseworker review an older application prior to introduction of date stamp context.