### PR TITLE
Fix: complete page expects decisions

### DIFF
--- a/app/aggregates/deciding/decision.rb
+++ b/app/aggregates/deciding/decision.rb
@@ -55,6 +55,10 @@ module Deciding
       Types::InterestsOfJusticeDecision[@interests_of_justice]
     end
 
+    def complete?
+      @funding_decision.present?
+    end
+
     def attributes
       {
         interests_of_justice:,

--- a/app/aggregates/reviewing.rb
+++ b/app/aggregates/reviewing.rb
@@ -14,6 +14,7 @@ module Reviewing
   class CannotMarkAsReadyWhenSentBack < Error; end
   class CannotSendBackWhenCompleted < Error; end
   class NotReceived < Error; end
+  class IncompleteDecisions < Error; end
 
   class DecisionAdded < Event; end
 

--- a/app/aggregates/reviewing/commands/complete.rb
+++ b/app/aggregates/reviewing/commands/complete.rb
@@ -9,9 +9,12 @@ module Reviewing
           review.complete(user_id:)
 
           decisions = review.decision_ids.map do |decision_id|
-            Deciding::LoadDecision.call(
+            decision = Deciding::LoadDecision.call(
               application_id:, decision_id:
             )
+            raise IncompleteDecisions unless decision.complete?
+
+            decision.attributes
           end
 
           DatastoreApi::Requests::UpdateApplication.new(

--- a/app/controllers/casework/completes_controller.rb
+++ b/app/controllers/casework/completes_controller.rb
@@ -4,13 +4,13 @@ module Casework
 
     def show; end
 
-    def create # rubocop:disable Metrics/MethodLength
+    def create # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       Reviewing::Complete.new(
         application_id: @crime_application.id,
         user_id: current_user_id
       ).call
 
-      if FeatureFlags.adding_decisions.enabled?
+      if FeatureFlags.adding_decisions.enabled? && @crime_application.draft_decisions.any?
         redirect_to crime_application_complete_path(@crime_application)
       else
         set_flash :completed

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -45,6 +45,7 @@ en:
       not_allocated_to_appropriate_work_stream:
         - You must be allocated to the %{work_queue} work queue to review this application
         - Contact your supervisor to arrange this
+      incomplete_decisions: Please complete any pending funding decisions
 
 
   primary_navigation:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,7 +25,7 @@ feature_flags:
     production: true
   adding_decisions:
     local: false
-    staging: true
+    staging: false
     production: false
   other_charges:
     local: true

--- a/spec/aggregates/deciding/decision_spec.rb
+++ b/spec/aggregates/deciding/decision_spec.rb
@@ -23,4 +23,26 @@ describe Deciding::Decision do
       expect(decision.attributes[:comment]).to eq(comment)
     end
   end
+
+  describe '#complete?' do
+    context 'when funding_decision is present' do
+      let(:funding_decision) { 'granted' }
+
+      before do
+        decision.set_funding_decision(user_id: SecureRandom.uuid, funding_decision: funding_decision)
+      end
+
+      it 'returns true' do
+        expect(decision.complete?).to be(true)
+      end
+    end
+
+    context 'when funding_decision is not present' do
+      let(:funding_decision) { nil }
+
+      it 'returns false' do
+        expect(decision.complete?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/aggregates/reviewing/complete_spec.rb
+++ b/spec/aggregates/reviewing/complete_spec.rb
@@ -37,4 +37,23 @@ RSpec.describe Reviewing::Complete do
     expect { command.call }.to change { review.state }
       .from(:open).to(:completed)
   end
+
+  context 'when there are incomplete decisions' do
+    before do
+      args = {
+        application_id: application_id,
+        user_id: SecureRandom.uuid,
+        decision_id: SecureRandom.uuid
+      }
+
+      Reviewing::AddDecision.call(**args)
+      Deciding::CreateDraft.call(**args)
+    end
+
+    it 'throws an error' do
+      expect do
+        command.call
+      end.to raise_error(Reviewing::IncompleteDecisions)
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
A fix to address an error where on completing an application the user is redirected to the new confirmation page, which expects at least one funding decision to exist so it can be shown. The user is now redirected to the assigned application list (as it was done before) if there are no funding decisions.

This also fixes an issue where entire decision object were being sent to the Datastore, rather than just the necessary attributes.

The `adding_decisions` feature flag is temporarily **disabled** in **staging** so that the Datastore can be tested in its current state in production-like conditions, where `adding_decisions` is disabled.

## Link to relevant ticket
[LAA-REVIEW-CRIMINAL-LEGAL-AID-1K](https://ministryofjustice.sentry.io/issues/5968122648/?alert_rule_id=15149521&alert_type=issue&notification_uuid=1270e1be-929a-4faf-934a-7c8d8ebe2841&project=4507142463291392&referrer=slack)

## How to manually test the feature

1. Choose an application that is ready to be marked as completed and has **no** funding decision
2. Click "Mark as completed"
3. You should be redirected to your assigned application list with a flash message saying that the application has been marked as completed.