### PR TITLE
Enable adding_decisions in staging

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,7 +25,7 @@ feature_flags:
     production: true
   adding_decisions:
     local: false
-    staging: false
+    staging: true
     production: false
   other_charges:
     local: true


### PR DESCRIPTION
## Description of change
Enable `adding_decisions` in staging so it can be QA'd.

## Link to relevant ticket
[CRIMAPP-1355](https://dsdmoj.atlassian.net/browse/CRIMAPP-1355)

[CRIMAPP-1355]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ