### PR TITLE
Update search page default review status to all applications

### DIFF
--- a/app/controllers/casework/assigned_applications_controller.rb
+++ b/app/controllers/casework/assigned_applications_controller.rb
@@ -13,7 +13,7 @@ module Casework
       return unless assignments_count.positive?
 
       set_search(
-        default_filter: { assigned_status: current_user_id },
+        default_filter: { assigned_status: current_user_id, application_status: 'open' },
         default_sorting: { sort_by: 'submitted_at', sort_direction: 'ascending' }
       )
     end

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -18,6 +18,7 @@ module Types # rubocop:disable Metrics/ModuleLength
   # Map of review status groups to LaaCrimeSchemas::Types:REVIEW_APPLICATION_STATUSES
   #
   REVIEW_STATUS_GROUPS = {
+    'all' => REVIEW_APPLICATION_STATUSES,
     'open' => [
       Types::ReviewApplicationStatus['application_received'],
       Types::ReviewApplicationStatus['ready_for_assessment']
@@ -30,10 +31,9 @@ module Types # rubocop:disable Metrics/ModuleLength
     'sent_back' => [
       Types::ReviewApplicationStatus['returned_to_provider']
     ],
-    'all' => REVIEW_APPLICATION_STATUSES
   }.freeze
 
-  ReviewStatusGroup = String.default('open'.freeze).enum(
+  ReviewStatusGroup = String.default('all'.freeze).enum(
     *REVIEW_STATUS_GROUPS.keys
   )
 

--- a/app/models/get_next.rb
+++ b/app/models/get_next.rb
@@ -1,8 +1,8 @@
 class GetNext
   def initialize(work_streams:, application_types:)
     @application_types = application_types
-    filter = ApplicationSearchFilter.new(assigned_status: 'unassigned', work_stream: work_streams,
-                                         application_type: application_types)
+    filter = ApplicationSearchFilter.new(assigned_status: 'unassigned', application_status: 'open',
+                                         work_stream: work_streams, application_type: application_types)
     pagination = Pagination.new(limit_value: 1)
     sorting = ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending')
     @search = ApplicationSearch.new(filter:, pagination:, sorting:)

--- a/spec/models/application_search_filter_spec.rb
+++ b/spec/models/application_search_filter_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ApplicationSearchFilter do
     context 'when the filter is empty' do
       let(:expected_datastore_params) do
         {
-          review_status: %w[application_received ready_for_assessment],
+          review_status: %w[application_received returned_to_provider ready_for_assessment assessment_completed],
         }
       end
 

--- a/spec/system/casework/assigning/get_next_application_spec.rb
+++ b/spec/system/casework/assigning/get_next_application_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe 'Assigning an application to myself' do
       let(:expected_params) do
         ApplicationSearchFilter.new(
           assigned_status: 'unassigned',
+          application_status: 'open',
           work_stream: gets_next_from,
           application_type: get_next_types
         ).datastore_params

--- a/spec/system/casework/searching/filter_by_age_in_business_days_spec.rb
+++ b/spec/system/casework/searching/filter_by_age_in_business_days_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Search applications by age in business days' do
       expect_datastore_to_have_been_searched_with(
         {
           application_id_in: unassigned_application_ids,
-          review_status: Types::REVIEW_STATUS_GROUPS['open']
+          review_status: Types::REVIEW_STATUS_GROUPS['all']
         }
       )
     end

--- a/spec/system/casework/searching/filter_by_caseworker_spec.rb
+++ b/spec/system/casework/searching/filter_by_caseworker_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Search applications casewoker filter' do
 
     it 'excludes assigned applications from the search' do
       expect_datastore_to_have_been_searched_with({
-                                                    review_status: Types::REVIEW_STATUS_GROUPS['open'],
+                                                    review_status: Types::REVIEW_STATUS_GROUPS['all'],
         application_id_in: unassigned_application_ids
                                                   })
     end
@@ -40,7 +40,7 @@ RSpec.describe 'Search applications casewoker filter' do
 
     it 'excludes unassigned applications from the search' do
       expect_datastore_to_have_been_searched_with({
-                                                    review_status: Types::REVIEW_STATUS_GROUPS['open'],
+                                                    review_status: Types::REVIEW_STATUS_GROUPS['all'],
         application_id_in: current_assignment_ids
                                                   })
     end
@@ -58,7 +58,7 @@ RSpec.describe 'Search applications casewoker filter' do
 
     it 'excludes unassigned applications from the search' do
       expect_datastore_to_have_been_searched_with({
-                                                    review_status: Types::REVIEW_STATUS_GROUPS['open'],
+                                                    review_status: Types::REVIEW_STATUS_GROUPS['all'],
         application_id_in: davids_applications
                                                   })
     end

--- a/spec/system/casework/searching/filter_by_date_of_birth_spec.rb
+++ b/spec/system/casework/searching/filter_by_date_of_birth_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Search applications applicant date of birth filter' do
   it 'searches by applicant date of birth' do
     expect_datastore_to_have_been_searched_with({
                                                   applicant_date_of_birth: '2011-06-09',
-      review_status: Types::REVIEW_STATUS_GROUPS['open']
+      review_status: Types::REVIEW_STATUS_GROUPS['all']
                                                 })
   end
 

--- a/spec/system/casework/searching/filter_by_date_range_spec.rb
+++ b/spec/system/casework/searching/filter_by_date_range_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Search by submitted date' do
       {
         submitted_before: '2023-01-09 00:00:00 +0000',
         submitted_after: '2023-06-08 00:00:00 +0100',
-        review_status: Types::REVIEW_STATUS_GROUPS['open']
+        review_status: Types::REVIEW_STATUS_GROUPS['all']
       }
     )
   end

--- a/spec/system/casework/searching/filter_by_status_spec.rb
+++ b/spec/system/casework/searching/filter_by_status_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'Search applications status filter' do
     click_link 'Search'
   end
 
-  it 'filters by "Open" by default' do
-    expect(page).to have_select(filter_field, selected: 'Open')
+  it 'filters by "All" by default' do
+    expect(page).to have_select(filter_field, selected: 'All applications')
   end
 
   it "can choose from 'Open', 'Completed', 'Sent back to provider' or 'All applications'" do
@@ -20,8 +20,8 @@ RSpec.describe 'Search applications status filter' do
 
   describe 'search by:' do
     describe 'default' do
-      it 'filters by status "open"' do
-        expect(page).to have_select(filter_field, selected: 'Open')
+      it 'filters by status "all"' do
+        expect(page).to have_select(filter_field, selected: 'All applications')
       end
     end
 


### PR DESCRIPTION
## Description of change
Changes search default from open to all applications. This was attempted in PR #722 but there were areas of the app that returned all applications when they shouldn't have been. So this PR also explicitly sets the review status search filter to `open` for assigned applications and get next functions 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1385

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1208" alt="Screenshot 2024-10-10 at 08 46 13" src="https://github.com/user-attachments/assets/af786380-4376-4db0-b857-d4f4b8e7b37a">

## How to manually test the feature
