### PR TITLE
Fix unhandled errors in system specs

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,8 +28,12 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
-  # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = :all
+  # :rescuable configures Action Pack rescue from exceptions defined in
+  # config.action_dispatch.rescue_responses, and raise all others.
+  #
+  # If this is set to :all in the test environment then unhandled exceptions
+  # are masked (such as Webmock errors).
+  config.action_dispatch.show_exceptions = :rescuable
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/init/api_data.rb
+++ b/spec/init/api_data.rb
@@ -25,6 +25,31 @@ RSpec.configure do |config|
     ).to_return(body: LaaCrimeSchemas.fixture(1.0, name: 'application_returned').read, status: 200)
 
     #
+    # For resubmission testing
+    #
+    resubmission_data = JSON.parse(LaaCrimeSchemas.fixture(1.0).read).deep_merge(
+      'id' => '012a553f-e9b7-4e9a-a265-67682b572fd0',
+      'parent_id' => 'ff32c3e6-a88e-4d3d-a595-5a11b0aea9ef',
+      'client_details' => { 'applicant' => { 'first_name' => 'Jessica', 'last_name' => 'Rhode' } }
+    )
+
+    stub_request(
+      :get,
+      "#{ENV.fetch('DATASTORE_API_ROOT')}/api/v1/applications/012a553f-e9b7-4e9a-a265-67682b572fd0"
+    ).to_return(body: resubmission_data.to_json, status: 200)
+
+    origional_submission_data = JSON.parse(LaaCrimeSchemas.fixture(1.0).read).deep_merge(
+      'id' => 'ff32c3e6-a88e-4d3d-a595-5a11b0aea9ef',
+      'parent_id' => nil,
+      'client_details' => { 'applicant' => { 'first_name' => 'Jessica', 'last_name' => 'Rhode' } }
+    )
+
+    stub_request(
+      :get,
+      "#{ENV.fetch('DATASTORE_API_ROOT')}/api/v1/applications/ff32c3e6-a88e-4d3d-a595-5a11b0aea9ef"
+    ).to_return(body: origional_submission_data.to_json, status: 200)
+
+    #
     # For an application not found on the datastore
     #
     stub_request(:get, "#{ENV.fetch('DATASTORE_API_ROOT')}/api/v1/applications/123")

--- a/spec/requests/api/events_spec.rb
+++ b/spec/requests/api/events_spec.rb
@@ -218,9 +218,10 @@ RSpec.describe 'Api::Events' do
     end
 
     it 'throws exception' do
-      do_request
-
-      expect(response).to have_http_status :internal_server_error
+      expect { do_request }.to raise_error(
+        Aws::SNS::MessageVerifier::VerificationError,
+        'The certificate does not match expected X509 PEM format.'
+      )
     end
   end
 

--- a/spec/system/casework/viewing_an_application/application_details/supporting_evidence_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/supporting_evidence_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Viewing supporting evidence' do
   include_context 'with stubbed application'
+  include_context 'when downloading a document'
 
   before do
     visit crime_application_path(application_id)

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -350,19 +350,23 @@ RSpec.describe 'Viewing an application unassigned, open application' do
         end
 
         it 'shows the relationship to client' do
-          expect(page).to have_summary_row(residence_question, "In someone else's home")
-          expect(page).to have_summary_row(relationship_question, 'Friend')
+          within_card('Client details') do |card|
+            expect(card).to have_summary_row(residence_question, "In someone else's home")
+            expect(card).to have_summary_row(relationship_question, 'Friend')
+          end
         end
       end
 
       context 'when it was not asked at time of application' do
         let(:application_data) do
-          super().merge('client_details' => { 'applicant' => {} })
+          super().merge('client_details' => { 'applicant' => { 'date_of_birth' => '2000-11-11' } })
         end
 
         it 'does not display' do
-          expect(page).to have_no_content(residence_question)
-          expect(page).to have_no_content(relationship_question)
+          within_card('Client details') do |card|
+            expect(card).to have_no_content(residence_question)
+            expect(card).to have_no_content(relationship_question)
+          end
         end
       end
     end
@@ -377,15 +381,19 @@ RSpec.describe 'Viewing an application unassigned, open application' do
       end
 
       it 'does display relationship status details' do
-        expect(page).to have_content('Relationship status Separated')
-        expect(page).to have_content('Date client separated from partner 12/03/2008')
+        within_card('Client details') do |card|
+          expect(card).to have_content('Relationship status Separated')
+          expect(card).to have_content('Date client separated from partner 12/03/2008')
+        end
       end
     end
 
     context 'when the question was not asked' do
       it 'does not display relationship status details' do
-        expect(page).to have_no_content('Relationship status')
-        expect(page).to have_no_content('Date client separated from partner')
+        within_card('Client details') do |card|
+          expect(card).to have_no_content('Relationship status')
+          expect(card).to have_no_content('Date client separated from partner')
+        end
       end
     end
   end

--- a/spec/system/errors_spec.rb
+++ b/spec/system/errors_spec.rb
@@ -2,27 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'Error pages' do
   context 'when authenticated' do
-    context 'when an unhandled error occurs' do
-      before do
-        allow(ApplicationSearchFilter).to receive(:new) {
-          raise StandardError
-        }
-
-        visit '/'
-        click_on 'Search'
-      end
-
-      it 'shows the unhandled error page and status' do
-        expect(page).to have_content 'Sorry, something went wrong with our service'
-        expect(page).to have_http_status(:internal_server_error)
-      end
-
-      it 'uses the simplified error page layout' do
-        expect(page).to have_no_css('nav.moj-primary-navigation')
-        expect(page).to have_no_link('Sign out')
-      end
-    end
-
     context 'when crime application is not found' do
       before do
         visit '/applications/123'


### PR DESCRIPTION
## Description of change

Raise unhandled errors in system specs

## Link to relevant ticket

## Notes for reviewer

The `show_exceptions` setting was incorrectly configured to `:all` in the test environment, causing unhandled exceptions (e.g., WebMock errors) in system specs to be hidden.

Changing the configuration to `:rescuable` ensures that handled error pages are shown, while unhandled errors are properly raised.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
