### PR TITLE
[CRIMAPP-1335] Update supporting evidence card design

### DIFF
--- a/app/views/casework/crime_applications/_supporting_evidence.html.erb
+++ b/app/views/casework/crime_applications/_supporting_evidence.html.erb
@@ -34,9 +34,9 @@
       title: label_text(:evidence_other)
     } %>
 
-<% if crime_application.supporting_evidence.present? %>
-  <%= govuk_summary_card(title: label_text(:file_name)) do
-    govuk_summary_list(actions: false) do |list|
+<%= govuk_summary_card(title: label_text(:file_name)) do
+  govuk_summary_list(actions: false) do |list|
+    if crime_application.supporting_evidence.present?
       crime_application.supporting_evidence.each do |evidence|
         list.with_row do |row|
           row.with_key { evidence.filename }
@@ -50,15 +50,10 @@
           end
         end
       end
+    else
+      list.with_row do |row|
+        row.with_key { label_text(:no_files_uploaded) }
+      end
     end
-  end %>
-<% else %>
-  <div class="govuk-summary-card">
-    <div class="govuk-summary-card__title-wrapper">
-      <h2 class="govuk-summary-card__title"><%= t('labels.file_name') %></h2>
-    </div>
-    <div class="govuk-summary-card__content">
-      <p class="govuk-heading-s"><%= t('labels.no_files_uploaded') %></p>
-    </div>
-  </div>
-<% end %>
+  end
+end %>

--- a/app/views/casework/crime_applications/_supporting_evidence.html.erb
+++ b/app/views/casework/crime_applications/_supporting_evidence.html.erb
@@ -35,25 +35,25 @@
     } %>
 
 <%= govuk_summary_card(title: label_text(:file_name)) do
-  govuk_summary_list(actions: false) do |list|
-    if crime_application.supporting_evidence.present?
-      crime_application.supporting_evidence.each do |evidence|
-        list.with_row do |row|
-          row.with_key { evidence.filename }
-          row.with_value do
-            govuk_link_to(
-              sanitize(t(:download_file, scope: 'values',
-                         file_extension: evidence.file_extension,
-                         file_size: number_to_human_size(evidence.file_size))),
-              download_documents_path(crime_application_id: crime_application.id, id: evidence.s3_object_key)
-            )
+      govuk_summary_list(actions: false) do |list|
+        if crime_application.supporting_evidence.present?
+          crime_application.supporting_evidence.each do |evidence|
+            list.with_row do |row|
+              row.with_key { evidence.filename }
+              row.with_value do
+                govuk_link_to(
+                  sanitize(t(:download_file, scope: 'values',
+                             file_extension: evidence.file_extension,
+                             file_size: number_to_human_size(evidence.file_size))),
+                  download_documents_path(crime_application_id: crime_application.id, id: evidence.s3_object_key)
+                )
+              end
+            end
+          end
+        else
+          list.with_row do |row|
+            row.with_key { label_text(:no_files_uploaded) }
           end
         end
       end
-    else
-      list.with_row do |row|
-        row.with_key { label_text(:no_files_uploaded) }
-      end
-    end
-  end
-end %>
+    end %>

--- a/app/views/casework/crime_applications/_supporting_evidence.html.erb
+++ b/app/views/casework/crime_applications/_supporting_evidence.html.erb
@@ -10,7 +10,7 @@
 
 <% if crime_application.evidence_details.show? %>
   <h2
-    class="govuk-heading-s govuk-!-margin-bottom-7"
+    class="govuk-heading-s govuk-!-margin-bottom-5"
     data-evidence-last-run-at="<%= crime_application.evidence_details.last_run_at %>">
       <%= label_text(:evidence_asked_for) %>:
   </h2>
@@ -36,20 +36,29 @@
 
 <% if crime_application.supporting_evidence.present? %>
   <%= govuk_summary_card(title: label_text(:file_name)) do
-        govuk_summary_list(actions: false) do |list|
-          crime_application.supporting_evidence.each do |evidence|
-            list.with_row do |row|
-              row.with_key { evidence.filename }
-              row.with_value do
-                govuk_link_to(
-                  sanitize(t(:download_file, scope: 'values',
-                             file_extension: evidence.file_extension,
-                             file_size: number_to_human_size(evidence.file_size))),
-                  download_documents_path(crime_application_id: crime_application.id, id: evidence.s3_object_key)
-                )
-              end
-            end
+    govuk_summary_list(actions: false) do |list|
+      crime_application.supporting_evidence.each do |evidence|
+        list.with_row do |row|
+          row.with_key { evidence.filename }
+          row.with_value do
+            govuk_link_to(
+              sanitize(t(:download_file, scope: 'values',
+                         file_extension: evidence.file_extension,
+                         file_size: number_to_human_size(evidence.file_size))),
+              download_documents_path(crime_application_id: crime_application.id, id: evidence.s3_object_key)
+            )
           end
         end
-      end %>
+      end
+    end
+  end %>
+<% else %>
+  <div class="govuk-summary-card">
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title"><%= t('labels.file_name') %></h2>
+    </div>
+    <div class="govuk-summary-card__content">
+      <p class="govuk-heading-s"><%= t('labels.no_files_uploaded') %></p>
+    </div>
+  </div>
 <% end %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -267,6 +267,7 @@ en:
     national_savings_certificate_value: What is the value of the certificate?
     national_savings_certificate_ownership_type: Who owns the certificate?
     next_court_hearing: Next court hearing the case
+    no_files_uploaded: No files were uploaded
     number_of_dependants: Number of dependants aged %{age_range} on next birthday
     offence: Offence
     offence_class: Class

--- a/spec/system/casework/viewing_an_application/application_details/supporting_evidence_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/supporting_evidence_spec.rb
@@ -31,8 +31,10 @@ RSpec.describe 'Viewing supporting evidence' do
         super().deep_merge('supporting_evidence' => [], 'evidence_details' => nil)
       end
 
-      it 'not show the files card' do
-        expect { files_card }.to raise_error Capybara::ElementNotFound
+      it 'shows the files card' do
+        within(files_card) do |card|
+          expect(card).to have_text 'No files were uploaded'
+        end
       end
     end
   end


### PR DESCRIPTION
## Description of change
Updates supporting evidence summary card to display card when no files have been uploaded

## Link to relevant ticket
[dsdmoj.atlassian.net/browse/CRIMAPP-1335](https://dsdmoj.atlassian.net/browse/CRIMAPP-1335)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

<img width="1057" alt="Screenshot 2024-10-22 at 14 47 25" src="https://github.com/user-attachments/assets/589157a7-63a2-4699-a07c-e196a3a7d7ab">

## How to manually test the feature
