### PR TITLE
Sns message id is not of type UUID

### DIFF
--- a/app/aggregates/reviewing/commands/receive_application.rb
+++ b/app/aggregates/reviewing/commands/receive_application.rb
@@ -6,8 +6,8 @@ module Reviewing
     attribute? :parent_id, Types::Uuid.optional
     attribute :work_stream, Types::WorkStreamType
     attribute :application_type, Types::ApplicationType
-    attribute? :correlation_id, Types::Uuid.optional
-    attribute? :causation_id, Types::Uuid.optional
+    attribute? :correlation_id, Types::String.optional
+    attribute? :causation_id, Types::String.optional
 
     def call
       with_review do |review|

--- a/spec/models/sns_event/receive_application_event_spec.rb
+++ b/spec/models/sns_event/receive_application_event_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SnsEvent::ReceiveApplicationEvent do
     @sns_message ||= {
       'Type' => 'Notificxation',
       'Token' => '2336412f37f',
-      'MessageId' => SecureRandom.uuid,
+      'MessageId' => SecureRandom.hex,
       'TopicArn' => 'arn:aws:sns:eu-west-2:754256621582:ImportantMaatTopic',
       'Subject' => 'apply.submission',
       'Message' => { event_name: 'apply.submission' }.to_json,

--- a/spec/requests/api/events_spec.rb
+++ b/spec/requests/api/events_spec.rb
@@ -5,7 +5,7 @@ require 'aws-sdk-sns'
 RSpec.describe 'Api::Events' do
   include_context 'with review'
 
-  let(:sns_message_id) { SecureRandom.uuid }
+  let(:sns_message_id) { SecureRandom.hex }
   let(:application_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
 
   let(:message) do


### PR DESCRIPTION
## Description of change

SNS message ID is not a UUID

## Link to relevant ticket

[LAA-REVIEW-CRIMINAL-LEGAL-AID-1V](https://ministryofjustice.sentry.io/issues/6001868959/)

## Notes for reviewer


## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
