### PR TITLE
[CRIMAPP-1389] Hide answer rows when question not asked

### DIFF
--- a/app/views/casework/crime_applications/_client_details.html.erb
+++ b/app/views/casework/crime_applications/_client_details.html.erb
@@ -32,89 +32,91 @@
       <%= l applicant.date_of_birth, format: :compact %>
     </dd>
   </div>
-  <% unless crime_application.pse? %>
+  <% unless crime_application.pse? || crime_application.appeal_no_changes? %>
+    <% unless crime_application.means_passported_on_age? %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:national_insurance_number) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= nino.presence || t(:not_provided, scope: 'values') %>
+        </dd>
+      </div>
+      <% if applicant.arc.present? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:arc) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= applicant.arc %>
+          </dd>
+        </div>
+      <% end %>
+    <% end %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        <%= label_text(:national_insurance_number) %>
+        <%= label_text(:telephone_number) %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= nino.presence || t(:not_provided, scope: 'values') %>
+        <%= applicant_tel.presence || t(:not_provided, scope: 'values') %>
       </dd>
     </div>
-    <% if applicant.arc.present? %>
+    <% if applicant.residence_type.present? %>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          <%= label_text(:arc) %>
+          <%= label_text(:residence_type) %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= applicant.arc %>
+          <%= t(applicant.residence_type, scope: 'values.residence_type') %>
         </dd>
       </div>
+      <% if applicant.residence_type == 'someone_else' %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:relationship_to_owner_of_usual_home_address) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= applicant.relationship_to_owner_of_usual_home_address %>
+          </dd>
+        </div>
+      <% end %>
     <% end %>
-    <% unless crime_application.appeal_no_changes? %>
+    <% if applicant.residence_type != 'none' %>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          <%= label_text(:telephone_number) %>
+          <%= label_text(:home_address) %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= applicant_tel.presence || t(:not_provided, scope: 'values') %>
-        </dd>
-      </div>
-      <% if applicant.residence_type.present? %>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            <%= label_text(:residence_type) %>
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <%= t(applicant.residence_type, scope: 'values.residence_type') %>
-          </dd>
-        </div>
-        <% if applicant.residence_type == 'someone_else' %>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              <%= label_text(:relationship_to_owner_of_usual_home_address) %>
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <%= applicant.relationship_to_owner_of_usual_home_address %>
-            </dd>
-          </div>
-        <% end %>
-      <% end %>
-      <% if applicant.residence_type != 'none' %>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            <%= label_text(:home_address) %>
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <% if applicant.home_address %>
-              <%= render 'address', address: applicant.home_address %>
-            <% else %>
-              <%= t(:no_home_address, scope: 'values') %>
-            <% end %>
-          </dd>
-        </div>
-      <% end %>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= label_text(:correspondence_address) %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <% if applicant.correspondence_address_type == 'other_address' %>
-            <%= render 'address', address: applicant.correspondence_address %>
+          <% if applicant.home_address %>
+            <%= render 'address', address: applicant.home_address %>
           <% else %>
-            <%= t(applicant.correspondence_address_type, scope: 'values') %>
+            <%= t(:no_home_address, scope: 'values') %>
           <% end %>
         </dd>
       </div>
     <% end %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        <%= label_text(:partner) %>
+        <%= label_text(:correspondence_address) %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= t(applicant.has_partner.presence, scope: 'values') || t(false, scope: 'values') %>
+        <% if applicant.correspondence_address_type == 'other_address' %>
+          <%= render 'address', address: applicant.correspondence_address %>
+        <% else %>
+          <%= t(applicant.correspondence_address_type, scope: 'values') %>
+        <% end %>
       </dd>
     </div>
+    <% unless crime_application.means_passported_on_age? %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:partner) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(applicant.has_partner.presence, scope: 'values') || t(false, scope: 'values') %>
+        </dd>
+      </div>
+    <% end %>
 
     <% if FeatureFlags.partner_journey.enabled? %>
       <% if applicant.has_partner == 'no' %>

--- a/spec/system/casework/viewing_an_application/appeal_no_changes_application_spec.rb
+++ b/spec/system/casework/viewing_an_application/appeal_no_changes_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Viewing an apeal with no changes application' do
+RSpec.describe 'Viewing an appeal with no changes application' do
   include_context 'with stubbed application'
 
   let(:application_data) do
@@ -17,8 +17,36 @@ RSpec.describe 'Viewing an apeal with no changes application' do
     )
   end
 
+  let(:appeal_maat_id) { nil }
+  let(:appeal_usn) { '456DEF' }
+
   before do
     visit crime_application_path(application_id)
+  end
+
+  describe 'client details card' do
+    let(:card) do
+      page.find('h2.govuk-summary-card__title', text: 'Client details').ancestor('div.govuk-summary-card')
+    end
+
+    it 'shows relevant details' do # rubocop:disable RSpec/MultipleExpectations
+      within(card) do |card|
+        expect(card).to have_summary_row 'First name', 'Kit'
+        expect(card).to have_summary_row 'Last name', 'Pound'
+        expect(card).to have_summary_row 'Other names', 'Not provided'
+        expect(card).to have_summary_row 'Date of birth', '09/06/2001'
+      end
+    end
+
+    it 'does not display unanswered questions' do # rubocop:disable RSpec/MultipleExpectations
+      expect(card).to have_no_content 'National Insurance Number'
+      expect(card).to have_no_content 'Application registration card (ARC) number'
+      expect(card).to have_no_content 'UK Telephone number'
+      expect(card).to have_no_content 'Where the client usually lives'
+      expect(card).to have_no_content 'Correspondence address'
+      expect(card).to have_no_content 'Partner'
+      expect(card).to have_no_content 'Relationship status'
+    end
   end
 
   describe 'case details card' do
@@ -27,9 +55,6 @@ RSpec.describe 'Viewing an apeal with no changes application' do
     end
 
     context 'when appeal no changes with USN' do
-      let(:appeal_maat_id) { nil }
-      let(:appeal_usn) { '456DEF' }
-
       it 'shows savings details' do # rubocop:disable RSpec/MultipleExpectations
         within(card) do |card|
           expect(card).to have_summary_row 'Case type', 'Appeal to crown court'

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -149,6 +149,30 @@ RSpec.describe 'Viewing an application unassigned, open application' do
       it 'does not show the passporting benefit row' do
         expect(page).to have_no_content('Passporting Benefit')
       end
+
+      describe 'client details card' do
+        let(:card) do
+          page.find('h2.govuk-summary-card__title', text: 'Client details').ancestor('div.govuk-summary-card')
+        end
+
+        it 'shows relevant details' do # rubocop:disable RSpec/MultipleExpectations
+          within(card) do |card|
+            expect(card).to have_summary_row 'First name', 'Kit'
+            expect(card).to have_summary_row 'Last name', 'Pound'
+            expect(card).to have_summary_row 'Other names', 'Not provided'
+            expect(card).to have_summary_row 'Date of birth', '09/06/2001'
+            expect(card).to have_summary_row 'UK Telephone number', '07771 231 231'
+            expect(card).to have_summary_row 'Correspondence address', 'Same as home address'
+          end
+        end
+
+        it 'does not display unanswered questions' do
+          expect(card).to have_no_content 'National Insurance Number'
+          expect(card).to have_no_content 'Application registration card (ARC) number'
+          expect(card).to have_no_content 'Partner'
+          expect(card).to have_no_content 'Relationship status'
+        end
+      end
     end
   end
 

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe 'Viewing an application unassigned, open application' do
           end
         end
 
-        it 'does not display unanswered questions' do
+        it 'does not display unanswered questions' do # rubocop:disable RSpec/MultipleExpectations
           expect(card).to have_no_content 'National Insurance Number'
           expect(card).to have_no_content 'Application registration card (ARC) number'
           expect(card).to have_no_content 'Partner'


### PR DESCRIPTION
## Description of change
Hides the nino answer row for appeal no changes and under 18 applications as the nino question is not asked
Client contact detail information is also hidden for appeal no changes applications as these questions are not asked during the application

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1389

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1068" alt="Screenshot 2024-10-28 at 14 18 32" src="https://github.com/user-attachments/assets/941a0e6a-7d9d-4e9f-af0a-bb1398a37705">
<img width="1068" alt="Screenshot 2024-10-28 at 14 18 43" src="https://github.com/user-attachments/assets/b78239eb-9899-489d-a270-ca8e4ba6b700">


### After changes:
<img width="1068" alt="Screenshot 2024-10-28 at 14 12 54" src="https://github.com/user-attachments/assets/2f676833-53fd-4f1b-827a-25028843d70d">
<img width="1068" alt="Screenshot 2024-10-28 at 14 13 00" src="https://github.com/user-attachments/assets/0ef23c54-6da2-489b-bac1-d9c589962d4b">


## How to manually test the feature
