### PR TITLE
Workload report only shows 0..4 business days

### DIFF
--- a/app/models/reporting/workload_report.rb
+++ b/app/models/reporting/workload_report.rb
@@ -1,6 +1,6 @@
 module Reporting
   class WorkloadReport
-    AGE_LIMIT = 9
+    AGE_LIMIT = 4
 
     # Builds a Workload Report from "observed_at" until "age_limit" business days
     # ago.

--- a/app/models/reporting/workload_report_row.rb
+++ b/app/models/reporting/workload_report_row.rb
@@ -24,10 +24,6 @@ module Reporting
       define_method(:"day#{i}") { backlogs[i] }
     end
 
-    def day4_to_last_day
-      day0_to_last_day - backlogs.first(4).sum
-    end
-
     def day0_to_last_day
       backlogs.sum
     end

--- a/app/views/reporting/base/_workload_report.en.html.erb
+++ b/app/views/reporting/base/_workload_report.en.html.erb
@@ -26,7 +26,7 @@
                 row.with_cell(text: '1 day', numeric: true, classes: 'colgroup-detail')
                 row.with_cell(text: '2 days', numeric: true, classes: 'colgroup-detail')
                 row.with_cell(text: '3 days', numeric: true, classes: 'colgroup-detail')
-                row.with_cell(text: '4-9 days', numeric: true, classes: 'colgroup-detail')
+                row.with_cell(text: '4 days', numeric: true, classes: 'colgroup-detail')
                 row.with_cell(text: 'Total', numeric: true, classes: 'colgroup-total')
               end
             end
@@ -69,7 +69,7 @@
                     classes: 'colgroup-detail'
                   )
                   row.with_cell(
-                    text: data_row.day4_to_last_day,
+                    text: data_row.day4,
                     numeric: true,
                     classes: 'colgroup-detail'
                   )
@@ -117,7 +117,7 @@
                   classes: 'colgroup-detail'
                 )
                 row.with_cell(
-                  text: data_rows.sum(&:day4_to_last_day),
+                  text: data_rows.sum(&:day4),
                   numeric: true,
                   classes: 'colgroup-detail'
                 )

--- a/spec/models/reporting/workload_report_spec.rb
+++ b/spec/models/reporting/workload_report_spec.rb
@@ -54,8 +54,7 @@ RSpec.describe Reporting::WorkloadReport do
   describe '#business_days' do
     it 'returns an array of the business days included in the report' do
       expect(report.business_days).to eq(
-        %w[2023-01-03 2022-12-30 2022-12-29 2022-12-28 2022-12-23 2022-12-22 2022-12-21 2022-12-20 2022-12-19
-           2022-12-16]
+        %w[2023-01-03 2022-12-30 2022-12-29 2022-12-28 2022-12-23]
       )
     end
   end

--- a/spec/system/reporting/workload_report_spec.rb
+++ b/spec/system/reporting/workload_report_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Workload Report' do
   end
 
   it 'shows the correct detail column headers' do
-    expected_headers = ['', 'Received', 'Closed', '0 days', '1 day', '2 days', '3 days', '4-9 days', 'Total']
+    expected_headers = ['', 'Received', 'Closed', '0 days', '1 day', '2 days', '3 days', '4 days', 'Total']
 
     within('#cat-1') do
       page.all('table thead tr.colgroup-details th').each_with_index do |el, i|


### PR DESCRIPTION
## Description of change

Show only the zero to 4 business days on the detailed workload report.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-1472

## Notes for reviewer

The data for days 5-9 is not useful, but it requires the same computational resources as the critical data from days 0-4. While optimisation is planned for this report, implementing this change should significantly reduce the processing time for these reports in the meantime.

The data for days 5-9 will still be able in the current workload reports.

## Screenshots of changes (if applicable)

### Before changes:

<img width="1059" alt="Screenshot 2024-10-28 at 14 27 52" src="https://github.com/user-attachments/assets/851c5171-e93e-4f28-8391-6613275c4a74">

### After changes:

<img width="1085" alt="Screenshot 2024-10-28 at 14 27 38" src="https://github.com/user-attachments/assets/11abf7c5-95c4-4ff4-96af-6cac5361fa2f">


## How to manually test the feature
