### PR TITLE
CRIMAPP-1361 remove a linked decision

### DIFF
--- a/app/aggregates/deciding.rb
+++ b/app/aggregates/deciding.rb
@@ -17,12 +17,16 @@ module Deciding
     end
   end
 
+  class CommentSet < Event; end
   class DraftCreated < Event; end
   class DraftCreatedFromMaat < Event; end
-  class InterestsOfJusticeSet < Event; end
   class FundingDecisionSet < Event; end
+  class InterestsOfJusticeSet < Event; end
+  class Linked < Event; end
   class SynchedWithMaat < Event; end
-  class CommentSet < Event; end
+  class Unlinked < Event; end
+
+  class ApplyDraftLinked < Event; end
 
   class << self
     def stream_name(decision_id)

--- a/app/aggregates/deciding/commands/unlink.rb
+++ b/app/aggregates/deciding/commands/unlink.rb
@@ -1,0 +1,16 @@
+module Deciding
+  class Unlink < Command
+    attribute :application_id, Types::Uuid
+    attribute :decision_id, Types::DecisionId
+    attribute :user_id, Types::Uuid
+
+    def call
+      with_decision do |decision|
+        ActiveRecord::Base.transaction do
+          decision.unlink(application_id:, user_id:)
+          Reviewing::RemoveDecision.call(decision_id:, application_id:, user_id:)
+        end
+      end
+    end
+  end
+end

--- a/app/aggregates/reviewing.rb
+++ b/app/aggregates/reviewing.rb
@@ -5,20 +5,16 @@ module Reviewing
     end
   end
 
-  class AlreadyCompleted < Error; end
   class AlreadyMarkedAsReady < Error; end
   class AlreadyReceived < Error; end
   class AlreadySentBack < Error; end
+  class AlreadyReviewed < Error; end
   class DecisionAlreadyLinked < Error; end
-  class CannotCompleteWhenSentBack < Error; end
-  class CannotMarkAsReadyWhenCompleted < Error; end
-  class CannotMarkAsReadyWhenSentBack < Error; end
-  class CannotSendBackWhenCompleted < Error; end
+  class DecisionNotLinked < Error; end
   class IncompleteDecisions < Error; end
-  class NotReceived < Error; end
 
   class DecisionAdded < Event; end
-  class MaatDecisionAdded < Event; end
+  class DecisionRemoved < Event; end
 
   class << self
     def stream_name(application_id)

--- a/app/aggregates/reviewing/commands/remove_decision.rb
+++ b/app/aggregates/reviewing/commands/remove_decision.rb
@@ -1,0 +1,13 @@
+module Reviewing
+  class RemoveDecision < Command
+    attribute :application_id, Types::Uuid
+    attribute :user_id, Types::Uuid
+    attribute :decision_id, Types::DecisionId
+
+    def call
+      with_review do |review|
+        review.remove_decision(user_id:, decision_id:)
+      end
+    end
+  end
+end

--- a/app/components/decision_component.rb
+++ b/app/components/decision_component.rb
@@ -20,7 +20,7 @@ class DecisionComponent < ViewComponent::Base
   def actions
     return [] unless draft? && show_actions
 
-    [change_action]
+    [change_action, remove_action].compact
   end
 
   def draft?
@@ -41,8 +41,23 @@ class DecisionComponent < ViewComponent::Base
     end
   end
 
+  def remove_action
+    return unless linked_to_maat?
+
+    button_to(
+      action_text(:unlink_decision),
+      crime_application_maat_decision_path(
+        crime_application_id: decision.application_id, id: decision.decision_id
+      ),
+      method: :delete,
+      class: 'govuk-link app-button--link'
+    )
+  end
+
   def update_path
-    crime_application_maat_decision_path(crime_application_id: decision.application_id, id: decision.decision_id)
+    crime_application_maat_decision_path(
+      crime_application_id: decision.application_id, id: decision.decision_id
+    )
   end
 
   def ioj_result

--- a/app/controllers/casework/maat_decisions_controller.rb
+++ b/app/controllers/casework/maat_decisions_controller.rb
@@ -57,6 +57,22 @@ module Casework
       )
     end
 
+    def destroy
+      Deciding::Unlink.call(
+        application_id: @crime_application.id,
+        user_id: current_user_id,
+        decision_id: @decision.decision_id
+      )
+
+      set_flash :decision_removed, success: true
+
+      if @crime_application.decision_ids.size > 1
+        redirect_to crime_application_decisions_path
+      else
+        redirect_to crime_application_path(@crime_application)
+      end
+    end
+
     private
 
     def permitted_params

--- a/app/controllers/casework/returns_controller.rb
+++ b/app/controllers/casework/returns_controller.rb
@@ -6,7 +6,6 @@ module Casework
       @return_details = ReturnDetails.new
     end
 
-    # rubocop:disable Metrics/MethodLength
     def create
       @return_details = ReturnDetails.new(return_params)
 
@@ -21,12 +20,9 @@ module Casework
       flash_and_redirect :success, :sent_back
     rescue ActiveModel::ValidationError
       render :new
-    rescue Reviewing::AlreadySentBack
-      flash_and_redirect :important, :already_sent_back
-    rescue Reviewing::CannotSendBackWhenCompleted
-      flash_and_redirect :important, :cannot_send_back_when_completed
+    rescue Reviewing::AlreadyReviewed
+      flash_and_redirect :important, :already_reviewed
     end
-    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -4,7 +4,7 @@ module Reviewable
   end
 
   delegate :reviewed_at, :reviewer_id, :reviewed?, :superseded_by, :superseded_at,
-           :business_day, :available_reviewer_actions, to: :review
+           :business_day, :available_reviewer_actions, :decision_ids, to: :review
 
   def review_status
     review.state
@@ -34,7 +34,7 @@ module Reviewable
   end
 
   def draft_decisions
-    @draft_decisions ||= review.decision_ids.map do |decision_id|
+    @draft_decisions ||= decision_ids.map do |decision_id|
       Decisions::Draft.build(
         Deciding::LoadDecision.call(
           application_id: id, decision_id: decision_id

--- a/app/views/casework/crime_applications/_funding_decision.html.erb
+++ b/app/views/casework/crime_applications/_funding_decision.html.erb
@@ -10,9 +10,8 @@
            )) %>
 
 <% if crime_application.decisions.empty? && crime_application.reviewable_by?(current_user_id) %>
-    <% if crime_application.means_tested? %>
-      <p><%= t('.create_application_on_maat',
-               reference: crime_application.reference) %></p>
+    <% if crime_application.status?(::Types::ReviewState[:marked_as_ready]) %>
+      <p><%= t('.create_application_on_maat', reference: crime_application.reference) %></p>
 
       <%= govuk_button_to(
             action_text(:add_funding_decision),
@@ -20,7 +19,9 @@
               crime_application
             )
           ) %>
-    <% else %>
+    <% end %>
+
+    <% unless crime_application.means_tested?  %>
       <p><%= t '.manually_enter_decision' %></p>
 
       <%= govuk_button_to action_text(:start),

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -12,11 +12,12 @@ en:
   flash:
     success:
       assigned_to_self: You assigned this application to your list
-      unassigned_from_self: You removed the application from your list
-      sent_back: You sent the application back to the provider
       completed: You marked the application as complete
       completed_with_decisions: Application complete. Decision sent to provider.  
+      decision_removed: Decision removed
       marked_as_ready: You marked the application as ready for assessment
+      sent_back: You sent the application back to the provider
+      unassigned_from_self: You removed the application from your list
       maat_decision_linked:
         - Linked to MAAT application with MAAT ID %{maat_id} 
         - Check the decision, and make any required amendments on MAAT. 
@@ -39,13 +40,11 @@ en:
       no_change_since_last_update:
         - The application on MAAT has not changed.
         - Make any required amendments on MAAT using the MAAT ID %{maat_id}. 
-      already_sent_back: This application was already sent back to the provider
-      already_completed: This application was already marked as complete
+      already_reviewed: This application was already reviewed
       already_marked_as_ready: This application was already marked as ready for assessment
       cannot_complete_when_sent_back: This application was already sent back to the provider
       cannot_mark_as_ready_when_completed: This application was already marked as complete
       cannot_mark_as_ready_when_sent_back: This application was already sent back to the provider
-      cannot_send_back_when_completed: This application was already marked as complete
       cannot_send_back_when_marked_as_ready: This application was already marked as ready for assessment
       cannot_download_doc_uploaded_to_another_app: File must be uploaded to current application to download
       cannot_download_try_again: "%{file_name} could not be downloaded – try again"
@@ -637,27 +636,28 @@ en:
     back_to_list: Back to your list
     change: Change
     clear_search: Clear
+    complete: Mark as completed
     confirm_reassign_to_self: Yes, reassign
     copy_reference_number: Copy reference number
     copy_urn: Copy URN
     go_to_latest: Go to the latest version
-    reassign_to_self: Reassign to your list
-    search: Search
-    unassign_from_self: Remove from your list
-    view_all_open_applications: Check open applications
-    view_daily_count: Check when applications were received
-    view_closed_on_count: Check when applications were closed
-    mark_complete: Mark as completed
-    complete: Mark as completed
-    send_back: Send back to provider
     mark_as_ready: Mark as ready for MAAT
+    mark_complete: Mark as completed
+    reassign_to_self: Reassign to your list
     save_and_come_back: Save and come back later
-    sign_out: Sign out
+    search: Search
+    send_back: Send back to provider
     sign_in: Sign in
-    start_now: Start now
+    sign_out: Sign out
     start: Start
+    start_now: Start now
     submit_decision: Send to provider
+    unassign_from_self: Remove from your list
+    unlink_decision: Remove
     update_from_maat: Update from MAAT
+    view_all_open_applications: Check open applications
+    view_closed_on_count: Check when applications were closed
+    view_daily_count: Check when applications were received
 
   actions: *ACTIONS
   confirmations:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,7 @@ Rails.application.routes.draw do
         end
       end
       
-      resources :maat_decisions, only: [:new, :create, :update] do
+      resources :maat_decisions, only: [:new, :create, :update, :destroy] do
         post :create_by_reference, on: :collection
       end
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_15_132443) do
+ActiveRecord::Schema[7.2].define(version: 2024_03_15_132443) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"

--- a/spec/aggregates/reviewing/review_spec.rb
+++ b/spec/aggregates/reviewing/review_spec.rb
@@ -45,6 +45,11 @@ describe Reviewing::Review do
 
     it 'becomes "sent_back"' do
       expect(review.state).to eq :sent_back
+      expect(review.reviewed_at).to be_present
+    end
+
+    it 'becomes "reviewed"' do
+      expect(review).to be_reviewed
     end
 
     it 'creates an event' do
@@ -56,19 +61,19 @@ describe Reviewing::Review do
     it 'can only happen once' do
       expect do
         review.send_back(user_id:, reason:)
-      end.to raise_error Reviewing::AlreadySentBack
+      end.to raise_error Reviewing::AlreadyReviewed
     end
 
     it 'cannot then be completed' do
       expect do
         review.complete(user_id:)
-      end.to raise_error Reviewing::CannotCompleteWhenSentBack
+      end.to raise_error Reviewing::AlreadyReviewed
     end
 
     it 'cannot then be marked as ready' do
       expect do
         review.mark_as_ready(user_id:)
-      end.to raise_error Reviewing::CannotMarkAsReadyWhenSentBack
+      end.to raise_error Reviewing::AlreadyReviewed
     end
   end
 
@@ -84,6 +89,10 @@ describe Reviewing::Review do
       expect(review.state).to eq :completed
     end
 
+    it 'becomes "reviewed"' do
+      expect(review).to be_reviewed
+    end
+
     it 'creates an event' do
       expect(review.unpublished_events.map(&:event_type)).to match [
         'Reviewing::ApplicationReceived', 'Reviewing::Completed'
@@ -92,20 +101,20 @@ describe Reviewing::Review do
 
     it 'can only happen once' do
       expect { review.complete(user_id:) }.to raise_error(
-        Reviewing::AlreadyCompleted
+        Reviewing::AlreadyReviewed
       )
     end
 
     it 'cannot then be sent back' do
       expect do
         review.send_back(user_id:, reason:)
-      end.to raise_error Reviewing::CannotSendBackWhenCompleted
+      end.to raise_error Reviewing::AlreadyReviewed
     end
 
     it 'cannot then be marked as ready' do
       expect do
         review.mark_as_ready(user_id:)
-      end.to raise_error Reviewing::CannotMarkAsReadyWhenCompleted
+      end.to raise_error Reviewing::AlreadyReviewed
     end
   end
 

--- a/spec/system/casework/deciding/adding_another_maat_decision_spec.rb
+++ b/spec/system/casework/deciding/adding_another_maat_decision_spec.rb
@@ -82,6 +82,13 @@ RSpec.describe 'Adding another MAAT decision' do
     end
   end
 
+  it 'returns to the decisions page when one of the deicisons is removed' do
+    within_card('Case 1') { click_button('Remove') }
+
+    expect(page).to have_success_notification_banner(text: 'Decision removed')
+    expect(current_path).to eq(crime_application_decisions_path(application_id))
+  end
+
   it 'returns an error if submitting with an incomplete decision' do
     click_button('Send to provider')
 

--- a/spec/system/casework/deciding/removing_a_maat_decision_spec.rb
+++ b/spec/system/casework/deciding/removing_a_maat_decision_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe 'Removing a MAAT decision' do
+  include DecisionFormHelpers
+
+  include_context 'with stubbed application'
+
+  let(:mock_get_decision) { instance_double(Maat::GetDecision) }
+  let(:maat_decision) do
+    Maat::Decision.new(
+      maat_id: maat_id,
+      reference: 6_000_001,
+      interests_of_justice: {
+        result: 'pass',
+        assessed_by: 'Jo Bloggs',
+        assessed_on:  1.day.ago.to_s
+      },
+      means: {
+        result: 'pass',
+        assessed_by: 'Jo Bloggs',
+        assessed_on:  1.day.ago.to_s
+      },
+      funding_decision: 'granted'
+    )
+  end
+
+  let(:maat_id) { 123 }
+
+  before do
+    allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
+      .and_return(instance_double(DatastoreApi::Requests::UpdateApplication, call: {}))
+
+    allow(FeatureFlags).to receive(:adding_decisions) {
+      instance_double(FeatureFlags::EnabledFeature, enabled?: true)
+    }
+
+    allow(mock_get_decision).to receive(:by_maat_id).with(maat_id).and_return(maat_decision)
+    allow(Maat::GetDecision).to receive(:new).and_return(mock_get_decision)
+
+    visit crime_application_path(application_id)
+    click_button 'Assign to your list'
+    click_button 'Mark as ready for MAAT'
+    visit new_crime_application_maat_decision_path(application_id)
+
+    fill_in('MAAT ID', with: maat_id)
+
+    save_and_continue
+    click_button('Remove')
+  end
+
+  it 'removes the maat decision and redirects to the details page' do
+    expect(page).to have_success_notification_banner(
+      text: 'Decision removed'
+    )
+
+    expect(current_path).to eq(
+      '/applications/696dd4fd-b619-4637-ab42-a5f4565bcf4a'
+    )
+  end
+
+  it 'the removed decision can be re-added' do
+    visit new_crime_application_maat_decision_path(application_id)
+    fill_in('MAAT ID', with: maat_id)
+    save_and_continue
+
+    expect(page).to have_success_notification_banner(
+      text: 'Linked to MAAT application with MAAT ID 123',
+      details: 'Check the decision, and make any required amendments on MAAT.'
+    )
+  end
+end

--- a/spec/system/casework/reviewing/mark_application_as_complete_spec.rb
+++ b/spec/system/casework/reviewing/mark_application_as_complete_spec.rb
@@ -70,22 +70,22 @@ RSpec.describe 'Marking an application as complete' do
       end
 
       describe 'AlreadyCompleted' do
-        let(:error_class) { Reviewing::AlreadyCompleted }
+        let(:error_class) { Reviewing::AlreadyReviewed }
         let(:message) do
-          'This application was already marked as complete'
+          'This application was already reviewed'
         end
 
         it 'notifies that the application has already been completed' do
-          expect(page).to have_content message
+          expect(page).to have_notification_banner text: message
         end
       end
 
-      describe 'CannotCompleteWhenSentBack' do
-        let(:error_class) { Reviewing::CannotCompleteWhenSentBack }
-        let(:message) { 'This application was already sent back to the provider' }
+      describe 'IncompleteDecisions' do
+        let(:error_class) { Reviewing::IncompleteDecisions }
+        let(:message) { 'Please complete any pending funding decisions' }
 
         it 'notifies that the application has already been sent back' do
-          expect(page).to have_content message
+          expect(page).to have_notification_banner text: message
         end
       end
     end

--- a/spec/system/casework/reviewing/mark_application_as_ready_spec.rb
+++ b/spec/system/casework/reviewing/mark_application_as_ready_spec.rb
@@ -59,25 +59,16 @@ RSpec.describe 'Marking an application as ready for assessment' do
         end
 
         it 'notifies that the application has already been marked as ready for assessment' do
-          expect(page).to have_content message
-        end
-      end
-
-      describe 'CannotMarkAsReadyWhenSentBack' do
-        let(:error_class) { Reviewing::CannotMarkAsReadyWhenSentBack }
-        let(:message) { 'This application was already sent back to the provider' }
-
-        it 'notifies that the application has already been sent back' do
-          expect(page).to have_content message
+          expect(page).to have_notification_banner text: message
         end
       end
 
       describe 'CannotMarkAsReadyWhenCompleted' do
-        let(:error_class) { Reviewing::CannotMarkAsReadyWhenCompleted }
-        let(:message) { 'This application was already marked as complete' }
+        let(:error_class) { Reviewing::AlreadyReviewed }
+        let(:message) { 'This application was already reviewed' }
 
-        it 'notifies that the application has already been complete' do
-          expect(page).to have_content message
+        it 'notifies that the application has already been completed' do
+          expect(page).to have_notification_banner text: message
         end
       end
     end

--- a/spec/system/casework/reviewing/send_back_to_provider_spec.rb
+++ b/spec/system/casework/reviewing/send_back_to_provider_spec.rb
@@ -160,28 +160,12 @@ RSpec.describe 'Send an application back to the provider' do
       click_button(send_back_cta)
     end
 
-    describe 'AlreadySentBack' do
-      let(:error_class) { Reviewing::AlreadySentBack }
+    describe 'AlreadyReviewed' do
+      let(:error_class) { Reviewing::AlreadyReviewed }
+      let(:message) { 'This application was already reviewed' }
 
-      let(:message) do
-        'This application was already sent back to the provider'
-      end
-
-      it 'notifies that the application has already been sent back' do
-        expect(page).to have_content message
-      end
-
-      it 'does not send the notification email' do
-        expect(NotifyMailer).not_to have_received(:application_returned_email)
-      end
-    end
-
-    describe 'CannotSendBackWhenCompleted' do
-      let(:error_class) { Reviewing::CannotSendBackWhenCompleted }
-      let(:message) { 'This application was already marked as complete' }
-
-      it 'notifies that the application was already completed' do
-        expect(page).to have_content message
+      it 'notifies that the application was already reviewed' do
+        expect(page).to have_notification_banner text: message
       end
 
       it 'does not send the notification email' do


### PR DESCRIPTION
## Description of change

Decisions linked by MAAT ID can be removed.

## Link to relevant ticket
[CRIMAPP-1361](https://dsdmoj.atlassian.net/browse/CRIMAPP-1361)

## Notes for reviewer

- Only MAAT decisions can be removed
- They cannot be removed after the decision has been submitted
- When there are more than one decision, the user is redirected to the decisions/index page.
- When the last decision is removed, the user is redirected to the application details page.
- A previously linked decision, that has been removed, can be linked again. 
- When a removed decision is linked, comments from when previously linked are removed.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

<img width="1040" alt="Screenshot 2024-10-29 at 14 24 28" src="https://github.com/user-attachments/assets/395b0b26-de3e-45eb-9de3-b19e003a1c33">

<img width="1001" alt="Screenshot 2024-10-29 at 14 24 36" src="https://github.com/user-attachments/assets/2340dee9-dc57-4f2b-b12a-01b9ec9759dc">

<img width="1038" alt="Screenshot 2024-10-29 at 14 24 45" src="https://github.com/user-attachments/assets/cbcd213a-ec8c-4c47-a3c8-434a1c13d2a5">


## How to manually test the feature


[CRIMAPP-1361]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ