### PR TITLE
[CRIMAPP-1398] Bump schemas to v1.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.4.0'
+    tag: 'v1.4.1'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: a2b69c10443a70370bd618a98a59379decf44f4c
-  tag: v1.4.0
+  revision: 355ebc430e935a91c4339432d90116bf7c938ea0
+  tag: v1.4.1
   specs:
-    laa-criminal-legal-aid-schemas (1.4.0)
+    laa-criminal-legal-aid-schemas (1.4.1)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)


### PR DESCRIPTION
## Description of change
Bump `laa-criminal-legal-aid-schemas` to v1.4.1.

## Link to relevant ticket
[CRIMAPP-1398](https://dsdmoj.atlassian.net/browse/CRIMAPP-1398)

[CRIMAPP-1398]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ