### PR TITLE
[CRIMAPP-1468] Display armed forces question in review

### DIFF
--- a/app/views/casework/crime_applications/sections/_employment.html.erb
+++ b/app/views/casework/crime_applications/sections/_employment.html.erb
@@ -9,6 +9,16 @@
           <%= t(income_details.employment_type, scope: 'values.employment_type').to_sentence  %>
         </dd>
       </div>
+      <% unless income_details.client_in_armed_forces.nil? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:client_in_armed_forces) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= t(income_details.client_in_armed_forces, scope: 'values') %>
+          </dd>
+        </div>
+      <% end %>
       <% unless income_details.ended_employment_within_three_months.nil? %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">

--- a/app/views/casework/crime_applications/sections/_employment.html.erb
+++ b/app/views/casework/crime_applications/sections/_employment.html.erb
@@ -9,7 +9,7 @@
           <%= t(income_details.employment_type, scope: 'values.employment_type').to_sentence  %>
         </dd>
       </div>
-      <% unless income_details.client_in_armed_forces.nil? %>
+      <% if income_details.client_in_armed_forces == 'yes' %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             <%= label_text(:client_in_armed_forces) %>

--- a/app/views/casework/crime_applications/sections/_partner_employment.html.erb
+++ b/app/views/casework/crime_applications/sections/_partner_employment.html.erb
@@ -5,6 +5,13 @@
             row.with_key { label_text(:partner_employment_type) }
             row.with_value { t(income_details.partner_employment_type, scope: 'values.employment_type').to_sentence }
           end
+
+          if income_details.partner_in_armed_forces.present?
+            list.with_row do |row|
+              row.with_key { label_text(:partner_in_armed_forces) }
+              row.with_value { t(income_details.partner_in_armed_forces, scope: 'values') }
+            end
+          end
         end %>
   <% end %>
 <% end %>

--- a/app/views/casework/crime_applications/sections/_partner_employment.html.erb
+++ b/app/views/casework/crime_applications/sections/_partner_employment.html.erb
@@ -6,7 +6,7 @@
             row.with_value { t(income_details.partner_employment_type, scope: 'values.employment_type').to_sentence }
           end
 
-          if income_details.partner_in_armed_forces.present?
+          if income_details.partner_in_armed_forces == 'yes'
             list.with_row do |row|
               row.with_key { label_text(:partner_in_armed_forces) }
               row.with_value { t(income_details.partner_in_armed_forces, scope: 'values') }

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -125,6 +125,7 @@ en:
     case_type: Case type
     caseworker: Caseworker
     client_details: Client details
+    client_in_armed_forces: Client in armed forces?
     client_other_charges: Other charges
     client_other_charges_explicit: "Other charges: client"
     client_owns_property: Has land or property?
@@ -300,6 +301,7 @@ en:
     partner_details: Partner details
     partner_employment: Partner's employment
     partner_employment_type: Partner's employment status
+    partner_in_armed_forces: Partner in armed forces?
     partner_other_charges: "Other charges: partner"
     pays_council_tax: Council Tax
     passporting_benefit: Passporting Benefit

--- a/spec/system/casework/viewing_an_application/application_details/employment_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/employment_spec.rb
@@ -33,12 +33,6 @@ RSpec.describe 'Viewing the employment details of an application' do
       end
     end
 
-    it 'shows whether client is member of armed forces' do
-      within(card) do |card|
-        expect(card).to have_summary_row 'Client in armed forces?', 'No'
-      end
-    end
-
     context 'when job was not lost in custody' do
       let(:application_data) do
         super().deep_merge('means_details' => { 'income_details' => { 'lost_job_in_custody' => 'no',
@@ -50,6 +44,22 @@ RSpec.describe 'Viewing the employment details of an application' do
           expect(card).to have_summary_row 'Did they lose their job as a result of being in custody?', 'No'
         end
         expect(page).to have_no_content('When did they lose their job?')
+      end
+    end
+
+    it 'does not show armed forces row if client is not part of armed forces' do
+      expect(page).to have_no_content('Client in armed forces? No')
+    end
+
+    context 'when armed forces question has been answered' do
+      let(:application_data) do
+        super().deep_merge('means_details' => { 'income_details' => { 'client_in_armed_forces' => 'yes' } })
+      end
+
+      it 'shows if client is part of armed forces' do
+        within(card) do |card|
+          expect(card).to have_summary_row 'Client in armed forces?', 'Yes'
+        end
       end
     end
 

--- a/spec/system/casework/viewing_an_application/application_details/employment_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/employment_spec.rb
@@ -8,19 +8,35 @@ RSpec.describe 'Viewing the employment details of an application' do
   end
 
   context 'with employment details' do
+    let(:card) do
+      page.find('h2.govuk-summary-card__title', text: 'Employment').ancestor('div.govuk-summary-card')
+    end
+
     it { expect(page).to have_content('Employment') }
 
     it 'shows employment type' do
-      expect(page).to have_content("Client's employment status Not working")
+      within(card) do |card|
+        expect(card).to have_summary_row "Client's employment status", 'Not working'
+      end
     end
 
     it 'shows whether employment has ended in the last three months' do
-      expect(page).to have_content('Have they ended employment in the last 3 months? Yes')
+      within(card) do |card|
+        expect(card).to have_summary_row 'Have they ended employment in the last 3 months?', 'Yes'
+      end
     end
 
     it 'shows whether job was lost in custody and date details' do
-      expect(page).to have_content('Did they lose their job as a result of being in custody? Yes')
-      expect(page).to have_content('When did they lose their job? 01/09/2023')
+      within(card) do |card|
+        expect(card).to have_summary_row 'Did they lose their job as a result of being in custody?', 'Yes'
+        expect(card).to have_summary_row 'When did they lose their job?', '01/09/2023'
+      end
+    end
+
+    it 'shows whether client is member of armed forces' do
+      within(card) do |card|
+        expect(card).to have_summary_row 'Client in armed forces?', 'No'
+      end
     end
 
     context 'when job was not lost in custody' do
@@ -30,8 +46,20 @@ RSpec.describe 'Viewing the employment details of an application' do
       end
 
       it 'does not show date custody lost details' do
-        expect(page).to have_content('Did they lose their job as a result of being in custody? No')
+        within(card) do |card|
+          expect(card).to have_summary_row 'Did they lose their job as a result of being in custody?', 'No'
+        end
         expect(page).to have_no_content('When did they lose their job?')
+      end
+    end
+
+    context 'when armed forces question is not answered' do
+      let(:application_data) do
+        super().deep_merge('means_details' => { 'income_details' => { 'client_in_armed_forces' => nil } })
+      end
+
+      it 'does not show armed forces details' do
+        expect(page).to have_no_content('Client in armed forces?')
       end
     end
   end

--- a/spec/system/casework/viewing_an_application/application_details/partner_employment_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/partner_employment_spec.rb
@@ -18,9 +18,19 @@ RSpec.describe 'Viewing the employment details of the partner' do
       end
     end
 
-    it 'shows partners armed forces details' do
-      within(card) do |card|
-        expect(card).to have_summary_row 'Partner in armed forces?', 'No'
+    it 'does not show armed forces row if partner is not part of armed forces' do
+      expect(page).to have_no_content('Partner in armed forces? No')
+    end
+
+    context 'when armed forces question has been answered' do
+      let(:application_data) do
+        super().deep_merge('means_details' => { 'income_details' => { 'partner_in_armed_forces' => 'yes' } })
+      end
+
+      it 'shows if partner is part of armed forces' do
+        within(card) do |card|
+          expect(card).to have_summary_row 'Partner in armed forces?', 'Yes'
+        end
       end
     end
 

--- a/spec/system/casework/viewing_an_application/application_details/partner_employment_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/partner_employment_spec.rb
@@ -18,6 +18,22 @@ RSpec.describe 'Viewing the employment details of the partner' do
       end
     end
 
+    it 'shows partners armed forces details' do
+      within(card) do |card|
+        expect(card).to have_summary_row 'Partner in armed forces?', 'No'
+      end
+    end
+
+    context 'when armed forces question is not answered' do
+      let(:application_data) do
+        super().deep_merge('means_details' => { 'income_details' => { 'partner_in_armed_forces' => nil } })
+      end
+
+      it 'does not show armed forces details' do
+        expect(page).to have_no_content('Partner in armed forces?')
+      end
+    end
+
     context 'when partner is employed and self employed' do
       let(:application_data) do
         JSON.parse(LaaCrimeSchemas.fixture(1.0).read).deep_merge(


### PR DESCRIPTION
## Description of change
Displays answer for armed forces question when client or partner are in the armed forces question
If the answer is no or the question was not asked, then the question is not displayed

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1468

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
**When answer is yes**
<img width="1143" alt="Screenshot 2024-11-06 at 10 57 14" src="https://github.com/user-attachments/assets/cd4f7002-97ac-4f05-a066-951740be4f39">
<img width="1143" alt="Screenshot 2024-11-06 at 10 57 24" src="https://github.com/user-attachments/assets/75e5741b-7abc-4349-9953-d962f1ffa542">

**When answer is no**
<img width="1143" alt="Screenshot 2024-11-06 at 13 55 10" src="https://github.com/user-attachments/assets/d41a7075-23ad-43b9-97f1-8ae0b691f55b">
<img width="1143" alt="Screenshot 2024-11-06 at 13 55 04" src="https://github.com/user-attachments/assets/05d876e4-bab4-42e8-8486-2885b1fa6a52">


## How to manually test the feature
Submit an application in apply where the client/partner armed forces question is **yes** (client/partner must be employed). Confirm that the answer is displayed.

Submit an application in apply where the client/partner armed forces question is **no** (client/partner must be employed). Confirm that the answer is **not** displayed.
