### PR TITLE
[CRIMAPP-1476] Ignore Trivy vulns outside our control

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,6 +1,14 @@
 # CVEs that are outside of our control
 #
-# Accept all risks until 2023-09-28 - may have been resolved by cloud platform
-CVE-2023-2253 exp:2023-09-28
-CVE-2023-28840 exp:2023-09-28
-CVE-2023-30551 exp:2023-09-28
+# Accept all risks until 2025-05-14 - may have been resolved by cloud platform
+GHSA-9763-4f94-gfch exp:2025-05-14
+CVE-2024-41110 exp:2025-05-14
+CVE-2023-49569 exp:2025-05-14
+CVE-2023-49568 exp:2025-05-14
+CVE-2024-3817 exp:2025-05-14
+CVE-2024-6257 exp:2025-05-14
+CVE-2024-23652 exp:2025-05-14
+CVE-2024-23653 exp:2025-05-14
+CVE-2024-23651 exp:2025-05-14
+CVE-2024-21626 exp:2025-05-14
+CVE-2024-26147 exp:2025-05-14


### PR DESCRIPTION
## Description of change
Updated the Trivy ignore file with vulnerabilities that are to do with the Cloud Platform and not our code. These will be ignored until 14th May, 2025.

## Link to relevant ticket
[CRIMAPP-1476](https://dsdmoj.atlassian.net/browse/CRIMAPP-1476)

[CRIMAPP-1476]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ