### PR TITLE
[CRIMAPP-1495] Remove eForms link

### DIFF
--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -11,10 +11,6 @@
       Only caseworkers who have received an email invitation will have access.
     </p>
 
-    <p class="govuk-body">
-      If you do not have access, you should <%= link_to 'continue using eForms', t('urls.eforms_url'), { rel: 'external' } %>.
-    </p>
-
   <div class="govuk-!-margin-top-9">
     <%= govuk_start_button(text: t('calls_to_action.start_now'), href: user_azure_ad_omniauth_authorize_path, as_button: true) %>
   </div>


### PR DESCRIPTION
## Description of change
Removed the content line about eForms from the homepage.

## Link to relevant ticket
[CRIMAPP-1495](https://dsdmoj.atlassian.net/browse/CRIMAPP-1495)

## Screenshots of changes (if applicable)

### Before changes:
![image](https://github.com/user-attachments/assets/29282634-c2ba-4867-9204-d77686ecffab)

### After changes:
![image](https://github.com/user-attachments/assets/f6af319a-8acd-4286-b1aa-004a89627e27)


[CRIMAPP-1495]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ