### PR TITLE
[CRIMAPP-1412] Update time display across app

### DIFF
--- a/app/models/reporting/snapshot.rb
+++ b/app/models/reporting/snapshot.rb
@@ -46,14 +46,14 @@ module Reporting
       starts_on = observed_business_day.starts_on
 
       if observed_business_day == starts_on
-        I18n.l(observed_at, format: '00:00 until %H:%M')
+        I18n.l(observed_at, format: 'midnight until %-l:%M%P')
       else
-        starts_on.strftime('00:00 %A to ') + I18n.l(observed_at, format: '%H:%M %A')
+        starts_on.strftime('midnight %A to ') + I18n.l(observed_at, format: '%-l:%M%P %A')
       end
     end
 
     def observed_at_time
-      I18n.l(observed_at, format: '%H:%M')
+      I18n.l(observed_at, format: '%-l:%M%P')
     end
 
     private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,10 +24,10 @@ en:
     formats:
       <<: *DATE_FORMATS
       datetime: '%-l:%M%P %-d %b %Y'  # 2:45pm 3 Jan 2019
-      timestamp: '%A %-d %b %H:%M'  # Thursday 3 Jan 14:45
-      snapshot: '%A %-d %B %H:%M'
+      timestamp: '%A %-d %b %-l:%M%P'  # Thursday 3 Jan 2:45pm
+      snapshot: '%A %-d %B %-l:%M%P'
       now: '%A %-d %B'
-      datestamp: '%d/%m/%Y %H:%M%P' # 03/01/2019 15:29pm
+      datestamp: '%d/%m/%Y %-l:%M%P' # 03/01/2019 3:29pm
       dob: '%-d %B %Y' # 1 January 1990
 
   flash:

--- a/spec/models/reporting/snapshot_spec.rb
+++ b/spec/models/reporting/snapshot_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Reporting::Snapshot do
 
     context 'when observed business day follows a non-working day' do
       it 'shows the start and end days and times' do
-        expect(text).to eq '00:00 Saturday to 12:11 Monday'
+        expect(text).to eq 'midnight Saturday to 12:11pm Monday'
       end
     end
 
@@ -39,7 +39,7 @@ RSpec.describe Reporting::Snapshot do
       let(:observed_at) { Time.zone.local(2023, 10, 11, 11, 11) }
 
       it 'shows the start and end time' do
-        expect(text).to eq '00:00 until 12:11'
+        expect(text).to eq 'midnight until 12:11pm'
       end
     end
   end

--- a/spec/system/casework/viewing_an_application/history_spec.rb
+++ b/spec/system/casework/viewing_an_application/history_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Viewing application history' do
 
     it 'includes the submission event' do
       first_row = page.first('.app-dashboard-table tbody tr').text
-      expect(first_row).to match('Monday 24 Oct 10:50 John Doe Application submitted')
+      expect(first_row).to match('Monday 24 Oct 10:50am John Doe Application submitted')
     end
   end
 

--- a/spec/system/casework/viewing_an_application/post_submission_evidence_application_spec.rb
+++ b/spec/system/casework/viewing_an_application/post_submission_evidence_application_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'Viewing an application unassigned, open, post submission evidenc
 
     it 'includes the submission event' do
       first_row = page.first('.app-dashboard-table tbody tr').text
-      expect(first_row).to match('Monday 24 Oct 10:50 John Doe Post submission evidence submitted')
+      expect(first_row).to match('Monday 24 Oct 10:50am John Doe Post submission evidence submitted')
     end
 
     it 'includes the assigned event' do

--- a/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_is_open_and_unassigned_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe 'Viewing an application unassigned, open application' do
     let(:application_data) { super().deep_merge('date_stamp' => '2022-11-21T16:57:51.000+00:00') }
 
     it 'includes the correct date stamp' do
-      expect(page).to have_content('Date stamp 21/11/2022 16:57pm')
+      expect(page).to have_content('Date stamp 21/11/2022 4:57pm')
     end
   end
 

--- a/spec/system/reporting/snapshot_reports_spec.rb
+++ b/spec/system/reporting/snapshot_reports_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe 'Snapshot report' do
     end
 
     it 'shows the report at the specified time' do
-      pp page
       expect(page).to have_text yesterday.strftime('%A %-d %B 12:00')
     end
   end

--- a/spec/system/reporting/snapshot_reports_spec.rb
+++ b/spec/system/reporting/snapshot_reports_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe 'Snapshot report' do
     end
 
     it 'shows the report at the specified time' do
+      pp page
       expect(page).to have_text yesterday.strftime('%A %-d %B 12:00')
     end
   end

--- a/spec/system/reporting/workload_report_spec.rb
+++ b/spec/system/reporting/workload_report_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe 'Workload Report' do
   end
 
   it 'shows the expected colgroup headers' do
-    expected_headers = ['', 'From 00:00 until 23:59',
-                        'Applications still open by age in business days at 23:59']
+    expected_headers = ['', 'From midnight until 11:59pm',
+                        'Applications still open by age in business days at 11:59pm']
 
     within('#cat-1') do
       page.all('table thead tr.colgroup-headers th').each_with_index do |el, i|


### PR DESCRIPTION
## Description of change
Updates time display to 12hr from 24hr clock where applicable

Impacts the following screens: 
- Application details (date stamp)
- Application history 
- User competencies history
- Workload report

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-1412

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1036" alt="Screenshot 2024-12-04 at 09 50 48" src="https://github.com/user-attachments/assets/85d6e7b4-d20d-4c16-844f-0f4b7f5b3b82">

### After changes:
<img width="1036" alt="Screenshot 2024-12-04 at 11 32 27" src="https://github.com/user-attachments/assets/5611c4d5-dc72-43ca-a753-f295a67fce12">
<img width="974" alt="Screenshot 2024-12-04 at 11 48 45" src="https://github.com/user-attachments/assets/69b467cd-84b8-4f25-9128-c4ac2ee137d5">
<img width="974" alt="Screenshot 2024-12-04 at 11 49 06" src="https://github.com/user-attachments/assets/bb72f0f2-06a9-4de1-98b5-4ff7cf33095c">


## How to manually test the feature
