### PR TITLE
[CRIMAPP-1412] Update datetime view

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,7 @@ en:
   time:
     formats:
       <<: *DATE_FORMATS
-      datetime: '%-l:%M%P %-d %b %Y'  # 2:45pm 3 Jan 2019
+      datetime: '%-d %b %Y %-l:%M%P'  # 3 Jan 2019 2:45pm
       timestamp: '%A %-d %b %-l:%M%P'  # Thursday 3 Jan 2:45pm
       snapshot: '%A %-d %B %-l:%M%P'
       now: '%A %-d %B'

--- a/spec/system/manage_competencies/history_spec.rb
+++ b/spec/system/manage_competencies/history_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe 'View caseworker competencies history' do
 
       it 'shows the correct table content' do
         first_data_row = page.first('tbody tr.govuk-table__row:nth-of-type(1)').text
-        expected_event = ['10:04am 13 Nov 2023 Competencies set to no competencies Joe EXAMPLE'].join(' ')
+        expected_event = ['13 Nov 2023 10:04am Competencies set to no competencies Joe EXAMPLE'].join(' ')
         expect(first_data_row).to eq(expected_event)
 
         second_data_row = page.first('tbody tr.govuk-table__row:nth-of-type(2)').text
-        expected_event = ['10:04am 13 Nov 2023 Competencies set to CAT 2 Joe EXAMPLE'].join(' ')
+        expected_event = ['13 Nov 2023 10:04am Competencies set to CAT 2 Joe EXAMPLE'].join(' ')
         expect(second_data_row).to eq(expected_event)
       end
     end


### PR DESCRIPTION
## Description of change
Update datetime view to display date before the time
This impacts the competencies and user manager screens 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1412

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1070" alt="Screenshot 2024-12-09 at 09 28 16" src="https://github.com/user-attachments/assets/40998bf7-9273-4e82-b8b9-a05b60aa129f">
<img width="1070" alt="Screenshot 2024-12-09 at 09 32 05" src="https://github.com/user-attachments/assets/50b5de78-a3a3-4bc9-82a1-f2251b9fb82d">

### After changes:

<img width="1070" alt="Screenshot 2024-12-09 at 09 56 00" src="https://github.com/user-attachments/assets/9cd45ecd-8a04-4ac1-a521-0eaa9774ecac">
<img width="1070" alt="Screenshot 2024-12-09 at 09 55 33" src="https://github.com/user-attachments/assets/dfc75242-a47e-43f6-8f74-103e108a1ea6">


## How to manually test the feature
