### PR TITLE
[CRIMAPP-1510] Sanitise upload file names

### DIFF
--- a/app/services/datastore/documents/download.rb
+++ b/app/services/datastore/documents/download.rb
@@ -30,7 +30,9 @@ module Datastore
 
       def response_content_disposition
         # To force download of file rather than opening in another window
-        %(attachment; filename="#{@document.filename}")
+        filename_safe = @document.filename.gsub(/[^a-zA-Z0-9._-]/, '_')
+        filename_escaped = ERB::Util.url_encode(@document.filename)
+        %(attachment; filename=#{filename_safe}; filename*= UTF-8''#{filename_escaped};)
       end
     end
   end

--- a/spec/services/datastore/documents/download_spec.rb
+++ b/spec/services/datastore/documents/download_spec.rb
@@ -32,5 +32,32 @@ RSpec.describe Datastore::Documents::Download do
         expect(download_service.call).to be(false)
       end
     end
+
+    context 'when the file name contains UTF-8 characters' do
+      let(:filename) { 'Document 1 – Main Account 1-15 November.rtf' }
+      let(:filename_safe) { 'Document_1___Main_Account_1-15_November.rtf' }
+      let(:filename_escaped) { 'Document%201%20%E2%80%93%20Main%20Account%201-15%20November.rtf' }
+
+      let(:expected_query) do
+        {
+          object_key: %r{123/.*},
+          s3_opts: {
+            expires_in: Datastore::Documents::Download::PRESIGNED_URL_EXPIRES_IN,
+            response_content_disposition:
+              "attachment; filename=#{filename_safe}; filename*= UTF-8''#{filename_escaped};"
+          }
+        }
+      end
+
+      before do
+        stub_request(:put, 'https://datastore-api-stub.test/api/v1/documents/presign_download')
+          .with(body: expected_query)
+          .to_return(status: 201, body: { url: presign_download_url }.to_json)
+      end
+
+      it 'returns a presigned download url' do
+        expect(download_service.call.url).to eq(presign_download_url)
+      end
+    end
   end
 end

--- a/spec/shared_contexts/when_downloading_a_document.rb
+++ b/spec/shared_contexts/when_downloading_a_document.rb
@@ -3,8 +3,13 @@ RSpec.shared_context 'when downloading a document' do
   let(:s3_object_key) { '123/abcdef1234' }
 
   let(:expected_query) do
-    { object_key: %r{123/.*}, s3_opts: { expires_in: Datastore::Documents::Download::PRESIGNED_URL_EXPIRES_IN,
-                                         response_content_disposition:  "attachment; filename=\"#{filename}\"" } }
+    {
+      object_key: %r{123/.*},
+      s3_opts: {
+        expires_in: Datastore::Documents::Download::PRESIGNED_URL_EXPIRES_IN,
+        response_content_disposition: "attachment; filename=#{filename}; filename*= UTF-8''#{filename};"
+      }
+    }
   end
 
   let(:presign_download_url) do


### PR DESCRIPTION
## Description of change
Update `response_content_disposition` for uploaded files to handle file names that contain characters outside the ISO-8859-1 character set.

## Link to relevant ticket
[CRIMAPP-1510](https://dsdmoj.atlassian.net/browse/CRIMAPP-1510)

## How to manually test the feature
Upload a file whose name contains UTF-8 characters on Apply and attempt to download them on Review.
Some examples that would normally fail:
- `Document 1 – Main Account 1-15 November.pdf`
- `Payslip - Sept ‘24.pdf`

[CRIMAPP-1510]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ