### PR TITLE
[CRIMAPP-907] Translate MAAT decisions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.4.3'
+    tag: 'v1.5.1'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 861869efc25d2804f2b66d62df50d1330f28243f
-  tag: v1.4.3
+  revision: 35163d1b4b46a921fb997f1b158fa1debc622f5b
+  tag: v1.5.1
   specs:
-    laa-criminal-legal-aid-schemas (1.4.3)
+    laa-criminal-legal-aid-schemas (1.5.0)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
@@ -184,8 +184,9 @@ GEM
     dry-configurable (1.2.0)
       dry-core (~> 1.0, < 2)
       zeitwerk (~> 2.6)
-    dry-core (1.0.1)
+    dry-core (1.0.2)
       concurrent-ruby (~> 1.0)
+      logger
       zeitwerk (~> 2.6)
     dry-inflector (1.1.0)
     dry-initializer (3.1.1)
@@ -291,7 +292,7 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
-    logger (1.6.2)
+    logger (1.6.4)
     lograge (0.14.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -593,7 +594,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.18)
+    zeitwerk (2.7.1)
 
 PLATFORMS
   ruby

--- a/app/aggregates/deciding/commands/create_draft_from_maat.rb
+++ b/app/aggregates/deciding/commands/create_draft_from_maat.rb
@@ -2,7 +2,7 @@ module Deciding
   class CreateDraftFromMaat < Command
     attribute :application_id, Types::Uuid
     attribute :application_type, Types::ApplicationType
-    attribute :maat_decision, Maat::Decision
+    attribute :maat_decision, Decisions::Draft
     attribute :user_id, Types::Uuid
 
     def call

--- a/app/aggregates/deciding/commands/set_funding_decision.rb
+++ b/app/aggregates/deciding/commands/set_funding_decision.rb
@@ -1,7 +1,7 @@
 module Deciding
   class SetFundingDecision < Command
     attribute :user_id, Types::Uuid
-    attribute :funding_decision, Types::FundingDecisionResult
+    attribute :funding_decision, Types::FundingDecision
 
     def call
       with_decision do |decision|

--- a/app/aggregates/deciding/commands/update_from_maat_decision.rb
+++ b/app/aggregates/deciding/commands/update_from_maat_decision.rb
@@ -1,11 +1,13 @@
 module Deciding
   class UpdateFromMaatDecision < Command
-    attribute :maat_decision, Maat::Decision
+    attribute :maat_decision, Decisions::Draft
     attribute :user_id, Types::Uuid
 
     def call
       with_decision do |decision|
-        decision.sync_with_maat(maat_decision:, user_id:)
+        raise MaatRecordNotChanged unless maat_decision.checksum != decision.checksum
+
+        decision.sync_with_maat(maat_decision: maat_decision.to_h, user_id: user_id)
       end
     end
   end

--- a/app/aggregates/deciding/decision.rb
+++ b/app/aggregates/deciding/decision.rb
@@ -22,6 +22,7 @@ module Deciding
     def create_draft_from_maat(application_id:, maat_decision:, user_id:, application_type:)
       raise AlreadyCreated unless @state.nil?
 
+      maat_decision = maat_decision.to_h
       apply DraftCreatedFromMaat.new(
         data: { decision_id:, application_id:, maat_decision:, user_id:, application_type: }
       )
@@ -42,9 +43,7 @@ module Deciding
     end
 
     def sync_with_maat(maat_decision:, user_id:)
-      raise MaatRecordNotChanged unless maat_decision&.checksum != checksum
-
-      apply SynchedWithMaat.build(self, maat_decision:, user_id:)
+      apply SynchedWithMaat.build(self, maat_decision: maat_decision.to_h, user_id: user_id)
     end
 
     def set_interests_of_justice(user_id:, interests_of_justice:)
@@ -128,7 +127,7 @@ module Deciding
     end
 
     def update_from_maat(maat_attributes)
-      decision = Maat::Decision.new(maat_attributes)
+      decision = Decisions::Draft.new(maat_attributes)
 
       @maat_id = decision.maat_id
       @reference = decision.reference

--- a/app/components/decision_result_component.rb
+++ b/app/components/decision_result_component.rb
@@ -21,11 +21,9 @@ class DecisionResultComponent < ViewComponent::Base
   attr_reader :result
 
   def colour
-    case result
-    when /fail|inel/
-      'red'
-    else
-      'green'
-    end
+    {
+      Types::FundingDecision['granted'] => 'green',
+      Types::FundingDecision['refused'] => 'red'
+    }.fetch(result, nil)
   end
 end

--- a/app/controllers/casework/maat_decisions_controller.rb
+++ b/app/controllers/casework/maat_decisions_controller.rb
@@ -13,7 +13,6 @@ module Casework
     # import failed due to a technical issue).
     def create
       @form_object = ::Decisions::MaatIdForm.new(application: @crime_application)
-
       @form_object.create_with_user!(permitted_params, current_user_id)
 
       set_flash(:maat_decision_linked, maat_id: @form_object.maat_id)

--- a/app/lib/maat/decision.rb
+++ b/app/lib/maat/decision.rb
@@ -1,55 +1,28 @@
 module Maat
-  class Decision < LaaCrimeSchemas::Structs::Decision
-    attribute :maat_id, Types::Integer
-    attribute? :case_id, Types::String.optional
-    attribute :funding_decision, Types::FundingDecisionResult.optional
+  class Decision < Dry::Struct
+    transform_keys(&:to_sym)
 
-    def checksum
-      Digest::MD5.hexdigest(to_json)
-    end
+    attribute? :maat_ref, Types::MaatId
+    attribute? :usn, Types::ApplicationReference.optional
+    attribute? :case_id, Types::String
+    attribute? :case_type, Types::String
+    attribute? :app_created_date, Types::DateTime.optional
 
-    alias decision_id maat_id
+    attribute? :ioj_result, Types::String.optional
+    attribute? :ioj_reason, Types::String.optional
+    attribute? :ioj_assessor_name, Types::String.optional
 
-    class << self
-      def build(response)
-        new(
-          reference: response['usn'],
-          maat_id: response['maat_ref'],
-          case_id: response['case_id'],
-          funding_decision: funding_decision(response['funding_decision']),
-          interests_of_justice: interests_of_justice(response),
-          means: means(response)
-        )
-      end
+    attribute? :ioj_appeal_result, Types::String.optional
 
-      def funding_decision(maat_value)
-        return nil if maat_value.blank?
+    attribute? :means_result, Types::String.optional
+    attribute? :means_assessor_name, Types::String.optional
+    attribute? :date_means_created, Types::DateTime.optional
 
-        maat_value.downcase
-      end
+    attribute? :passport_result, Types::String.optional
+    attribute? :passport_assessor_name, Types::String.optional
+    attribute? :date_passport_created, Types::DateTime.optional
 
-      def interests_of_justice(response)
-        return nil if response['ioj_result'].blank?
-
-        {
-          result: response['ioj_result'].downcase,
-          details: response['ioj_reason'],
-          assessed_by: response['ioj_assessor_name'],
-          assessed_on: response['app_created_date']
-        }
-      end
-
-      def result(maat_result); end
-
-      def means(response)
-        return nil if response['means_result'].blank?
-
-        {
-          result: response['means_result'].downcase,
-          assessed_by: response['means_assessor_name'],
-          assessed_on: response['date_means_created']
-        }
-      end
-    end
+    attribute? :funding_decision, Types::String.optional
+    attribute? :cc_rep_decision, Types::String.optional
   end
 end

--- a/app/lib/maat/get_decision.rb
+++ b/app/lib/maat/get_decision.rb
@@ -48,7 +48,7 @@ module Maat
       # the response body includes a MAAT ID (maat_ref).
       return nil unless response.body.present? && response.body['maat_ref'].present?
 
-      Decision.build(response.body)
+      Decision.new(response.body)
     end
 
     attr_reader :http_client

--- a/app/models/decisions/draft.rb
+++ b/app/models/decisions/draft.rb
@@ -1,12 +1,12 @@
+require 'laa_crime_schemas'
 module Decisions
   class Draft < LaaCrimeSchemas::Structs::Decision
-    attribute? :funding_decision, Types::Nil | Types::FundingDecisionResult
+    attribute? :funding_decision, Types::Nil | Types::FundingDecision
     attribute? :reference, Types::Nil | Types::Integer
     attribute? :decision_id, Types::Nil | Types::Integer | Types::Uuid
     attribute? :application_id, Types::Uuid
     attribute? :maat_id, Types::Integer.optional
     attribute? :case_id, Types::String.optional
-    attribute? :checksum, Types::String.optional
 
     def to_param
       { crime_application_id: application_id, decision_id: decision_id }
@@ -16,8 +16,8 @@ module Decisions
       funding_decision.present?
     end
 
-    def as_json
-      LaaCrimeSchemas::Structs::Decision.new(self)
+    def checksum
+      Digest::MD5.hexdigest(to_json)
     end
 
     class << self

--- a/app/models/decisions/overall_result_form.rb
+++ b/app/models/decisions/overall_result_form.rb
@@ -6,7 +6,7 @@ module Decisions
     validates :funding_decision, inclusion: { in: :possible_decisions }
 
     def possible_decisions
-      [Types::FundingDecisionResult['granted_on_ioj'], Types::FundingDecisionResult['fail_on_ioj']]
+      [Types::FundingDecision['granted'], Types::FundingDecision['refused']]
     end
 
     class << self

--- a/app/services/maat/base_translator.rb
+++ b/app/services/maat/base_translator.rb
@@ -1,0 +1,24 @@
+module Maat
+  class BaseTranslator
+    def initialize(original:)
+      @original = original
+    end
+
+    class << self
+      def translate(original)
+        new(original:).translate
+      end
+    end
+
+    # :nocov:
+    def translate
+      raise 'implement in subclasses'
+    end
+    # :nocov:
+    #
+
+    private
+
+    attr_reader :original
+  end
+end

--- a/app/services/maat/create_draft_decision_from_reference.rb
+++ b/app/services/maat/create_draft_decision_from_reference.rb
@@ -37,7 +37,11 @@ module Maat
     delegate :decision_id, to: :maat_decision
 
     def maat_decision
-      @maat_decision ||= Maat::GetDecision.new.by_usn!(reference)
+      return @maat_decision if @maat_decision
+
+      maat_decision = Maat::GetDecision.new.by_usn!(reference)
+
+      Maat::DecisionTranslator.translate(maat_decision) if maat_decision.present?
     end
   end
 end

--- a/app/services/maat/crown_court_decision_translator.rb
+++ b/app/services/maat/crown_court_decision_translator.rb
@@ -1,0 +1,20 @@
+module Maat
+  class CrownCourtDecisionTranslator < BaseTranslator
+    def translate
+      return nil if funding_decision.blank?
+
+      Types::FundingDecision[funding_decision]
+    end
+
+    private
+
+    def funding_decision
+      case original
+      when /Granted/
+        'granted'
+      when /Refused|Failed/
+        'refused'
+      end
+    end
+  end
+end

--- a/app/services/maat/decision_translator.rb
+++ b/app/services/maat/decision_translator.rb
@@ -1,0 +1,54 @@
+module Maat
+  class DecisionTranslator
+    def initialize(maat_decision:)
+      @maat_decision = maat_decision
+    end
+
+    class << self
+      def translate(maat_decision)
+        new(maat_decision:).translate
+      end
+    end
+
+    def translate
+      Decisions::Draft.new(
+        maat_id:, case_id:, reference:, interests_of_justice:,
+        means:, funding_decision:, decision_id:
+      )
+    end
+
+    private
+
+    def maat_id
+      maat_decision.maat_ref
+    end
+    alias decision_id maat_id
+
+    def reference
+      maat_decision.usn
+    end
+
+    def interests_of_justice
+      InterestsOfJusticeTranslator.translate(maat_decision)
+    end
+
+    def means
+      MeansTranslator.translate(maat_decision)
+    end
+
+    def funding_decision
+      return crown_court_decision if crown_court_decision
+      return nil unless maat_decision.funding_decision
+
+      FundingDecisionTranslator.translate(maat_decision.funding_decision)
+    end
+
+    delegate :case_id, to: :maat_decision
+
+    def crown_court_decision
+      CrownCourtDecisionTranslator.translate(maat_decision.cc_rep_decision)
+    end
+
+    attr_reader :maat_decision
+  end
+end

--- a/app/services/maat/funding_decision_translator.rb
+++ b/app/services/maat/funding_decision_translator.rb
@@ -1,0 +1,20 @@
+module Maat
+  class FundingDecisionTranslator < BaseTranslator
+    def translate
+      return nil if funding_decision.blank?
+
+      Types::FundingDecision[funding_decision]
+    end
+
+    private
+
+    def funding_decision
+      case original
+      when /PASS|GRANTED|FULL/
+        'granted'
+      when /INEL|FAIL/
+        'refused'
+      end
+    end
+  end
+end

--- a/app/services/maat/interests_of_justice_result_translator.rb
+++ b/app/services/maat/interests_of_justice_result_translator.rb
@@ -1,0 +1,20 @@
+module Maat
+  class InterestsOfJusticeResultTranslator < BaseTranslator
+    def translate
+      return nil if original.blank?
+
+      Types::TestResult[means_result]
+    end
+
+    private
+
+    def means_result
+      case original
+      when /PASS/
+        'passed'
+      when /FAIL/
+        'failed'
+      end
+    end
+  end
+end

--- a/app/services/maat/interests_of_justice_translator.rb
+++ b/app/services/maat/interests_of_justice_translator.rb
@@ -1,0 +1,45 @@
+module Maat
+  class InterestsOfJusticeTranslator
+    def initialize(maat_decision:)
+      @maat_decision = maat_decision
+    end
+
+    class << self
+      def translate(maat_decision)
+        new(maat_decision:).translate
+      end
+    end
+
+    def translate
+      return nil unless result
+
+      LaaCrimeSchemas::Structs::TestResult.new(
+        result:, assessed_by:, assessed_on:, details:
+      )
+    end
+
+    private
+
+    def assessed_on
+      maat_decision.app_created_date
+    end
+
+    def assessed_by
+      maat_decision.ioj_assessor_name
+    end
+
+    def details
+      maat_decision.ioj_reason
+    end
+
+    def result
+      InterestsOfJusticeResultTranslator.translate(maat_result)
+    end
+
+    def maat_result
+      maat_decision.ioj_appeal_result.presence || maat_decision.ioj_result
+    end
+
+    attr_reader :maat_decision
+  end
+end

--- a/app/services/maat/maat_id_service_object.rb
+++ b/app/services/maat/maat_id_service_object.rb
@@ -26,7 +26,11 @@ module Maat
     end
 
     def maat_decision
-      @maat_decision ||= Maat::GetDecision.new.by_maat_id!(maat_id)
+      return @maat_decision if @maat_decision
+
+      maat_decision = Maat::GetDecision.new.by_maat_id!(maat_id)
+
+      Maat::DecisionTranslator.translate(maat_decision) if maat_decision.present?
     end
   end
 end

--- a/app/services/maat/means_result_translator.rb
+++ b/app/services/maat/means_result_translator.rb
@@ -1,0 +1,22 @@
+module Maat
+  class MeansResultTranslator < BaseTranslator
+    def translate
+      return nil if original.blank?
+
+      Types::TestResult[means_result]
+    end
+
+    private
+
+    def means_result
+      case original
+      when /PASS/
+        'passed'
+      when /FULL/
+        'passed_with_contribution'
+      when /FAIL|INEL/
+        'failed'
+      end
+    end
+  end
+end

--- a/app/services/maat/means_translator.rb
+++ b/app/services/maat/means_translator.rb
@@ -1,0 +1,60 @@
+module Maat
+  class MeansTranslator
+    def initialize(maat_decision:)
+      @maat_decision = maat_decision
+    end
+
+    def translate
+      return nil unless result
+
+      LaaCrimeSchemas::Structs::TestResult.new(
+        result:, assessed_by:, assessed_on:
+      )
+    end
+
+    class << self
+      def translate(maat_decision)
+        new(maat_decision:).translate
+      end
+    end
+
+    private
+
+    attr_reader :maat_decision
+
+    def assessed_on
+      if passport_result_most_recent?
+        maat_decision.date_passport_created
+      else
+        maat_decision.date_means_created
+      end
+    end
+
+    def assessed_by
+      if passport_result_most_recent?
+        maat_decision.passport_assessor_name
+      else
+        maat_decision.means_assessor_name
+      end
+    end
+
+    def result
+      Maat::MeansResultTranslator.translate(maat_result)
+    end
+
+    def maat_result
+      if passport_result_most_recent?
+        maat_decision.passport_result
+      else
+        maat_decision.means_result
+      end
+    end
+
+    def passport_result_most_recent?
+      return false if maat_decision.date_passport_created.blank?
+      return true if maat_decision.date_means_created.blank?
+
+      maat_decision.date_passport_created > maat_decision.date_means_created
+    end
+  end
+end

--- a/app/views/casework/crime_applications/show.html.erb
+++ b/app/views/casework/crime_applications/show.html.erb
@@ -1,8 +1,10 @@
 <% title t('.page_title') %>
+
 <% if FeatureFlags.adding_decisions.enabled? && @crime_application.decisions_pending? && @crime_application.reviewable_by?(current_user_id) %>
   <% message = t(:finish_adding_decisions, scope: 'flash.important', continue_adding_decision_link: govuk_link_to(t(:continue_adding_decision, scope: 'flash.important'), crime_application_send_decisions_path(@crime_application))) %>
   <%= render FlashNotice.new(:important, message) %>
 <% end %>
+
 <%= render partial: 'review_overview', locals: { crime_application: @crime_application } %>
 
 <div class="govuk-grid-row">

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -13,7 +13,7 @@ en:
     success:
       assigned_to_self: You assigned this application to your list
       completed: You marked the application as complete
-      completed_with_decisions: Application complete. Decision sent to provider.  
+      completed_with_decisions: Application complete. Decision sent to provider.
       decision_removed: Decision removed
       marked_as_ready: You marked the application as ready for assessment
       sent_back: You sent the application back to the provider
@@ -21,8 +21,8 @@ en:
       maat_decision_linked:
         - MAAT ID %{maat_id} linked
       updated_from_maat:
-        - Updated from MAAT application with MAAT ID %{maat_id} 
-        - Check the decision, and make any required amendments on MAAT. 
+        - Updated from MAAT application with MAAT ID %{maat_id}
+        - Check the decision, and make any required amendments on MAAT.
     important:
       reassigned_to_someone_else:
         - This application could not be reassigned to your list
@@ -37,7 +37,7 @@ en:
         - No MAAT ID found that links to LAA reference number %{reference}
       no_change_since_last_update:
         - The application on MAAT has not changed.
-        - Make any required amendments on MAAT using the MAAT ID %{maat_id}. 
+        - Make any required amendments on MAAT using the MAAT ID %{maat_id}.
       already_reviewed: This application was already reviewed
       already_marked_as_ready: This application was already marked as ready for assessment
       cannot_complete_when_sent_back: This application was already sent back to the provider
@@ -56,14 +56,13 @@ en:
         - You must be allocated to the %{work_queue} work queue to review this application
         - Contact your supervisor to arrange this
       incomplete_decisions: Please complete any pending funding decisions
-      incomplete_maat_decision: 
+      incomplete_maat_decision:
         - Information missing
         - Complete details in MAAT and then update this page.
       finish_adding_decisions:
         - You need to finish adding the funding decision details
         - "%{continue_adding_decision_link}"
       continue_adding_decision: Continue adding funding decision
-
 
   primary_navigation:
     your_list: "Your list (%{count})"
@@ -93,8 +92,8 @@ en:
     arc: Application registration card (ARC) number
     are_partners_wages_paid_into_account: Partner’s wages or benefits paid into this account?
     are_wages_paid_into_account: Client’s wages or benefits paid into this account?
-    assets: 'Capital: Assets'
-    assigned_to: 'Assigned to:'
+    assets: "Capital: Assets"
+    assigned_to: "Assigned to:"
     benefit_check_status: Passporting benefit check outcome
     benefit_child: Child Benefit
     benefit_incapacity: Incapacity Benefit
@@ -135,8 +134,8 @@ en:
     client_in_armed_forces: Client in armed forces?
     client_other_charges: Other charges
     client_other_charges_explicit: "Other charges: client"
-    client_owns_property: '%{subject} owns home, land or property?'
-    closed_by: 'Closed by:'
+    client_owns_property: "%{subject} owns home, land or property?"
+    closed_by: "Closed by:"
     codefendant: Co-defendant
     codefendants: Co-defendants
     confirmed_details: Confirmed details correct?
@@ -145,20 +144,20 @@ en:
     criminal_applications_team: CAT 1
     criminal_applications_team_2: CAT 2
     date:
-      completed: 'Date closed:'
-      sent_back: 'Date closed:'
+      completed: "Date closed:"
+      sent_back: "Date closed:"
     date_appeal_lodged: Date the appeal was lodged
     date_case_concluded: When the case concluded
     date_client_remanded: When they were remanded
     date_job_lost: When did they lose their job?
     date_of_birth: Date of birth
     date_of_latest_jsa_appointment: Date of latest JSA appointment
-    date_received: 'Date received:'
+    date_received: "Date received:"
     date_stamp: Date stamp
     date_stamp_details: Details entered for date stamp
     decision_card_title: Case
     decision_case_reference: Case
-    decision_comment: Comments 
+    decision_comment: Comments
     dependants: Dependants
     details: Details
     does_client_have_national_savings_certificates: National Savings Certificates?
@@ -187,16 +186,16 @@ en:
     further_information_any: Any additional information?
     further_information_details: Details
     further_information_present:
-      'true': Yes
-      'false': No
+      "true": Yes
+      "false": No
     funding_decision: Funding decision
     has_codefendants: Co-defendants?
     has_dependants: Has dependants?
     has_frozen_income_or_assets: Income, savings or assets under a restraint or freezing order
     has_no_other_assets: Has no other assets or capital?
     has_premium_bonds: Premium Bonds
-    has_premium_bonds_client: 'Premium Bonds: client'
-    has_premium_bonds_partner: 'Premium Bonds: partner'
+    has_premium_bonds_client: "Premium Bonds: client"
+    has_premium_bonds_partner: "Premium Bonds: partner"
     has_savings: Savings or investments?
     has_same_address_as_client: Lives at same address as client?
     home_address: Home address
@@ -265,7 +264,7 @@ en:
     means_tested: Subject to means test?
     means_assessed_by: Means test caseworker
     means_assessed_on: Means test date
-    means_details: Means reason 
+    means_details: Means reason
     means_result: Means test result
     name: Name
     national_crime_team: CAT 2
@@ -273,7 +272,7 @@ en:
     national_savings_certificates: National Savings Certificates
     national_savings_certificate: National Savings Certificate
     national_savings_certificate_holder_number: What is the customer number or holder number?
-    national_savings_certificate_certificate_number: 'What is the certificate number?'
+    national_savings_certificate_certificate_number: "What is the certificate number?"
     national_savings_certificate_value: What is the value of the certificate?
     national_savings_certificate_ownership_type: Who owns the certificate?
     next_court_hearing: Next court hearing
@@ -326,10 +325,10 @@ en:
     payments: Payments
     payments_the_client_makes: Payments the %{subject} makes
     post_submission_evidence: Post submission evidence
-    premium_bonds: 'Premium Bonds'
+    premium_bonds: "Premium Bonds"
     premium_bonds_holder_number: Holder number
-    premium_bonds_holder_number_client: 'Holder number: client'
-    premium_bonds_holder_number_partner: 'Holder number: partner'
+    premium_bonds_holder_number_client: "Holder number: client"
+    premium_bonds_holder_number_partner: "Holder number: partner"
     premium_bonds_total_value: Total value
     preorder_work_date: When you or your firm were first instructed
     preorder_work_details: Details about the urgency of the work
@@ -356,7 +355,7 @@ en:
       national_savings_or_post_office: National Savings or Post Office accounts
       other: Cash investment
     savings: Savings
-    savings_and_investments: 'Capital: Savings and investments'
+    savings_and_investments: "Capital: Savings and investments"
     search_criteria: Search criteria
     search_text: Reference number or applicant's first or last name
     select_return_reason: Select the reason for returning this application
@@ -463,25 +462,21 @@ en:
     change_in_financial_circumstances: Change in financial circumstances
     date_stamp_context_changed: Changed after date stamp
     committal: Committal for sentence
-    deleted_user_name: '[deleted]'
+    deleted_user_name: "[deleted]"
     decision_ioj_test_result:
-      pass: Passed
-      fail: Refused
+      passed: Passed
+      failed: Failed
     decision_means_test_result:
-      pass: Passed
-      fail: Failed
-      full: Contribution
-      inel: Ineligible
+      passed: Passed
+      passed_with_contribution: Passed - with a contribution
+      failed: Failed
+    decision_funding_decision:
+      granted: Granted
+      refused: Refused
     decision_overall_result:
       granted: Granted
-      granted_on_ioj: Granted
-      fail_on_ioj: Failed IoJ
-      failmeans: Failed means
-      failmeioj: Failed means and IoJ
-      failioj: Failed IoJ
-      inel: Ineligible 
-      full: Granted - with a contribution 
-
+      refused: Refused
+      granted_failed_means: Granted - failed means test
     either_way: Either way
     esa: Income-related Employment and Support Allowance (ESA)
     guarantee_pension: Guarantee Credit element of Pension Credit
@@ -587,10 +582,10 @@ en:
       board_and_lodging: Board and lodgings
       mortgage: Mortgage
       rent: Rent
-      none: 'None'
+      none: "None"
     pays_council_tax:
-      'yes': 'Yes'
-      'no': 'No'
+      "yes": "Yes"
+      "no": "No"
     residential: Residential Property
     commercial: Commercial Property
     land: Land
@@ -613,7 +608,7 @@ en:
       property_company: Property company
       other: Their relationship is not listed
     has_no_other_assets:
-      'yes': Confirmed
+      "yes": Confirmed
     benefit_check_status:
       confirmed: Confirmed
       no_check_required: No check required
@@ -632,7 +627,7 @@ en:
       victim: Victim
       prosecution_witness: Prosecution witness
       codefendant: Co-defendant
-      none: 'No'
+      none: "No"
     relationship_status:
       single: Single
       widowed: Widowed
@@ -644,20 +639,20 @@ en:
       partner: Partner's name
       applicant_and_partner: Client and partner
     client_or_partner_passported:
-      client: 'Yes'
-      partner: 'Yes - partner'
-      neither: 'No'
+      client: "Yes"
+      partner: "Yes - partner"
+      neither: "No"
     client_remanded:
-      'yes': In court custody
-      'no': 'No'
+      "yes": In court custody
+      "no": "No"
     is_first_court_hearing:
-      'yes': 'Yes'
-      'no': 'No'
+      "yes": "Yes"
+      "no": "No"
       no_hearing_yet: There has not been a hearing yet
 
   calls_to_action: &ACTIONS
     abandon_reassign_to_self: No, do not reassign
-    add_another_decision: Add another case 
+    add_another_decision: Add another case
     add_funding_decision: Add funding decision from MAAT
     assign_to_self: Assign to your list
     back_to_list: Back to your list
@@ -737,7 +732,6 @@ en:
         revival_awaited: Account revival requested
         revived: Account revived
         role_changed: Role changed from %{from} to %{to}
-
 
   casework:
     assigned_applications:
@@ -833,7 +827,7 @@ en:
     decisions:
       index:
         title:
-          zero: Add a MAAT ID 
+          zero: Add a MAAT ID
           one: You have added %{count} MAAT ID
           other: You have added %{count} MAAT IDs
       interests_of_justices:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -5,7 +5,7 @@ en:
 
     hint:
       decisions_interests_of_justice_form:
-        assessed_on: For example, DD/MM/YYY 
+        assessed_on: For example, DD/MM/YYY
       decisions_maat_id_form:
         maat_id: If you have created more that one MAAT ID, link one at a time.
 
@@ -18,29 +18,29 @@ en:
       decisions_comment_form:
         comment_required: Comments for provider (optional)
       decisions_maat_id_form:
-        maat_id: MAAT ID  
+        maat_id: MAAT ID
       decisions_add_another_form:
-        add_another_decision: Do you want to add another case?  
+        add_another_decision: Do you want to add another case?
       decisions_send_to_provider_form:
         next_step: What do you want to do next?
 
     label:
       decisions_interests_of_justice_form:
         result_options:
-          pass: Passed
-          fail: Refused
+          passed: Passed
+          failed: Failed
         details: What is the reason for this?
         assessed_by: What is the name of the caseworker who assessed this?
       decisions_overall_result_form:
         funding_decision_options:
-          granted_on_ioj: Granted
-          fail_on_ioj: Failed interests of justice test
+          granted: Granted
+          refused: Refused
       decisions_comment_form:
         comment: Comments for provider (optional)
       decisions_maat_id_form:
-        maat_id: MAAT ID  
+        maat_id: MAAT ID
       decisions_send_to_provider_form:
-        next_step_options: 
+        next_step_options:
           add_another: Add another MAAT ID
           send_to_provider: Send to provider
 

--- a/spec/aggregates/deciding/decision_spec.rb
+++ b/spec/aggregates/deciding/decision_spec.rb
@@ -6,7 +6,7 @@ describe Deciding::Decision do
   describe '#attributes' do
     let(:interests_of_justice) do
       LaaCrimeSchemas::Structs::TestResult.new(
-        result: 'pass',
+        result: 'passed',
         details: 'details',
         assessed_by: 'Grace Nolan',
         assessed_on: Date.new(2024, 10, 1)

--- a/spec/components/decision_component_spec.rb
+++ b/spec/components/decision_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DecisionComponent, type: :component do
     allow(decision).to receive_messages(
       interests_of_justice: {},
       means: {},
-      funding_decision: 'failioj',
+      funding_decision: 'granted',
       comment: nil,
       maat_id: nil
     )

--- a/spec/components/decision_result_component_spec.rb
+++ b/spec/components/decision_result_component_spec.rb
@@ -8,45 +8,17 @@ RSpec.describe DecisionResultComponent, type: :component do
       render_inline(described_class.new(result:))
     end
 
-    context 'when result is "granted"' do
+    context 'when decision is "grant"' do
       let(:result) { 'granted' }
 
       it { is_expected.to have_text('Granted') }
       it { is_expected.to have_css('.govuk-tag--green') }
     end
 
-    context 'when result is "granted_on_ioj"' do
-      let(:result) { 'granted_on_ioj' }
+    context 'when decision is "refuse"' do
+      let(:result) { 'refused' }
 
-      it { is_expected.to have_text('Granted') }
-      it { is_expected.to have_css('.govuk-tag--green') }
-    end
-
-    context 'when result is "failed_on_ioj"' do
-      let(:result) { 'fail_on_ioj' }
-
-      it { is_expected.to have_text('Failed IoJ') }
-      it { is_expected.to have_css('.govuk-tag--red') }
-    end
-
-    context 'when result is "failioj"' do
-      let(:result) { 'failioj' }
-
-      it { is_expected.to have_text('Failed IoJ') }
-      it { is_expected.to have_css('.govuk-tag--red') }
-    end
-
-    context 'when result is "inel"' do
-      let(:result) { 'inel' }
-
-      it { is_expected.to have_text('Ineligible') }
-      it { is_expected.to have_css('.govuk-tag--red') }
-    end
-
-    context 'when result is "failmeans"' do
-      let(:result) { 'failmeans' }
-
-      it { is_expected.to have_text('Failed means') }
+      it { is_expected.to have_text('Refused') }
       it { is_expected.to have_css('.govuk-tag--red') }
     end
   end

--- a/spec/lib/maat/decision_spec.rb
+++ b/spec/lib/maat/decision_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Maat::Decision do
-  describe '.build()' do
-    subject(:build) { described_class.build(response) }
+  describe '.new' do
+    subject(:new) { described_class.new(response) }
 
     let(:response) do
       {
@@ -21,29 +21,76 @@ RSpec.describe Maat::Decision do
       }
     end
 
-    it 'returns an instance of a Maat::Decision' do
-      expect(build).to be_a described_class
+    describe '#usn' do
+      subject(:usn) { new.usn }
+
+      it { is_expected.to be 10 }
     end
 
-    it 'sets the interests of justice' do
-      expect(build.interests_of_justice.attributes).to eq(
-        assessed_by: 'System Test IoJ',
-        assessed_on: Date.new(2024, 9, 23),
-        details: 'Details of IoJ',
-        result: 'pass'
-      )
+    describe '#maat_ref' do
+      subject(:maat_ref) { new.maat_ref }
+
+      it { is_expected.to be 600 }
     end
 
-    it 'sets the means' do
-      expect(build.means.attributes).to eq(
-        assessed_by: 'System Test Means',
-        assessed_on: Date.new(2024, 9, 23),
-        result: 'pass'
-      )
+    describe '#case_id' do
+      subject(:case_id) { new.case_id }
+
+      it { is_expected.to eq '123123123' }
     end
 
-    it 'sets the funding decision' do
-      expect(build.funding_decision).to eq('granted')
+    describe '#case_type' do
+      subject(:case_type) { new.case_type }
+
+      it { is_expected.to eq 'SUMMARY ONLY' }
+    end
+
+    describe '#ioj_result' do
+      subject(:ioj_result) { new.ioj_result }
+
+      it { is_expected.to eq 'PASS' }
+    end
+
+    describe '#ioj_assessor_name' do
+      subject(:ioj_assessor_name) { new.ioj_assessor_name }
+
+      it { is_expected.to eq 'System Test IoJ' }
+    end
+
+    describe '#ioj_reason' do
+      subject(:ioj_reason) { new.ioj_reason }
+
+      it { is_expected.to eq 'Details of IoJ' }
+    end
+
+    describe '#app_created_date' do
+      subject(:app_created_date) { new.app_created_date }
+
+      it { is_expected.to eq '2024-09-23T00:00:00' }
+    end
+
+    describe '#means_result' do
+      subject(:means_result) { new.means_result }
+
+      it { is_expected.to eq 'PASS' }
+    end
+
+    describe '#means_assessor_name' do
+      subject(:means_assessor_name) { new.means_assessor_name }
+
+      it { is_expected.to eq 'System Test Means' }
+    end
+
+    describe '#date_means_created' do
+      subject(:date_means_created) { new.date_means_created }
+
+      it { is_expected.to eq '2024-09-23T17:18:56' }
+    end
+
+    describe '#funding_decision' do
+      subject(:funding_decision) { new.funding_decision }
+
+      it { is_expected.to eq 'GRANTED' }
     end
   end
 end

--- a/spec/lib/maat/get_decision_spec.rb
+++ b/spec/lib/maat/get_decision_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Maat::GetDecision do
 
   before do
     allow(connection).to receive(:get) { response }
-    allow(Maat::Decision).to receive(:build).with(body) { instance_double(Maat::Decision) }
+    allow(Maat::Decision).to receive(:new).with(body) { instance_double(Maat::Decision) }
   end
 
   describe '#by_usn' do
@@ -23,14 +23,14 @@ RSpec.describe Maat::GetDecision do
       expect(connection).to have_received(:get)
         .with('/api/external/v1/crime-application/result/usn/123456')
 
-      expect(Maat::Decision).to have_received(:build).with(body)
+      expect(Maat::Decision).to have_received(:new).with(body)
     end
 
     context 'when decision is empty found' do
       let(:body) { {} }
 
       it 'returns nil' do
-        expect(Maat::Decision).not_to have_received(:build)
+        expect(Maat::Decision).not_to have_received(:new)
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe Maat::GetDecision do
       let(:body) { { 'maat_ref' => nil } }
 
       it 'returns nil' do
-        expect(Maat::Decision).not_to have_received(:build)
+        expect(Maat::Decision).not_to have_received(:new)
       end
     end
   end
@@ -49,7 +49,7 @@ RSpec.describe Maat::GetDecision do
     it 'makes a GET request to the MAAT API USN path' do
       get_by_usn!
 
-      expect(Maat::Decision).to have_received(:build).with(body)
+      expect(Maat::Decision).to have_received(:new).with(body)
     end
 
     context 'when decision is empty found' do
@@ -76,7 +76,7 @@ RSpec.describe Maat::GetDecision do
       expect(connection).to have_received(:get)
         .with('/api/external/v1/crime-application/result/rep-order-id/60123')
 
-      expect(Maat::Decision).to have_received(:build).with(body)
+      expect(Maat::Decision).to have_received(:new).with(body)
     end
   end
 end

--- a/spec/models/decisions/interests_of_justice_form_spec.rb
+++ b/spec/models/decisions/interests_of_justice_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Decisions::InterestsOfJusticeForm do
   describe '#possible_results' do
     subject(:possible_results) { form_object.possible_results }
 
-    it { is_expected.to eq %w[pass fail] }
+    it { is_expected.to eq %w[passed failed] }
   end
 
   describe '#command_class' do

--- a/spec/models/decisions/overall_result_form_spec.rb
+++ b/spec/models/decisions/overall_result_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Decisions::OverallResultForm do
   describe '#possible_decisions' do
     subject(:possible_decisions) { form_object.possible_decisions }
 
-    it { is_expected.to eq %w[granted_on_ioj fail_on_ioj] }
+    it { is_expected.to eq %w[granted refused] }
   end
 
   describe '#command_class' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,9 +1,9 @@
 require_relative '../config/environment'
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 
+require 'laa_crime_schemas'
 require 'spec_helper'
 require 'rspec/rails'
-require 'laa_crime_schemas'
 require 'axe-rspec'
 
 ['init/*.rb', 'shared_contexts/*.rb', 'shared_examples/*.rb', 'support/**/*.rb'].each do |path|

--- a/spec/services/maat/crown_court_decision_translator_spec.rb
+++ b/spec/services/maat/crown_court_decision_translator_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Maat::CrownCourtDecisionTranslator do
+  expected_translations = [
+    'Granted - Passed Means Test', 'granted',
+    'Granted - Failed Means Test', 'granted',
+    'Refused - Ineligible', 'refused',
+    'Failed - CfS Failed Means Test', 'refused'
+  ].freeze
+
+  it_behaves_like 'a MAAT value translator', expected_translations
+end

--- a/spec/services/maat/decision_translator_spec.rb
+++ b/spec/services/maat/decision_translator_spec.rb
@@ -1,0 +1,140 @@
+require 'rails_helper'
+
+RSpec.describe Maat::DecisionTranslator do
+  let(:maat_decision) { Maat::Decision.new(funding_decision: nil) }
+
+  describe '.translate' do
+    subject(:translate) { described_class.translate(maat_decision) }
+
+    let(:maat_decision) { Maat::Decision.new }
+
+    it { is_expected.to be_a Decisions::Draft }
+
+    describe '#funding_decision' do
+      subject(:funding_decision) { translate.funding_decision }
+
+      context 'when not decided' do
+        it { is_expected.to be_nil }
+      end
+
+      context 'when funding decision exists' do
+        let(:maat_decision) { Maat::Decision.new(funding_decision: 'FAILIOJ') }
+
+        it { is_expected.to eq 'refused' }
+      end
+
+      context 'when a crown court decision exists' do
+        let(:maat_decision) { Maat::Decision.new(cc_rep_decision: 'Granted - Passported') }
+
+        it { is_expected.to eq 'granted' }
+      end
+
+      context 'when both a crown court and funding decision exists' do
+        let(:maat_decision) do
+          Maat::Decision.new(
+            funding_decision: 'FAILMEIOJ',
+            cc_rep_decision: 'Granted - Passported'
+          )
+        end
+
+        it 'returns the crown court decision' do
+          expect(funding_decision).to eq 'granted'
+        end
+      end
+    end
+
+    describe '#case_id' do
+      subject(:case_id) { translate.case_id }
+
+      context 'when case_id nil' do
+        it { is_expected.to be_nil }
+      end
+
+      context 'when case_id is set' do
+        let(:maat_decision) { Maat::Decision.new(case_id: 'AbD123') }
+
+        it { is_expected.to eq 'AbD123' }
+      end
+    end
+
+    describe '#maat_id' do
+      subject(:maat_id) { translate.maat_id }
+
+      context 'when maat_ref nil' do
+        it { is_expected.to be_nil }
+      end
+
+      context 'when maat_ref is set' do
+        let(:maat_decision) { Maat::Decision.new(maat_ref: 6_090_910) }
+
+        it { is_expected.to be 6_090_910 }
+      end
+    end
+
+    describe '#decision_id' do
+      subject(:decision_id) { translate.decision_id }
+
+      context 'when maat_ref nil' do
+        it { is_expected.to be_nil }
+      end
+
+      context 'when maat_ref is set' do
+        let(:maat_decision) { Maat::Decision.new(maat_ref: 6_090_910) }
+
+        it { is_expected.to be 6_090_910 }
+      end
+    end
+
+    describe '#reference' do
+      subject(:reference) { translate.reference }
+
+      context 'when usn nil' do
+        it { is_expected.to be_nil }
+      end
+
+      context 'when usn is set' do
+        let(:maat_decision) { Maat::Decision.new(usn: 6_090_910) }
+
+        it { is_expected.to be 6_090_910 }
+      end
+    end
+
+    describe '#means' do
+      subject(:means) { translate.means }
+
+      let(:translated_means) do
+        LaaCrimeSchemas::Structs::TestResult.new(
+          result: 'passed',
+          assessed_by: 'Ken',
+          assessed_on: '2024-12-12'
+        )
+      end
+
+      before do
+        allow(Maat::MeansTranslator).to receive(:translate)
+          .with(maat_decision) { translated_means }
+      end
+
+      it { is_expected.to be translated_means }
+    end
+
+    describe '#interests_of_justice' do
+      subject(:interests_of_justice) { translate.interests_of_justice }
+
+      let(:translated_interests_of_justice) do
+        LaaCrimeSchemas::Structs::TestResult.new(
+          result: 'failed',
+          assessed_by: 'Jo',
+          assessed_on: '2024-12-11'
+        )
+      end
+
+      before do
+        allow(Maat::InterestsOfJusticeTranslator).to receive(:translate)
+          .with(maat_decision) { translated_interests_of_justice }
+      end
+
+      it { is_expected.to be translated_interests_of_justice }
+    end
+  end
+end

--- a/spec/services/maat/funding_decision_translator_spec.rb
+++ b/spec/services/maat/funding_decision_translator_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Maat::FundingDecisionTranslator do
+  expected_translations = %w[
+    PASS granted
+    FAIL refused
+    INEL refused
+    FULL granted
+    GRANTED granted
+    FAILMEANS refused
+    FAILIOJ refused
+    FAILMEIOJ refused
+  ]
+
+  it_behaves_like 'a MAAT value translator', expected_translations
+end

--- a/spec/services/maat/interests_of_justice_translator_spec.rb
+++ b/spec/services/maat/interests_of_justice_translator_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe Maat::InterestsOfJusticeTranslator do
+  let(:maat_decision) do
+    Maat::Decision.new(
+      maat_ref: 6_000_001,
+      ioj_reason: 'because',
+      ioj_assessor_name: 'Ken',
+      ioj_result: ioj_result,
+      app_created_date: DateTime.new(2024, 12, 12, 12),
+      ioj_appeal_result: ioj_appeal_result
+    )
+  end
+
+  let(:ioj_appeal_result) { nil }
+
+  describe '.translate' do
+    subject(:translate) { described_class.translate(maat_decision) }
+
+    context 'when IoJ result is nil' do
+      let(:ioj_result) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when IoJ result set' do
+      let(:ioj_result) { 'FAIL' }
+
+      it 'returns the translated result as a hash' do
+        expect(translate).to eq LaaCrimeSchemas::Structs::TestResult.new(
+          assessed_by: 'Ken',
+          assessed_on: DateTime.new(2024, 12, 12, 12),
+          details: 'because',
+          result: 'failed'
+        )
+      end
+
+      context 'when IoJ appeal result present' do
+        let(:ioj_appeal_result) { 'PASS' }
+
+        it 'uses the appeal result' do
+          expect(translate).to eq LaaCrimeSchemas::Structs::TestResult.new(
+            assessed_by: 'Ken',
+            assessed_on: DateTime.new(2024, 12, 12, 12),
+            details: 'because',
+            result: 'passed'
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/services/maat/means_result_translator_spec.rb
+++ b/spec/services/maat/means_result_translator_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Maat::MeansResultTranslator do
+  expected_translations = %w[
+    PASS passed
+    INEL failed
+    FULL passed_with_contribution
+    FAIL failed
+  ]
+
+  it_behaves_like 'a MAAT value translator', expected_translations
+end

--- a/spec/services/maat/means_translator_spec.rb
+++ b/spec/services/maat/means_translator_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe Maat::MeansTranslator do
+  let(:maat_decision) { Maat::Decision.new }
+
+  describe '.translate' do
+    subject(:translate) { described_class.translate(maat_decision) }
+
+    context 'when the means result and passport result are both nil' do
+      let(:maat_decision) { Maat::Decision.new(maat_ref: 6_000_001) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when only the passport result is present' do
+      let(:maat_decision) do
+        Maat::Decision.new(
+          passport_assessor_name: 'Pam',
+          passport_result: 'PASS',
+          date_passport_created: DateTime.new(2024, 12, 12, 13)
+        )
+      end
+
+      it 'returns the passporting result details' do
+        expect(translate).to eq LaaCrimeSchemas::Structs::TestResult.new(
+          assessed_by: 'Pam',
+          assessed_on: DateTime.new(2024, 12, 12, 13),
+          result: 'passed'
+        )
+      end
+    end
+
+    context 'when only the means result is present' do
+      let(:maat_decision) do
+        Maat::Decision.new(
+          means_assessor_name: 'Kit',
+          means_result: 'FAIL',
+          date_means_created: DateTime.new(2024, 12, 12, 12)
+        )
+      end
+
+      it 'returns the means result details' do
+        expect(translate).to eq LaaCrimeSchemas::Structs::TestResult.new(
+          assessed_by: 'Kit',
+          assessed_on: DateTime.new(2024, 12, 12, 12),
+          result: 'failed'
+        )
+      end
+    end
+
+    context 'when both means and passport results are present' do
+      let(:maat_decision) do
+        Maat::Decision.new(
+          passport_assessor_name: 'Pam',
+          passport_result: 'PASS',
+          date_passport_created: DateTime.new(2024, 12, 12, 13),
+          means_assessor_name: 'Kit',
+          means_result: 'FAIL',
+          date_means_created: DateTime.new(2024, 12, 12, 12)
+        )
+      end
+
+      it 'uses the most recent' do
+        expect(translate).to eq LaaCrimeSchemas::Structs::TestResult.new(
+          assessed_by: 'Pam',
+          assessed_on: DateTime.new(2024, 12, 12, 13),
+          result: 'passed'
+        )
+      end
+    end
+
+    context 'when means and passport results have the same timestamp' do
+      let(:maat_decision) do
+        Maat::Decision.new(
+          passport_assessor_name: 'Pam',
+          passport_result: 'PASS',
+          date_passport_created: DateTime.new(2024, 12, 12, 12),
+          means_assessor_name: 'Kit',
+          means_result: 'FAIL',
+          date_means_created: DateTime.new(2024, 12, 12, 12)
+        )
+      end
+
+      it 'returns the means result details' do
+        expect(translate).to eq LaaCrimeSchemas::Structs::TestResult.new(
+          assessed_by: 'Kit',
+          assessed_on: DateTime.new(2024, 12, 12, 12),
+          result: 'failed'
+        )
+      end
+    end
+  end
+end

--- a/spec/shared_contexts/when_adding_a_decision_by_maat_id.rb
+++ b/spec/shared_contexts/when_adding_a_decision_by_maat_id.rb
@@ -1,0 +1,32 @@
+RSpec.shared_context 'when adding a decision by MAAT ID' do
+  let(:maat_decision) do
+    Maat::Decision.new(
+      maat_ref: maat_decision_maat_id,
+      usn: maat_decision_reference,
+      ioj_result: 'PASS',
+      ioj_assessor_name: 'Jo Bloggs',
+      app_created_date: 1.day.ago.to_s,
+      means_result: 'PASS',
+      means_assessor_name: 'Jo Bloggs',
+      date_means_created:  1.day.ago.to_s,
+      funding_decision: maat_decision_funding_decision
+    )
+  end
+
+  let(:maat_decision_funding_decision) { 'GRANTED' }
+  let(:maat_decision_reference) { 6_000_001 }
+  let(:maat_decision_maat_id) { 999_333 }
+  let(:mock_get_decision) { instance_double(Maat::GetDecision) }
+
+  before do
+    allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
+      .and_return(instance_double(DatastoreApi::Requests::UpdateApplication, call: {}))
+
+    allow(FeatureFlags).to receive(:adding_decisions) {
+      instance_double(FeatureFlags::EnabledFeature, enabled?: true)
+    }
+
+    allow(mock_get_decision).to receive(:by_maat_id!).with(maat_decision_maat_id).and_return(maat_decision)
+    allow(Maat::GetDecision).to receive(:new).and_return(mock_get_decision)
+  end
+end

--- a/spec/shared_examples/a_maat_value_translator.rb
+++ b/spec/shared_examples/a_maat_value_translator.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples 'a MAAT value translator' do |expected_translations|
+  expected_translations.each_slice(2).each do |original, expected|
+    it "#{original} is translated to #{expected}" do
+      expect(described_class.translate(original)).to eq(expected)
+    end
+  end
+end

--- a/spec/system/casework/deciding/adding_a_cifc_decision_spec.rb
+++ b/spec/system/casework/deciding/adding_a_cifc_decision_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'Adding a decision by MAAT ID' do
   include_context 'with stubbed application'
+  include_context 'when adding a decision by MAAT ID'
+
   let(:application_id) { '98ab235c-f125-4dcb-9604-19e81782e53b' }
   let(:application_data) { JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'change_in_financial_circumstances').read) }
-
-  let(:mock_get_decision) { instance_double(Maat::GetDecision) }
 
   let(:origional_application) do
     instance_double(
@@ -18,16 +18,6 @@ RSpec.describe 'Adding a decision by MAAT ID' do
   end
 
   before do
-    allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
-      .and_return(instance_double(DatastoreApi::Requests::UpdateApplication, call: {}))
-
-    allow(FeatureFlags).to receive(:adding_decisions) {
-      instance_double(FeatureFlags::EnabledFeature, enabled?: true)
-    }
-
-    allow(mock_get_decision).to receive(:by_maat_id!).with(maat_id).and_return(maat_decision)
-    allow(Maat::GetDecision).to receive(:new).and_return(mock_get_decision)
-
     visit crime_application_path(application_id)
     click_button 'Assign to your list'
     click_button 'Mark as ready for MAAT'
@@ -39,23 +29,8 @@ RSpec.describe 'Adding a decision by MAAT ID' do
   context 'when the original maat record is found' do
     let(:maat_id) { 987_654_321 }
 
-    let(:maat_decision) do
-      Maat::Decision.new(
-        maat_id: maat_id,
-        reference: origional_application.reference,
-        interests_of_justice: {
-          result: 'pass',
-          assessed_by: 'Jo Bloggs',
-          assessed_on:  1.day.ago.to_s
-        },
-        means: {
-          result: 'pass',
-          assessed_by: 'Jo Bloggs',
-          assessed_on:  1.day.ago.to_s
-        },
-        funding_decision: 'granted'
-      )
-    end
+    let(:maat_decision_maat_id) { maat_id }
+    let(:maat_decision_reference) { origional_application.reference }
 
     it 'creates the decision and shows the success message' do
       save_and_continue

--- a/spec/system/casework/deciding/adding_a_maat_decision_by_maat_id_spec.rb
+++ b/spec/system/casework/deciding/adding_a_maat_decision_by_maat_id_spec.rb
@@ -4,21 +4,11 @@ RSpec.describe 'Adding a decision by MAAT ID' do
   include DecisionFormHelpers
 
   include_context 'with stubbed application'
+  include_context 'when adding a decision by MAAT ID'
 
-  let(:mock_get_decision) { instance_double(Maat::GetDecision) }
-  let(:maat_decision) { nil }
+  let(:maat_decision_maat_id) { maat_id }
 
   before do
-    allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
-      .and_return(instance_double(DatastoreApi::Requests::UpdateApplication, call: {}))
-
-    allow(FeatureFlags).to receive(:adding_decisions) {
-      instance_double(FeatureFlags::EnabledFeature, enabled?: true)
-    }
-
-    allow(mock_get_decision).to receive(:by_maat_id!).with(maat_id).and_return(maat_decision)
-    allow(Maat::GetDecision).to receive(:new).and_return(mock_get_decision)
-
     visit crime_application_path(application_id)
     click_button 'Assign to your list'
     click_button 'Mark as ready for MAAT'
@@ -31,6 +21,7 @@ RSpec.describe 'Adding a decision by MAAT ID' do
 
   context 'when MAAT ID not entered' do
     let(:maat_id) { nil }
+    let(:maat_decision) { nil }
 
     it 'shows an error' do
       expect(page).to have_error(
@@ -54,19 +45,15 @@ RSpec.describe 'Adding a decision by MAAT ID' do
 
     let(:maat_decision) do
       Maat::Decision.new(
-        maat_id: maat_id,
-        reference: 6_000_001,
-        interests_of_justice: {
-          result: 'fail',
-          assessed_by: 'Jo Blogs',
-          assessed_on:  Date.new(2024, 2, 1)
-        },
-        means: {
-          result: 'fail',
-          assessed_by: 'Jan Blogs',
-          assessed_on:  Date.new(2024, 2, 2)
-        },
-        funding_decision: 'failmeioj'
+        maat_ref: maat_id,
+        usn: 6_000_001,
+        ioj_result: 'FAIL',
+        ioj_assessor_name: 'Jo Blogs',
+        app_created_date: Date.new(2024, 2, 1),
+        means_result: 'FAIL',
+        means_assessor_name: 'Jan Blogs',
+        date_means_created:  Date.new(2024, 2, 2),
+        funding_decision: 'FAILMEIOJ'
       )
     end
 
@@ -76,14 +63,14 @@ RSpec.describe 'Adding a decision by MAAT ID' do
       )
 
       expect(summary_card('Case')).to have_rows(
-        'Interests of justice (IoJ) test result', 'Refused',
+        'Interests of justice (IoJ) test result', 'Failed',
         'IoJ comments', '',
         'IoJ caseworker', 'Jo Blogs',
         'IoJ test date', '01/02/2024',
         'Means test result', 'Failed',
         'Means test caseworker', 'Jan Blogs',
         'Means test date', '02/02/2024',
-        'Overall result', 'Failed means and IoJ'
+        'Overall result', 'Refused'
       )
 
       expect(current_path).to eq(
@@ -97,11 +84,8 @@ RSpec.describe 'Adding a decision by MAAT ID' do
 
     let(:maat_decision) do
       Maat::Decision.new(
-        maat_id: maat_id,
-        reference: 6_000_002,
-        interests_of_justice: nil,
-        means: nil,
-        funding_decision: nil
+        maat_ref: maat_id,
+        usn: 6_000_002
       )
     end
 
@@ -117,11 +101,8 @@ RSpec.describe 'Adding a decision by MAAT ID' do
 
     let(:maat_decision) do
       Maat::Decision.new(
-        maat_id: maat_id,
-        reference: 6_000_001,
-        interests_of_justice: nil,
-        means: nil,
-        funding_decision: nil
+        maat_ref: maat_id,
+        usn: 6_000_001
       )
     end
 

--- a/spec/system/casework/deciding/adding_a_maat_decision_by_reference_spec.rb
+++ b/spec/system/casework/deciding/adding_a_maat_decision_by_reference_spec.rb
@@ -52,19 +52,15 @@ RSpec.describe 'Adding a decision by MAAT reference' do
   context 'when an application for the reference is found on MAAT' do
     let(:maat_decision) do
       Maat::Decision.new(
-        maat_id: 999_333,
-        reference: 6_000_001,
-        interests_of_justice: {
-          result: 'pass',
-          assessed_by: 'Jo Bloggs',
-          assessed_on:  1.day.ago.to_s
-        },
-        means: {
-          result: 'pass',
-          assessed_by: 'Jo Bloggs',
-          assessed_on:  1.day.ago.to_s
-        },
-        funding_decision: 'granted'
+        maat_ref: 999_333,
+        usn: 6_000_001,
+        ioj_result: 'PASS',
+        ioj_assessor_name: 'Jo Bloggs',
+        app_created_date: 1.day.ago.to_s,
+        means_result: 'PASS',
+        means_assessor_name: 'Jo Bloggs',
+        date_means_created:  1.day.ago.to_s,
+        funding_decision: 'GRANTED'
       )
     end
 

--- a/spec/system/casework/deciding/adding_another_maat_decision_spec.rb
+++ b/spec/system/casework/deciding/adding_another_maat_decision_spec.rb
@@ -4,44 +4,23 @@ RSpec.describe 'Adding another MAAT decision' do
   include DecisionFormHelpers
 
   include_context 'with stubbed application'
+  include_context 'when adding a decision by MAAT ID'
 
-  let(:mock_get_decision) { instance_double(Maat::GetDecision) }
   let(:maat_id) { 12_312_345 }
   let(:maat_id2) { 12_312_347 }
-
-  let(:maat_decision) do
-    Maat::Decision.new(
-      maat_id: maat_id,
-      reference: 6_000_001,
-      interests_of_justice: {
-        result: 'pass',
-        assessed_by: 'Jo Bloggs',
-        assessed_on:  1.day.ago.to_s
-      },
-      means: {
-        result: 'pass',
-        assessed_by: 'Jo Bloggs',
-        assessed_on:  1.day.ago.to_s
-      },
-      funding_decision: 'granted'
-    )
-  end
+  let(:maat_decision_maat_id) { maat_id }
 
   let(:maat_decision2) do
     Maat::Decision.new(
-      maat_id: maat_id2,
-      reference: nil,
-      interests_of_justice: {
-        result: 'pass',
-        assessed_by: 'Jo Bloggs',
-        assessed_on:  1.hour.ago.to_s
-      },
-      means: {
-        result: 'fail',
-        assessed_by: 'Jo Bloggs',
-        assessed_on:  1.hour.ago.to_s
-      },
-      funding_decision: 'failmeans'
+      maat_ref: maat_id2,
+      usn: nil,
+      ioj_result: 'PASS',
+      ioj_assessor_name: 'Jo Bloggs',
+      app_created_date: 1.day.ago.to_s,
+      means_result: 'FAIL',
+      means_assessor_name: 'Jo Bloggs',
+      date_means_created:  1.day.ago.to_s,
+      funding_decision: 'FAILMEANS'
     )
   end
 
@@ -49,13 +28,7 @@ RSpec.describe 'Adding another MAAT decision' do
     allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
       .and_return(instance_double(DatastoreApi::Requests::UpdateApplication, call: {}))
 
-    allow(FeatureFlags).to receive(:adding_decisions) {
-      instance_double(FeatureFlags::EnabledFeature, enabled?: true)
-    }
-
-    allow(mock_get_decision).to receive(:by_maat_id!).with(maat_id).and_return(maat_decision)
     allow(mock_get_decision).to receive(:by_maat_id!).with(maat_id2).and_return(maat_decision2)
-    allow(Maat::GetDecision).to receive(:new).and_return(mock_get_decision)
 
     visit crime_application_path(application_id)
     click_button 'Assign to your list'

--- a/spec/system/casework/deciding/removing_a_maat_decision_spec.rb
+++ b/spec/system/casework/deciding/removing_a_maat_decision_spec.rb
@@ -4,39 +4,12 @@ RSpec.describe 'Removing a MAAT decision' do
   include DecisionFormHelpers
 
   include_context 'with stubbed application'
-
-  let(:mock_get_decision) { instance_double(Maat::GetDecision) }
-  let(:maat_decision) do
-    Maat::Decision.new(
-      maat_id: maat_id,
-      reference: 6_000_001,
-      interests_of_justice: {
-        result: 'pass',
-        assessed_by: 'Jo Bloggs',
-        assessed_on:  1.day.ago.to_s
-      },
-      means: {
-        result: 'pass',
-        assessed_by: 'Jo Bloggs',
-        assessed_on:  1.day.ago.to_s
-      },
-      funding_decision: 'granted'
-    )
-  end
+  include_context 'when adding a decision by MAAT ID'
 
   let(:maat_id) { 123 }
+  let(:maat_decision_maat_id) { maat_id }
 
   before do
-    allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
-      .and_return(instance_double(DatastoreApi::Requests::UpdateApplication, call: {}))
-
-    allow(FeatureFlags).to receive(:adding_decisions) {
-      instance_double(FeatureFlags::EnabledFeature, enabled?: true)
-    }
-
-    allow(mock_get_decision).to receive(:by_maat_id!).with(maat_id).and_return(maat_decision)
-    allow(Maat::GetDecision).to receive(:new).and_return(mock_get_decision)
-
     visit crime_application_path(application_id)
     click_button 'Assign to your list'
     click_button 'Mark as ready for MAAT'

--- a/spec/system/casework/deciding/submitting_a_non_means_decision_spec.rb
+++ b/spec/system/casework/deciding/submitting_a_non_means_decision_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Submitting a Non-means decision' do
             'reference' => 6_000_001,
             'maat_id' => nil,
             'interests_of_justice' => {
-              'result' => 'pass',
+              'result' => 'passed',
               'details' => 'reason',
               'assessed_by' => 'Test User',
               'assessed_on' => '2024-10-01 00:00:00'

--- a/spec/system/casework/deciding/updating_a_decision_from_maat_spec.rb
+++ b/spec/system/casework/deciding/updating_a_decision_from_maat_spec.rb
@@ -9,21 +9,18 @@ RSpec.describe 'Adding a decision by MAAT reference' do
   let(:missing_prompt) { 'Information missing' }
   let(:maat_decision) do
     Maat::Decision.new(
-      maat_id: 999_333,
-      reference: 6_000_001,
-      interests_of_justice: {
-        result: 'pass',
-        assessed_by: 'Jo Bloggs',
-        assessed_on:  1.day.ago.to_s
-      },
-      means: {
-        result: 'pass',
-        assessed_by: 'Jo Bloggs',
-        assessed_on:  1.day.ago.to_s
-      },
+      maat_ref: 999_333,
+      usn: 6_000_001,
+      ioj_result: 'PASS',
+      ioj_assessor_name: 'Jo Bloggs',
+      app_created_date: 1.day.ago.to_s,
+      means_result: 'PASS',
+      means_assessor_name: 'Jo Bloggs',
+      date_means_created:  1.day.ago.to_s,
       funding_decision: nil
     )
   end
+
   let(:reference) { 6_000_001 }
 
   before do
@@ -36,7 +33,7 @@ RSpec.describe 'Adding a decision by MAAT reference' do
 
     allow(mock_get_decision).to receive(:by_usn!).with(reference).and_return(maat_decision)
 
-    allow(mock_get_decision).to receive(:by_maat_id!).with(maat_decision.maat_id).and_return(v2)
+    allow(mock_get_decision).to receive(:by_maat_id!).with(maat_decision.maat_ref).and_return(v2)
 
     allow(Maat::GetDecision).to receive(:new).and_return(mock_get_decision)
 
@@ -51,7 +48,7 @@ RSpec.describe 'Adding a decision by MAAT reference' do
   end
 
   context 'when nothing has changed on MAAT details are missing' do
-    let(:v2) { maat_decision }
+    let(:v2) { Maat::Decision.new(**maat_decision.attributes) }
 
     it 'instructs the caseworker to make changes on MAAT' do
       expect(page).to have_notification_banner(
@@ -68,21 +65,7 @@ RSpec.describe 'Adding a decision by MAAT reference' do
 
   context 'when changed on MAAT with missing details provided' do
     let(:v2) do
-      Maat::Decision.new(
-        maat_id: 999_333,
-        reference: 6_000_001,
-        interests_of_justice: {
-          result: 'pass',
-          assessed_by: 'Jo Bloggs',
-          assessed_on:  1.day.ago.to_s
-        },
-        means: {
-          result: 'pass',
-          assessed_by: 'Jo Bloggs',
-          assessed_on:  1.day.ago.to_s
-        },
-        funding_decision: 'granted'
-      )
+      Maat::Decision.new(**maat_decision.attributes, funding_decision: 'GRANTED')
     end
 
     it 'instructs the caseworker to check the decision' do


### PR DESCRIPTION
## Description of change
Introduce translators to the MAAT decision adapter.

## Link to relevant ticket

## Notes for reviewer

Translating MAAT decisions has become more complex as we now handle both Magistrates' and Crown Court decisions, along with workarounds like IoJ appeals and passporting versus standard means decisions. This PR introduces translators to address this complexity. 

Additionally, it simplifies the Crime Apply/Review decision data model types to better reflect their context, as opposed to previously copying the types directly from MAAT.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
