### PR TITLE
Update ModSec rules

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -34,6 +34,7 @@ metadata:
         ctl:ruleRemoveById=932100,\
         ctl:ruleRemoveById=932110,\
         ctl:ruleRemoveById=932115,\
+        ctl:ruleRemoveById=933160,\
         ctl:ruleRemoveById=942230"
 spec:
   ingressClassName: modsec

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -34,6 +34,7 @@ metadata:
         ctl:ruleRemoveById=932100,\
         ctl:ruleRemoveById=932110,\
         ctl:ruleRemoveById=932115,\
+        ctl:ruleRemoveById=933160,\
         ctl:ruleRemoveById=942230"
 spec:
   ingressClassName: modsec


### PR DESCRIPTION
## Description of change
Disable ModSec rule 933160 to prevent false positives on the `{application_id}/return` endpoint.

## Link to relevant ticket
[Slack conversation](https://mojdt.slack.com/archives/C06GX24DV26/p1736354100125169)