### PR TITLE
CRIMAPP-1536 rename search result caseworker column header

### DIFF
--- a/app/views/casework/application_searches/search.html.erb
+++ b/app/views/casework/application_searches/search.html.erb
@@ -29,7 +29,7 @@
                row.with_cell(colname: :case_type)
                row.with_cell(colname: :submitted_at)
                row.with_cell(colname: :reviewed_at)
-               row.with_cell(colname: :closed_by)
+               row.with_cell(colname: :caseworker)
                row.with_cell(colname: :status)
              end %>
         <% end %>

--- a/spec/system/casework/searching/search_filters_and_results_spec.rb
+++ b/spec/system/casework/searching/search_filters_and_results_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Search Page' do
 
     expect(column_headings).to eq(
       ["Applicant's name", 'Reference number', 'Type of application', 'Case type', 'Date received', 'Date closed',
-       'Closed by', 'Status']
+       'Caseworker', 'Status']
     )
   end
 


### PR DESCRIPTION
## Description of change
Rename search result caseworker column from "Closed by" to "Caseworker"

## Link to relevant ticket
[CRIMAPP-1536](https://dsdmoj.atlassian.net/browse/CRIMAPP-1536)

## Notes for reviewer

Search shows both open and closed applications and needs to show the name of the assigned caseworker.

## Screenshots of changes (if applicable)

### Before changes:
<img width="1039" alt="Screenshot 2025-01-13 at 10 45 25" src="https://github.com/user-attachments/assets/1f686283-6e8d-462f-9447-42bde979e513" />


### After changes:

<img width="997" alt="Screenshot 2025-01-13 at 10 45 10" src="https://github.com/user-attachments/assets/af245336-cf87-47e2-ae92-581d92f1c5a6" />


## How to manually test the feature


[CRIMAPP-1536]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ