### PR TITLE
Assets heading only displays if question asked

### DIFF
--- a/app/views/casework/crime_applications/_capital_details.html.erb
+++ b/app/views/casework/crime_applications/_capital_details.html.erb
@@ -1,9 +1,5 @@
 <% return if crime_application.means_details.capital_details.will_benefit_from_trust_fund.blank? %>
 
-<h2 class="govuk-heading-l">
-  <%= label_text(:assets) %>
-</h2>
-
 <%= render(
       partial: 'casework/crime_applications/sections/properties',
       locals: { capital_details: crime_application.means_details.capital_details }

--- a/app/views/casework/crime_applications/sections/_properties.html.erb
+++ b/app/views/casework/crime_applications/sections/_properties.html.erb
@@ -1,3 +1,7 @@
+<% if capital_details.has_no_properties == 'yes' || capital_details.properties.present?  %>
+  <h2 class="govuk-heading-l"><%= label_text(:assets) %></h2>
+<% end  %>
+
 <% if capital_details.has_no_properties == 'yes'  %>
   <%= govuk_summary_card(title: label_text(:properties_title)) do %>
     <%= govuk_summary_list(actions: false) do |list|


### PR DESCRIPTION
## Description of change
Fixes the assets heading which was displaying even when the assets question was not asked
## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1213" alt="Screenshot 2025-01-14 at 09 34 15" src="https://github.com/user-attachments/assets/6d5a37a4-363f-44c2-9e1b-1bcdb61df949" />

### After changes:

<img width="1213" alt="Screenshot 2025-01-14 at 09 59 31" src="https://github.com/user-attachments/assets/d15ff8d7-c325-4ab1-ae22-259ae182180e" />

**When assets question asked**
<img width="1213" alt="Screenshot 2025-01-14 at 09 57 09" src="https://github.com/user-attachments/assets/7e56e124-bd5f-491a-b62d-2029b077a3b4" />


## How to manually test the feature
