### PR TITLE
CRIMAPP-1569 overall result indicates when contribution possible

### DIFF
--- a/app/components/decision_component.html.erb
+++ b/app/components/decision_component.html.erb
@@ -47,7 +47,7 @@
 
       list.with_row do |row|
         row.with_key { label_text(:overall_result) }
-        row.with_value { decision_result(decision.funding_decision) }
+        row.with_value { decision_overall_result(decision:) }
       end
 
       if decision.comment.present?

--- a/app/components/decision_overall_result_component.rb
+++ b/app/components/decision_overall_result_component.rb
@@ -1,0 +1,52 @@
+class DecisionOverallResultComponent < ViewComponent::Base
+  with_collection_parameter :decision
+
+  def initialize(decision:)
+    @means_result = decision.means&.result
+    @funding_decision = decision.funding_decision
+
+    super
+  end
+
+  def call
+    return if funding_decision.nil?
+
+    govuk_tag(
+      text: t(overall_result, scope: [:values, :decision_overall_result]),
+      colour: colour
+    )
+  end
+
+  private
+
+  attr_reader :funding_decision, :means_result
+
+  # TODO: move to the decision model if overall result decision confirmed
+  # otherwise use the MAAT decision
+  #
+  def overall_result
+    return 'granted_failed_means' if granted? && failed_means?
+    return 'granted_with_contribution' if granted? && with_contribution?
+
+    funding_decision
+  end
+
+  def granted?
+    funding_decision == Types::FundingDecision['granted']
+  end
+
+  def failed_means?
+    means_result == Types::TestResult['failed']
+  end
+
+  def with_contribution?
+    means_result == Types::TestResult['passed_with_contribution']
+  end
+
+  def colour
+    {
+      Types::FundingDecision['granted'] => 'green',
+      Types::FundingDecision['refused'] => 'red'
+    }.fetch(funding_decision, nil)
+  end
+end

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -15,8 +15,8 @@ module ComponentsHelper
     render OffenceDatesComponent.new(offence:)
   end
 
-  def decision_result(result)
-    render DecisionResultComponent.new(result:)
+  def decision_overall_result(decision:)
+    render DecisionOverallResultComponent.new(decision:)
   end
 
   def conflict_of_interest(codefendant)

--- a/app/services/maat/means_translator.rb
+++ b/app/services/maat/means_translator.rb
@@ -39,7 +39,7 @@ module Maat
     end
 
     def result
-      Maat::MeansResultTranslator.translate(maat_result)
+      MeansResultTranslator.translate(maat_result)
     end
 
     def maat_result

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -477,6 +477,7 @@ en:
       granted: Granted
       refused: Refused
       granted_failed_means: Granted - failed means test
+      granted_with_contribution: Granted - with contribution
     either_way: Either way
     esa: Income-related Employment and Support Allowance (ESA)
     guarantee_pension: Guarantee Credit element of Pension Credit

--- a/spec/components/decision_component_spec.rb
+++ b/spec/components/decision_component_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe DecisionComponent, type: :component do
 
   before do
     allow(decision).to receive_messages(
-      interests_of_justice: {},
-      means: {},
+      interests_of_justice: nil,
+      means: nil,
       funding_decision: 'granted',
       comment: nil,
       maat_id: nil

--- a/spec/components/decision_overall_result_component_spec.rb
+++ b/spec/components/decision_overall_result_component_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe DecisionOverallResultComponent, type: :component do
+  describe '.new' do
+    subject(:tag) { page }
+
+    let(:decision) { instance_double Decisions::Draft, means:, funding_decision: }
+    let(:funding_decision) { nil }
+    let(:means) { nil }
+
+    before do
+      render_inline(described_class.new(decision:))
+    end
+
+    context 'when funding decision is "granted"' do
+      let(:funding_decision) { 'granted' }
+
+      it { is_expected.to have_text('Granted') }
+      it { is_expected.to have_css('.govuk-tag--green') }
+
+      context 'when with contribution' do
+        let(:means) do
+          instance_double(LaaCrimeSchemas::Structs::TestResult, result: 'passed_with_contribution')
+        end
+
+        it { is_expected.to have_text('Granted - with contribution') }
+        it { is_expected.to have_css('.govuk-tag--green') }
+      end
+
+      context 'when failed means' do
+        let(:means) do
+          instance_double(LaaCrimeSchemas::Structs::TestResult, result: 'failed')
+        end
+
+        it { is_expected.to have_text('Granted - failed means test') }
+        it { is_expected.to have_css('.govuk-tag--green') }
+      end
+    end
+
+    context 'when funding decision is "refuse"' do
+      let(:funding_decision) { 'refused' }
+
+      it { is_expected.to have_text('Refused') }
+      it { is_expected.to have_css('.govuk-tag--red') }
+
+      context 'when failed means' do
+        let(:means) do
+          instance_double(LaaCrimeSchemas::Structs::TestResult, result: 'failed')
+        end
+
+        it { is_expected.to have_text('Refused') }
+        it { is_expected.to have_css('.govuk-tag--red') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Overall results indicates when contribution possible.

## Link to relevant ticket

[CRIMAPP-1569](https://dsdmoj.atlassian.net/browse/CRIMAPP-1569)

## Notes for reviewer

This change is for User Research at this stage. Adds two additional overall results "Granted - with contribution" and "Granted - failed means test" in addition to "Granted" and "Failed".

## Screenshots of changes (if applicable)

### Before changes:

<img width="951" alt="Screenshot 2025-01-14 at 13 19 38" src="https://github.com/user-attachments/assets/010b7115-071d-4807-aa6d-bdc72028962a" />


### After changes:

<img width="963" alt="Screenshot 2025-01-14 at 13 19 26" src="https://github.com/user-attachments/assets/8b6fbb90-063b-4ed6-b5d7-b7268bc5da0b" />

## How to manually test the feature


[CRIMAPP-1569]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ