### PR TITLE
[CRIMAPP-1545] Use classes to implement superseded stying

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -35,7 +35,7 @@ form.search {
   }
 }
 
-p.help-text, #superseded_style  {
+p.help-text, .app_superseded_style  {
   color: govuk-colour("dark-grey");
 }
 

--- a/app/views/casework/crime_applications/_review_overview.html.erb
+++ b/app/views/casework/crime_applications/_review_overview.html.erb
@@ -4,11 +4,7 @@
       <%= govuk_tag(text: t(crime_application.review_status, scope: 'values.review_status'), colour: t(crime_application.review_status, scope: 'values.color')) %>
     </div>
 
-    <% if crime_application.superseded? %>
-      <% id = 'superseded_' %>
-    <% end %>
-
-    <p class="govuk-body-l govuk-!-margin-bottom-2" id="<%= id %>style">
+    <p class="govuk-body-l govuk-!-margin-bottom-2 <%= 'app_superseded_style' if crime_application.superseded? %>">
       <span class="govuk-!-margin-right-2" id="reference-number">
         <%= crime_application.reference %>
       </span>
@@ -17,7 +13,7 @@
       <% end %>
     </p>
 
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4" id="<%= id %>style">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4 <%= 'app_superseded_style' if crime_application.superseded? %>">
       <%= crime_application.applicant.full_name %>
     </h1>
 


### PR DESCRIPTION
## Description of change
Duplicate ids on the application details screen were flagged as having potential to cause accessibility issues for screen readers, as the reader might ignore the second instance of the same id. They were changed to css classes. 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1545

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
