### PR TITLE
[CRIMAPP-1503] Update URLs to use dashes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,9 @@ Rails.application.routes.draw do
     end
 
     authenticated :user do
-      get 'sign_out', to: 'users/sessions#destroy', as: :destroy_user_session
+      get 'sign-out', to: 'users/sessions#destroy', as: :destroy_user_session
+      # temp underscored routes
+      get 'sign_out', to: 'users/sessions#destroy'
     end
   end
 
@@ -37,23 +39,35 @@ Rails.application.routes.draw do
       resource :reassign, only: [:new, :create]
       resource :return, only: [:new, :create]
       resource :complete, only: [:create]
-      get 'what_do_you_want_to_do_next', to: 'send_decisions#new', as: :send_decisions
+      get 'what-do-you-want-to-do-next', to: 'send_decisions#new', as: :send_decisions
+      post 'what-do-you-want-to-do-next', to: 'send_decisions#create'
+      # temp underscored routes
+      get 'what_do_you_want_to_do_next', to: 'send_decisions#new'
       post 'what_do_you_want_to_do_next', to: 'send_decisions#create'
 
       resources :decisions, only: [:create] do 
         scope module: :decisions do
+          get 'interests-of-justice', to: 'interests_of_justices#edit'
+          put 'interests-of-justice', to: 'interests_of_justices#update'
+          # temp underscored routes
           get 'interests_of_justice', to: 'interests_of_justices#edit'
-          put 'interests_of_justice', to: 'interests_of_justices#update'
+          post 'interests_of_justice', to: 'interests_of_justices#update'
 
+          get 'overall-result', to: 'overall_results#edit'
+          put 'overall-result', to: 'overall_results#update'
+          # temp underscored routes
           get 'overall_result', to: 'overall_results#edit'
-          put 'overall_result', to: 'overall_results#update'
+          post 'overall_result', to: 'overall_results#update'
 
           get 'comment', to: 'comments#edit'
           put 'comment', to: 'comments#update'
         end
       end
       
-      get 'link_maat_id', to: 'maat_decisions#new', as: :maat_decisions
+      get 'link-maat-id', to: 'maat_decisions#new', as: :maat_decisions
+      post 'link-maat-id', to: 'maat_decisions#create'
+      # temp underscored routes
+      get 'link_maat_id', to: 'maat_decisions#new'
       post 'link_maat_id', to: 'maat_decisions#create'
 
       resources :maat_decisions, only: [:update, :destroy] do
@@ -64,13 +78,21 @@ Rails.application.routes.draw do
     get 'applications/open/:work_stream', to: 'crime_applications#open', as: :open_work_stream
     get 'applications/closed/:work_stream', to: 'crime_applications#closed', as: :closed_work_stream
 
-    resource :application_searches, only: [:new] do
+    resource :application_searches, path: 'application-searches', only: [:new] do
       get :search, on: :collection
     end
+    # temp underscored routes
+    get '/application_searches/new', to: 'application_searches#new'
+    get '/application_searches/search', to: 'application_searches#search'
 
-    resources :assigned_applications, only: [:index, :destroy, :create] do
+    resources :assigned_applications, path: 'assigned-applications', only: [:index, :destroy, :create] do
       post :next_application, on: :collection
     end
+    # temp underscored routes
+    get '/assigned_applications', to: 'assigned_applications#index'
+    post '/assigned_applications', to: 'assigned_applications#create'
+    post '/assigned_applications/next_application', to: 'assigned_applications#next_application'
+    delete '/assigned_applications/:id', to: 'assigned_applications#destroy'
 
     resource :documents, only: [:show] do
       get :download, on: :member
@@ -81,44 +103,68 @@ Rails.application.routes.draw do
     root to: 'user_reports#index'
     get ':report_type', to: 'user_reports#show', as: 'user_report'
 
-    get ':report_type/:interval/latest_complete', to: 'temporal_reports#latest_complete', as: :latest_complete_temporal_report
+    get ':report_type/:interval/latest-complete', to: 'temporal_reports#latest_complete', as: :latest_complete_temporal_report
+    # temp underscored routes
+    get ':report_type/:interval/latest_complete', to: 'temporal_reports#latest_complete'
     get ':report_type/:interval/:period', to: 'temporal_reports#show', as: :temporal_report
     get ':report_type/:interval/:period/download', to: 'temporal_reports#download', as: :download_temporal_report
     get ':report_type/:date/at/:time', to: 'snapshots#show', as: :snapshot
     get ':report_type/now', to: 'snapshots#now', as: :current_snapshot
   end
 
-  namespace :manage_users do
+  namespace :manage_users, path: 'manage-users' do
     root 'active_users#index'
-    resources :active_users, only: [:index]
+    resources :active_users, path: 'active-users', only: [:index]
     resources :history, only: [:show], controller: :history
-    resources :revive_users, only: [:edit]
-    resources :change_roles, only: [:edit, :update]
+    resources :revive_users, path: 'revive-users', only: [:edit]
+    resources :change_roles, path: 'change-roles', only: [:edit, :update]
 
     resources :invitations, only: [:index, :new, :destroy, :create, :update] do
       member do
-        get 'confirm_destroy'
-        get 'confirm_renew'
+        get 'confirm-destroy'
+        get 'confirm-renew'
       end
     end
 
-    resources :deactivated_users, only: [:index, :new, :create] do
+    resources :deactivated_users, path: 'deactivated-users', only: [:index, :new, :create] do
       member do
-        get 'confirm_reactivate'
+        get 'confirm-reactivate'
         patch 'reactivate'
       end
     end
   end
 
+  # temp underscored routes
+  get 'manage_users', to: 'manage_users/active_users#index'
+  get 'manage_users/active_users', to: 'manage_users/active_users#index'
+  get 'manage_users/revive_users/:id/edit', to: 'manage_users/revive_users#edit'
+  get 'manage_users/change_roles/:id/edit', to: 'manage_users/change_roles#edit'
+  patch 'manage_users/change_roles/:id', to: 'manage_users/change_roles#update'
+  put 'manage_users/change_roles/:id', to: 'manage_users/change_roles#update'
+  get 'manage_users/invitations/:id/confirm_destroy', to: 'manage_users/invitations#confirm_destroy'
+  get 'manage_users/invitations/:id/confirm_renew', to: 'manage_users/invitations#confirm_renew'
+  get 'manage_users/deactivated_users/:id/confirm_reactivate', to: 'manage_users/deactivated_users#confirm_reactivate'
+  patch 'manage_users/deactivated_users/:id/reactivate', to: 'manage_users/deactivated_users#reactivate'
+  get 'manage_users/deactivated_users', to: 'manage_users/deactivated_users#index'
+  post 'manage_users/deactivated_users', to: 'manage_users/deactivated_users#create'
+  get 'manage_users/deactivated_users/new', to: 'manage_users/deactivated_users#new'
+
   namespace :api do
     resources :events, only: [:create]
   end
 
-  namespace :manage_competencies do
+  namespace :manage_competencies, path: 'manage-competencies' do
     root 'caseworker_competencies#index'
-    resources :caseworker_competencies, only: [:index, :edit, :update]
+    resources :caseworker_competencies, path: 'caseworker-competencies', only: [:index, :edit, :update]
     resources :history, only: [:show], controller: :history
   end
+
+  # temp underscored routes
+  get 'manage_competencies', to: 'manage_competencies/caseworker_competencies#index'
+  get 'manage_competencies/caseworker_competencies', to: 'manage_competencies/caseworker_competencies#index'
+  get 'manage_competencies/caseworker_competencies/:id/edit', to: 'manage_competencies/caseworker_competencies#edit'
+  patch 'manage_competencies/caseworker_competencies/:id', to: 'manage_competencies/caseworker_competencies#update'
+  put 'manage_competencies/caseworker_competencies/:id', to: 'manage_competencies/caseworker_competencies#update'
 
   root 'landing_page#index'
 end

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -55,6 +55,10 @@ RSpec.describe 'Authorisation' do
       crime_application_maat_decisions
       crime_application_send_decisions
       crime_application_what_do_you_want_to_do_next
+      application_searches_new
+      application_searches_search
+      assigned_applications_next_application
+      reporting
     ]
   end
 
@@ -77,6 +81,9 @@ RSpec.describe 'Authorisation' do
       new_manage_users_deactivated_user
       new_manage_users_invitation
       reactivate_manage_users_deactivated_user
+      manage_users
+      manage_users_deactivated_users_new
+      manage_competencies
     ]
   end
 
@@ -248,6 +255,7 @@ RSpec.describe 'Authorisation' do
       turbo_resume_historical_location
       user_azure_ad_omniauth_authorize
       user_azure_ad_omniauth_callback
+      sign_out
     ]
   end
 

--- a/spec/system/authenticating/a_signed_out_user_spec.rb
+++ b/spec/system/authenticating/a_signed_out_user_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Authenticating a signed out user' do
   before do
     click_on 'Sign out'
-    visit '/assigned_applications'
+    visit '/assigned-applications'
   end
 
   it 'the cannot access their list' do

--- a/spec/system/casework/deciding/adding_a_maat_decision_by_reference_spec.rb
+++ b/spec/system/casework/deciding/adding_a_maat_decision_by_reference_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Adding a decision by MAAT reference' do
       expect(page).to have_notification_banner(
         text: 'No MAAT ID found that links to LAA reference number 6000001'
       )
-      expect(current_path).to eq('/applications/696dd4fd-b619-4637-ab42-a5f4565bcf4a/link_maat_id')
+      expect(current_path).to eq('/applications/696dd4fd-b619-4637-ab42-a5f4565bcf4a/link-maat-id')
     end
   end
 

--- a/spec/system/errors_spec.rb
+++ b/spec/system/errors_spec.rb
@@ -124,14 +124,14 @@ RSpec.describe 'Error pages' do
       include_context 'with an existing user'
 
       it 'shows forbidden even if the user exists' do
-        visit "/manage_users/history/#{user.id}"
+        visit "/manage-users/history/#{user.id}"
         expect(page).to have_http_status :forbidden
-        visit '/manage_users/history/n0tan1d'
+        visit '/manage-users/history/n0tan1d'
         expect(page).to have_http_status :forbidden
       end
 
       it 'uses the errors layout' do
-        visit "/manage_users/history/#{user.id}"
+        visit "/manage-users/history/#{user.id}"
         expect(page).to have_no_css '#navigation'
         expect(page).to have_no_content 'Sign out'
       end
@@ -166,9 +166,9 @@ RSpec.describe 'Error pages' do
 
       it 'redirects to sign in even if the user exists' do
         expected_content = 'Sign in to access the service'
-        visit "/manage_users/history/#{user.id}"
+        visit "/manage-users/history/#{user.id}"
         expect(page).to have_content expected_content
-        visit '/manage_users/history/n0tan1d'
+        visit '/manage-users/history/n0tan1d'
         expect(page).to have_content expected_content
       end
     end
@@ -199,7 +199,7 @@ RSpec.describe 'Error pages' do
 
     context 'when visiting a link to manage a non existent user' do
       it 'show page not found' do
-        visit '/manage_users/history/n0tan1d'
+        visit '/manage-users/history/n0tan1d'
         expect(page).to have_content 'Page not found'
         expect(page).to have_http_status(:not_found)
       end

--- a/spec/system/manage_competencies/viewing_spec.rb
+++ b/spec/system/manage_competencies/viewing_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'Manage Competencies Dashboard' do
       end
     end
 
-    it_behaves_like 'a paginated page', path: '/manage_competencies?page=2'
+    it_behaves_like 'a paginated page', path: '/manage-competencies?page=2'
 
     it_behaves_like 'an ordered user list' do
       let(:path) { manage_competencies_root_path }

--- a/spec/system/manage_users/add_user_spec.rb
+++ b/spec/system/manage_users/add_user_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe 'Invites from manage users dashboard' do
   let(:notify_mailer_method) { :access_granted_email }
 
   before do
-    visit '/'
-    visit '/manage_users'
+    visit '/manage-users'
     click_on 'Invite a user'
   end
 

--- a/spec/system/manage_users/change_user_role_spec.rb
+++ b/spec/system/manage_users/change_user_role_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Change user role' do
       User.create!(can_manage_others: true, auth_subject_id: SecureRandom.uuid, email: 'test2@eg.com')
 
       active_user.update(role: 'supervisor')
-      visit '/manage_users/active_users'
+      visit '/manage-users/active-users'
 
       click_on('Zoe Blogs')
       click_on('Change role')
@@ -55,7 +55,7 @@ RSpec.describe 'Change user role' do
 
     context 'with UI based flow' do
       before do
-        visit '/manage_users/deactivated_users'
+        visit '/manage-users/deactivated-users'
         click_on('Zoe Blogs')
       end
 
@@ -67,7 +67,7 @@ RSpec.describe 'Change user role' do
 
     context 'with URL based flow' do
       before do
-        visit "/manage_users/change_roles/#{user.id}/edit"
+        visit "/manage-users/change-roles/#{user.id}/edit"
       end
 
       it 'is not found' do
@@ -86,7 +86,7 @@ RSpec.describe 'Change user role' do
 
     context 'with UI based flow' do
       before do
-        visit '/manage_users/active_users'
+        visit '/manage-users/active-users'
         click_on('Zoe Blogs')
       end
 
@@ -98,7 +98,7 @@ RSpec.describe 'Change user role' do
 
     context 'with URL based flow' do
       before do
-        visit "/manage_users/change_roles/#{user.id}/edit"
+        visit "/manage-users/change-roles/#{user.id}/edit"
       end
 
       it 'shows warning' do
@@ -113,7 +113,7 @@ RSpec.describe 'Change user role' do
   describe 'when admin manipulates the HTTP client' do
     context 'with their own user id' do
       before do
-        visit "/manage_users/change_roles/#{current_user.id}/edit"
+        visit "/manage-users/change-roles/#{current_user.id}/edit"
         choose 'Data analyst'
         click_on 'Save new role'
       end
@@ -129,7 +129,7 @@ RSpec.describe 'Change user role' do
   describe 'when no new role is selected' do
     before do
       active_user
-      visit '/manage_users/active_users'
+      visit '/manage-users/active-users'
       click_on('Zoe Blogs')
       click_on('Change role')
       click_on('Save new role')

--- a/spec/system/manage_users/revive_a_user_spec.rb
+++ b/spec/system/manage_users/revive_a_user_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Revive a user' do
 
   describe 'when admin revives dormant user' do
     before do
-      visit '/manage_users/active_users'
+      visit '/manage-users/active-users'
       click_on('Taylor Quick')
       click_on('Revive')
     end
@@ -78,7 +78,7 @@ RSpec.describe 'Revive a user' do
     context 'when the admin user views manage users dashboard' do
       before do
         login_as(current_user) # The admin user logs in
-        visit '/manage_users/active_users'
+        visit '/manage-users/active-users'
         click_on('Taylor Quick')
       end
 
@@ -116,7 +116,7 @@ RSpec.describe 'Revive a user' do
 
   describe 'when dormant user misses revive deadline' do
     before do
-      visit '/manage_users/active_users' # As admin
+      visit '/manage-users/active-users' # As admin
       click_on('Taylor Quick')
       click_on('Revive')
 
@@ -136,7 +136,7 @@ RSpec.describe 'Revive a user' do
     end
 
     it 'allows admin to begin revive process again' do
-      visit '/manage_users/active_users'
+      visit '/manage-users/active-users'
       click_on('Taylor Quick')
 
       within actions do
@@ -159,7 +159,7 @@ RSpec.describe 'Revive a user' do
     end
 
     it 'does not allow revival process' do
-      visit '/manage_users/deactivated_users'
+      visit '/manage-users/deactivated-users'
       click_on('Will I Am')
 
       within actions do
@@ -169,7 +169,7 @@ RSpec.describe 'Revive a user' do
   end
 
   def login_as(user)
-    visit '/sign_out'
+    visit '/sign-out'
     click_button 'Start now'
     select user.email
     click_button 'Sign in'

--- a/spec/system/manage_users/viewing_spec.rb
+++ b/spec/system/manage_users/viewing_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Manage Users Dashboard' do
       expect(first_data_row).to eq([current_user.name, current_user.email, 'Yes', 'Caseworker'].join(' '))
     end
 
-    it_behaves_like 'a paginated page', path: '/manage_users?page=2'
+    it_behaves_like 'a paginated page', path: '/manage-users?page=2'
     it_behaves_like 'an ordered user list' do
       let(:path) { manage_users_root_path }
       let(:expected_order) do


### PR DESCRIPTION
## Description of change
Updates the routes to use dashes instead of underscores.

Temporarily retains underscored paths to ensure that back links and form URLs don't break for users using the service at the time of deployment.

## Link to relevant ticket
[CRIMAPP-1503](https://dsdmoj.atlassian.net/browse/CRIMAPP-1503)

[CRIMAPP-1503]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ