### PR TITLE
CRIMAPP-1577 Store MAAT overall result and CaseType

### DIFF
--- a/app/aggregates/deciding/decision.rb
+++ b/app/aggregates/deciding/decision.rb
@@ -1,5 +1,5 @@
 module Deciding
-  class Decision
+  class Decision # rubocop:disable Metrics/ClassLength
     include AggregateRoot
 
     def initialize(decision_id)
@@ -7,7 +7,8 @@ module Deciding
     end
 
     attr_reader :application_id, :decision_id, :funding_decision, :comment,
-                :state, :reference, :maat_id, :checksum, :case_id, :means, :interests_of_justice
+                :state, :reference, :maat_id, :checksum, :case_id, :means, :interests_of_justice,
+                :court_type, :overall_result
 
     # When decision is drafted on Review by the caseworker (e.g. Non-means tested)
     def create_draft(application_id:, user_id:, reference:)
@@ -129,13 +130,15 @@ module Deciding
     def update_from_maat(maat_attributes)
       decision = Decisions::Draft.new(maat_attributes)
 
-      @maat_id = decision.maat_id
-      @reference = decision.reference
       @case_id = decision.case_id
-      @interests_of_justice = decision.interests_of_justice
-      @means = decision.means
-      @funding_decision = decision.funding_decision
       @checksum = decision.checksum
+      @court_type = decision.court_type
+      @funding_decision = decision.funding_decision
+      @interests_of_justice = decision.interests_of_justice
+      @maat_id = decision.maat_id
+      @means = decision.means
+      @overall_result = decision.overall_result
+      @reference = decision.reference
     end
 
     def complete?

--- a/app/components/decision_component.html.erb
+++ b/app/components/decision_component.html.erb
@@ -11,6 +11,13 @@
         end
       end
 
+      if means.present?
+        list.with_row do |row|
+          row.with_key { label_text(:means_court_type) }
+          row.with_value { value_text(court_type, scope: :court_type) }
+        end
+      end
+
       if interests_of_justice.present?
         list.with_row do |row|
           row.with_key { label_text(:ioj_result) }

--- a/app/components/decision_component.rb
+++ b/app/components/decision_component.rb
@@ -16,7 +16,7 @@ class DecisionComponent < ViewComponent::Base
 
   attr_reader :decision, :decision_iteration, :show_actions, :action_context
 
-  delegate :means, :interests_of_justice, to: :decision
+  delegate :means, :interests_of_justice, :court_type, to: :decision
 
   def actions
     return [] unless draft? && show_actions

--- a/app/models/decisions/draft.rb
+++ b/app/models/decisions/draft.rb
@@ -18,18 +18,20 @@ module Decisions
     end
 
     class << self
-      def build(aggregate)
+      def build(aggregate) # rubocop:disable Metrics/MethodLength
         new(
-          maat_id: aggregate.maat_id,
-          case_id: aggregate.case_id,
           application_id: aggregate.application_id,
-          reference: aggregate.reference,
-          interests_of_justice: aggregate.interests_of_justice,
-          means: aggregate.means,
-          funding_decision: aggregate.funding_decision,
+          case_id: aggregate.case_id,
+          checksum: aggregate.checksum,
           comment: aggregate.comment,
+          court_type: aggregate.court_type,
           decision_id: aggregate.decision_id,
-          checksum: aggregate.checksum
+          funding_decision: aggregate.funding_decision,
+          interests_of_justice: aggregate.interests_of_justice,
+          maat_id: aggregate.maat_id,
+          means: aggregate.means,
+          overall_result: aggregate.overall_result,
+          reference: aggregate.reference
         )
       end
     end

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -264,6 +264,7 @@ en:
     means_tested: Subject to means test?
     means_assessed_by: Means test caseworker
     means_assessed_on: Means test date
+    means_court_type: Means test
     means_details: Means reason
     means_result: Means test result
     name: Name
@@ -460,6 +461,9 @@ en:
     class: Class
     class_not_determined: Not determined
     change_in_financial_circumstances: Change in financial circumstances
+    court_type:
+      magistrates: Magistrates Court
+      crown: Crown Court
     date_stamp_context_changed: Changed after date stamp
     committal: Committal for sentence
     deleted_user_name: "[deleted]"
@@ -477,7 +481,7 @@ en:
       granted: Granted
       refused: Refused
       granted_failed_means: Granted - failed means test
-      granted_with_contribution: Granted - with contribution
+      granted_with_contribution: Granted - with a contribution
     either_way: Either way
     esa: Income-related Employment and Support Allowance (ESA)
     guarantee_pension: Guarantee Credit element of Pension Credit

--- a/spec/aggregates/reviewing/complete_spec.rb
+++ b/spec/aggregates/reviewing/complete_spec.rb
@@ -43,8 +43,17 @@ RSpec.describe Reviewing::Complete do
     let(:decisions) do
       [
         Decisions::Draft.new(
-          reference: reference, maat_id: nil, case_id: nil, interests_of_justice: nil, means: nil,
-          funding_decision: 'granted', comment: nil, decision_id: decision_id, application_id: application_id
+          reference: reference,
+          maat_id: nil,
+          case_id: nil,
+          interests_of_justice: nil,
+          means: nil,
+          funding_decision: 'granted',
+          comment: nil,
+          decision_id: decision_id,
+          application_id: application_id,
+          court_type: nil,
+          overall_result: nil
         ).as_json
       ]
     end

--- a/spec/components/decision_overall_result_component_spec.rb
+++ b/spec/components/decision_overall_result_component_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe DecisionOverallResultComponent, type: :component do
           instance_double(LaaCrimeSchemas::Structs::TestResult, result: 'passed_with_contribution')
         end
 
-        it { is_expected.to have_text('Granted - with contribution') }
+        it { is_expected.to have_text('Granted - with a contribution') }
         it { is_expected.to have_css('.govuk-tag--green') }
       end
 

--- a/spec/system/casework/deciding/adding_a_maat_decision_by_maat_id_spec.rb
+++ b/spec/system/casework/deciding/adding_a_maat_decision_by_maat_id_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe 'Adding a decision by MAAT ID' do
       Maat::Decision.new(
         maat_ref: maat_id,
         usn: 6_000_001,
+        case_id: 'NOL-123',
         ioj_result: 'FAIL',
         ioj_assessor_name: 'Jo Blogs',
         app_created_date: Date.new(2024, 2, 1),
@@ -63,6 +64,9 @@ RSpec.describe 'Adding a decision by MAAT ID' do
       )
 
       expect(summary_card('Case')).to have_rows(
+        'MAAT ID', '123',
+        'Case number', 'NOL-123',
+        'Means test', 'Magistrates Court',
         'Interests of justice (IoJ) test result', 'Failed',
         'IoJ comments', '',
         'IoJ caseworker', 'Jo Blogs',


### PR DESCRIPTION
## Description of change

- send the court_type and overall_result to datastore
- show the 'Means type' (court_type) on the decision summary card
-  ignore funding decision of MAAT decisions without a means result

## Link to relevant ticket
[CRIMAPP-1577](https://dsdmoj.atlassian.net/browse/CRIMAPP-1577)

## Notes for reviewer

The MAAT API can return partially completed results. During reassessment, the MAAT API maintains the previous funding decision until the means assessment is completed. Therefore, funding decisions that exist without a corresponding means result should be ignored.

## Screenshots of changes (if applicable)

### Before changes:

<img width="931" alt="Screenshot 2025-01-20 at 14 41 22" src="https://github.com/user-attachments/assets/531f6138-c132-4026-aa97-db8ccc0cd955" />


### After changes:

<img width="978" alt="Screenshot 2025-01-20 at 14 41 03" src="https://github.com/user-attachments/assets/0ec94275-8a03-4799-b76f-23d3afc3b64b" />


## How to manually test the feature


[CRIMAPP-1577]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ