### PR TITLE
CRIMAPP-1583 skip mark_as_ready if CIFC

### DIFF
--- a/app/aggregates/reviewing/available_reviewer_actions.rb
+++ b/app/aggregates/reviewing/available_reviewer_actions.rb
@@ -5,6 +5,10 @@ module Reviewing
         open: [:mark_as_ready, :send_back],
         marked_as_ready: [:complete, :send_back],
       },
+      cifc: {
+        open: [:complete, :send_back],
+        marked_as_ready: [:complete, :send_back]
+      },
       non_means: {
         open:  [:complete, :send_back],
       },
@@ -17,6 +21,10 @@ module Reviewing
       means: {
         open: [:mark_as_ready, :send_back],
         marked_as_ready: [:send_back],
+      },
+      cifc: {
+        open: [:send_back],
+        marked_as_ready: [:send_back]
       },
       non_means: {
         open:  [:send_back],
@@ -47,6 +55,7 @@ module Reviewing
     end
 
     def review_type
+      return Types::ReviewType[:cifc] if cifc?
       return Types::ReviewType[:pse] if pse?
       return Types::ReviewType[:non_means] if non_means?
 
@@ -55,6 +64,10 @@ module Reviewing
 
     def pse?
       application_type == Types::ApplicationType['post_submission_evidence']
+    end
+
+    def cifc?
+      application_type == Types::ApplicationType['change_in_financial_circumstances']
     end
 
     def non_means?

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -42,7 +42,7 @@ module Types
 
   DecisionState = Symbol.enum(*%i[draft sent_to_provider])
 
-  ReviewType = Symbol.enum(*%i[means non_means pse])
+  ReviewType = Symbol.enum(*%i[means non_means pse cifc])
 
   CourtType = String.enum('crown', 'magistrates')
 

--- a/spec/aggregates/reviewing/available_reviewer_actions_spec.rb
+++ b/spec/aggregates/reviewing/available_reviewer_actions_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Reviewing::AvailableReviewerActions do
         let(:application_type) { Types::ApplicationType['change_in_financial_circumstances'] }
         let(:work_stream) { WorkStream.new('criminal_applications_team') }
 
-        it { is_expected.to eq %i[mark_as_ready send_back] }
+        it { is_expected.to eq %i[complete send_back] }
       end
     end
 

--- a/spec/system/casework/deciding/adding_a_cifc_decision_spec.rb
+++ b/spec/system/casework/deciding/adding_a_cifc_decision_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe 'Adding a decision by MAAT ID' do
   before do
     visit crime_application_path(application_id)
     click_button 'Assign to your list'
-    click_button 'Mark as ready for MAAT'
     find('p', text: 'To add the funding decision, update the origional application in MAAT first.')
     click_button 'Add funding decision from MAAT'
     fill_in('MAAT ID', with: maat_id)

--- a/spec/system/casework/reviewing/a_cifc_application_spec.rb
+++ b/spec/system/casework/reviewing/a_cifc_application_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe 'Reviewing a CIFC application' do
 
   it 'can be completed by the caseworker' do
     expect(page).to have_content('Change in financial circumstances')
-    click_button 'Mark as ready for MAAT'
     click_button 'Mark as completed'
     expect(page).to have_content('You marked the application as complete')
   end


### PR DESCRIPTION
## Description of change

Skip "Mark as ready for MAAT" if CIFC

## Link to relevant ticket

[CRIMAPP-1583](https://dsdmoj.atlassian.net/browse/CRIMAPP-1583)

## Notes for reviewer
  
The review process for CIFC applications differs from "initial" means-assessed applications. Instead of creating a new MAAT record, the CIFC application links to the original application's MAAT decision. Caseworkers manually adjust the original decision's means information based on the CIFC application's details, making the "Mark as ready for MAAT" action unnecessary.

This issue was identified during the outcome playback work. However, this change to remove "Mark as ready for MAAT" for CIFC will also effect current CIFC applications (i.e. before the outcome playback feature is enabled).

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1579]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CRIMAPP-1583]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ