### PR TITLE
CRIMAPP-1597 revert to using eForm's overall result text

### DIFF
--- a/app/aggregates/deciding/commands/set_funding_decision.rb
+++ b/app/aggregates/deciding/commands/set_funding_decision.rb
@@ -5,7 +5,29 @@ module Deciding
 
     def call
       with_decision do |decision|
-        decision.set_funding_decision(user_id:, funding_decision:)
+        decision.set_funding_decision(
+          user_id:, funding_decision:, overall_result:
+        )
+      end
+    end
+
+    private
+
+    # Store the overall results string as it would appear in eForms.
+    def overall_result
+      Maat::OverallResultTranslator.translate(maat_funding_decision)
+    end
+
+    # Crime Review only creates decisions for Non-Means applications.
+    # If a funding decision is refused, we can infer that the application
+    # failed the IoJ test. Consequently, the MAAT funding decision
+    # should be recorded as FAILIOJ.
+    def maat_funding_decision
+      case funding_decision
+      when /granted/
+        'GRANTED'
+      when /refused/
+        'FAILIOJ'
       end
     end
   end

--- a/app/aggregates/deciding/decision.rb
+++ b/app/aggregates/deciding/decision.rb
@@ -51,8 +51,8 @@ module Deciding
       apply InterestsOfJusticeSet.build(self, user_id:, interests_of_justice:)
     end
 
-    def set_funding_decision(user_id:, funding_decision:)
-      apply FundingDecisionSet.build(self, user_id:, funding_decision:)
+    def set_funding_decision(user_id:, funding_decision:, overall_result: nil)
+      apply FundingDecisionSet.build(self, user_id:, funding_decision:, overall_result:)
     end
 
     def set_comment(user_id:, comment:)
@@ -101,6 +101,7 @@ module Deciding
 
     on FundingDecisionSet do |event|
       @funding_decision = event.data.fetch(:funding_decision)
+      @overall_result = event.data.fetch(:overall_result, nil)
     end
 
     on CommentSet do |event|

--- a/app/components/decision_overall_result_component.rb
+++ b/app/components/decision_overall_result_component.rb
@@ -2,46 +2,22 @@ class DecisionOverallResultComponent < ViewComponent::Base
   with_collection_parameter :decision
 
   def initialize(decision:)
-    @means_result = decision.means&.result
-    @funding_decision = decision.funding_decision
+    @decision = decision
 
     super
   end
 
   def call
-    return if funding_decision.nil?
+    return if overall_result.nil?
 
-    govuk_tag(
-      text: t(overall_result, scope: [:values, :decision_overall_result]),
-      colour: colour
-    )
+    govuk_tag(text: overall_result, colour: colour)
   end
 
   private
 
-  attr_reader :funding_decision, :means_result
+  attr_reader :decision
 
-  # TODO: move to the decision model if overall result decision confirmed
-  # otherwise use the MAAT decision
-  #
-  def overall_result
-    return 'granted_failed_means' if granted? && failed_means?
-    return 'granted_with_contribution' if granted? && with_contribution?
-
-    funding_decision
-  end
-
-  def granted?
-    funding_decision == Types::FundingDecision['granted']
-  end
-
-  def failed_means?
-    means_result == Types::TestResult['failed']
-  end
-
-  def with_contribution?
-    means_result == Types::TestResult['passed_with_contribution']
-  end
+  delegate :overall_result, :funding_decision, to: :decision
 
   def colour
     {

--- a/app/services/maat/decision_translator.rb
+++ b/app/services/maat/decision_translator.rb
@@ -64,15 +64,16 @@ module Maat
       end
     end
 
-    # Store the overall result as provided by the MAAT API and used by eForms.
-    # This is stored temporarily in case the simplified status values are not
-    # approved.
-    # Note: The MAAT API returns a string for Crown Court decisions and
-    # a constant for Magistrates Court decisions.
+    # Store the overall result in the format previously shown to eForms users.
+    # Storing the string since rules as to what is shown are complex and vary
+    # by court and case type.
+    #
+    # Note: The MAAT API returns a string for Crown Court decisions
+    # but a constant for Magistrates' Court decisions.
     def overall_result
       return maat_decision.cc_rep_decision if court_type == Types::CourtType['crown']
 
-      maat_decision.funding_decision
+      OverallResultTranslator.translate(maat_decision.funding_decision)
     end
 
     def crown_court_decision

--- a/app/services/maat/overall_result_translator.rb
+++ b/app/services/maat/overall_result_translator.rb
@@ -1,0 +1,14 @@
+module Maat
+  class OverallResultTranslator < BaseTranslator
+    EFORMS_OVERALL_RESULT_TEXT = {
+      'GRANTED' => 'Granted',
+      'FAILMEANS' => 'Failed Means',
+      'FAILIOJ' => 'Failed IoJ',
+      'FAILMEIOJ' => 'Failed Means & IoJ'
+    }.freeze
+
+    def translate
+      EFORMS_OVERALL_RESULT_TEXT.fetch(original, original)
+    end
+  end
+end

--- a/spec/aggregates/reviewing/complete_spec.rb
+++ b/spec/aggregates/reviewing/complete_spec.rb
@@ -48,12 +48,12 @@ RSpec.describe Reviewing::Complete do
           case_id: nil,
           interests_of_justice: nil,
           means: nil,
-          funding_decision: 'granted',
+          funding_decision: 'refused',
           comment: nil,
           decision_id: decision_id,
           application_id: application_id,
           court_type: nil,
-          overall_result: nil
+          overall_result: 'Failed IoJ'
         ).as_json
       ]
     end
@@ -67,7 +67,7 @@ RSpec.describe Reviewing::Complete do
 
       Reviewing::AddDecision.call(**args)
       Deciding::CreateDraft.call(**args)
-      Deciding::SetFundingDecision.call(**args, funding_decision: 'granted')
+      Deciding::SetFundingDecision.call(**args, funding_decision: 'refused')
     end
 
     it 'changes the state from :received to :completed' do

--- a/spec/components/decision_component_spec.rb
+++ b/spec/components/decision_component_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe DecisionComponent, type: :component do
       interests_of_justice: nil,
       means: nil,
       funding_decision: 'granted',
+      overall_result: 'Granted',
       comment: nil,
       maat_id: nil
     )

--- a/spec/components/decision_overall_result_component_spec.rb
+++ b/spec/components/decision_overall_result_component_spec.rb
@@ -4,53 +4,36 @@ RSpec.describe DecisionOverallResultComponent, type: :component do
   describe '.new' do
     subject(:tag) { page }
 
-    let(:decision) { instance_double Decisions::Draft, means:, funding_decision: }
+    let(:decision) { instance_double Decisions::Draft, overall_result:, funding_decision: }
     let(:funding_decision) { nil }
-    let(:means) { nil }
+    let(:overall_result) { nil }
 
     before do
       render_inline(described_class.new(decision:))
     end
 
-    context 'when funding decision is "granted"' do
+    context 'when funding is "granted"' do
       let(:funding_decision) { 'granted' }
+      let(:overall_result) { 'Granted - Passed Means Test' }
 
       it { is_expected.to have_text('Granted') }
       it { is_expected.to have_css('.govuk-tag--green') }
-
-      context 'when with contribution' do
-        let(:means) do
-          instance_double(LaaCrimeSchemas::Structs::TestResult, result: 'passed_with_contribution')
-        end
-
-        it { is_expected.to have_text('Granted - with contribution') }
-        it { is_expected.to have_css('.govuk-tag--green') }
-      end
-
-      context 'when failed means' do
-        let(:means) do
-          instance_double(LaaCrimeSchemas::Structs::TestResult, result: 'failed')
-        end
-
-        it { is_expected.to have_text('Granted - failed means test') }
-        it { is_expected.to have_css('.govuk-tag--green') }
-      end
     end
 
-    context 'when funding decision is "refuse"' do
+    context 'when funding is "refused"' do
       let(:funding_decision) { 'refused' }
+      let(:overall_result) { 'Refused - Ineligible' }
 
-      it { is_expected.to have_text('Refused') }
+      it { is_expected.to have_text('Refused - Ineligible') }
       it { is_expected.to have_css('.govuk-tag--red') }
+    end
 
-      context 'when failed means' do
-        let(:means) do
-          instance_double(LaaCrimeSchemas::Structs::TestResult, result: 'failed')
-        end
+    context 'when overall_result is nil' do
+      let(:funding_decision) { 'refused' }
+      let(:overall_result) { nil }
 
-        it { is_expected.to have_text('Refused') }
-        it { is_expected.to have_css('.govuk-tag--red') }
-      end
+      it { is_expected.to have_text('') }
+      it { is_expected.not_to have_css('.govuk-tag') }
     end
   end
 end

--- a/spec/services/maat/overall_result_translator_spec.rb
+++ b/spec/services/maat/overall_result_translator_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Maat::OverallResultTranslator do
+  expected_translations = [
+    'GRANTED', 'Granted',
+    'FAILMEANS', 'Failed Means',
+    'FAILIOJ', 'Failed IoJ',
+    'FAILMEIOJ', 'Failed Means & IoJ'
+  ]
+
+  it_behaves_like 'a MAAT value translator', expected_translations
+end

--- a/spec/support/decision_form_helpers.rb
+++ b/spec/support/decision_form_helpers.rb
@@ -1,14 +1,14 @@
 module DecisionFormHelpers
-  def complete_ioj_form
-    choose_answer('What is the interests of justice test result?', 'Passed')
+  def complete_ioj_form(result = 'Passed')
+    choose_answer('What is the interests of justice test result?', result)
     fill_in('What is the reason for this?', with: 'Test result reason details')
     fill_in('What is the name of the caseworker who assessed this?', with: 'Zoe Blogs')
     fill_date('Enter the date of assessment', with: Date.new(2024, 2, 1))
     save_and_continue
   end
 
-  def complete_overall_result_form
-    choose_answer('What is the funding decision for this application?', 'Granted')
+  def complete_overall_result_form(decision = 'Granted')
+    choose_answer('What is the funding decision for this application?', decision)
     save_and_continue
   end
 
@@ -21,6 +21,13 @@ module DecisionFormHelpers
     click_button 'Start'
     complete_ioj_form
     complete_overall_result_form
+    complete_comment_form
+  end
+
+  def add_a_failed_non_means_decision
+    click_button 'Start'
+    complete_ioj_form('Failed')
+    complete_overall_result_form('Refused')
     complete_comment_form
   end
 

--- a/spec/system/casework/deciding/adding_a_maat_decision_by_maat_id_spec.rb
+++ b/spec/system/casework/deciding/adding_a_maat_decision_by_maat_id_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Adding a decision by MAAT ID' do
         'Means test result', 'Failed',
         'Means test caseworker', 'Jan Blogs',
         'Means test date', '02/02/2024',
-        'Overall result', 'Refused'
+        'Overall result', 'Failed Means & IoJ'
       )
 
       expect(current_path).to eq(

--- a/spec/system/casework/deciding/submitting_a_non_means_decision_spec.rb
+++ b/spec/system/casework/deciding/submitting_a_non_means_decision_spec.rb
@@ -18,13 +18,14 @@ RSpec.describe 'Submitting a Non-means decision' do
             'reference' => 6_000_001,
             'maat_id' => nil,
             'interests_of_justice' => {
-              'result' => 'passed',
+              'result' => 'failed',
               'details' => 'reason',
               'assessed_by' => 'Test User',
               'assessed_on' => '2024-10-01 00:00:00'
             },
             'means' => nil,
-            'funding_decision' => 'granted',
+            'funding_decision' => 'refused',
+            'overall_result' => 'Failed IoJ',
             'comment' => 'Test comment'
           }
         ]
@@ -51,9 +52,12 @@ RSpec.describe 'Submitting a Non-means decision' do
     end
 
     it 'shows the confirmation page' do # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
-      add_a_non_means_decision
+      add_a_failed_non_means_decision
       expect(page).to have_content('Your list (1)')
-
+      expect(summary_card('Case')).to have_rows(
+        'Interests of justice (IoJ) test result', 'Failed',
+        'Overall result', 'Failed IoJ'
+      )
       choose_answer(send_decisions_form_prompt, 'Send decision to provider')
       save_and_continue
 
@@ -67,11 +71,11 @@ RSpec.describe 'Submitting a Non-means decision' do
       # NB: the decision displayed should be that from the datastore
       # not the event sourced decision.
       expect(summary_card('Case')).to have_rows(
-        'Interests of justice (IoJ) test result', 'Passed',
+        'Interests of justice (IoJ) test result', 'Failed',
         'IoJ comments', 'reason',
         'IoJ caseworker', 'Test User',
         'IoJ test date', '01/10/2024',
-        'Overall result', 'Granted',
+        'Overall result', 'Failed IoJ',
         'Comments', 'Test comment'
       )
     end


### PR DESCRIPTION
## Description of change

Revert to using eForm's overall result text

## Link to relevant ticket
[CRIMAPP-1597](https://dsdmoj.atlassian.net/browse/CRIMAPP-1597)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1597]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ