### PR TITLE
CRIMAPP-1597 store overall_result type rather than string

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.5.2'
+    tag: 'v1.6.0'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 99982c0576a5fe9defeaccab89e16f6e3c11fd93
-  tag: v1.5.2
+  revision: a47fd2b1127e5c67a2a31b52d42e13f77771c6da
+  tag: v1.6.0
   specs:
-    laa-criminal-legal-aid-schemas (1.5.2)
+    laa-criminal-legal-aid-schemas (1.6.0)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/aggregates/deciding/commands/set_funding_decision.rb
+++ b/app/aggregates/deciding/commands/set_funding_decision.rb
@@ -5,29 +5,7 @@ module Deciding
 
     def call
       with_decision do |decision|
-        decision.set_funding_decision(
-          user_id:, funding_decision:, overall_result:
-        )
-      end
-    end
-
-    private
-
-    # Store the overall results string as it would appear in eForms.
-    def overall_result
-      Maat::OverallResultTranslator.translate(maat_funding_decision)
-    end
-
-    # Crime Review only creates decisions for Non-Means applications.
-    # If a funding decision is refused, we can infer that the application
-    # failed the IoJ test. Consequently, the MAAT funding decision
-    # should be recorded as FAILIOJ.
-    def maat_funding_decision
-      case funding_decision
-      when /granted/
-        'GRANTED'
-      when /refused/
-        'FAILIOJ'
+        decision.set_funding_decision(user_id:, funding_decision:)
       end
     end
   end

--- a/app/aggregates/deciding/overall_result_calculator.rb
+++ b/app/aggregates/deciding/overall_result_calculator.rb
@@ -1,0 +1,60 @@
+module Deciding
+  class OverallResultCalculator
+    def initialize(decision)
+      @decision = decision
+    end
+
+    def calculate
+      return unless funding_decision
+
+      Types::OverallResult[
+        [funding_decision, qualification].compact.join('_')
+      ]
+    end
+
+    private
+
+    attr_reader :decision
+
+    def qualification
+      return refusal_qualification if refused?
+
+      grant_qualification if granted?
+    end
+
+    def refusal_qualification
+      return 'failed_ioj_and_means' if failed_means? && failed_ioj?
+      return 'failed_ioj' if failed_ioj?
+
+      'failed_means' if failed_means?
+    end
+
+    def grant_qualification
+      return 'failed_means' if failed_means?
+
+      'with_contribution' if with_contribution?
+    end
+
+    delegate :funding_decision, to: :decision
+
+    def failed_means?
+      decision.means&.result == 'failed'
+    end
+
+    def granted?
+      funding_decision == 'granted'
+    end
+
+    def refused?
+      funding_decision == 'refused'
+    end
+
+    def with_contribution?
+      decision.means&.result == 'passed_with_contribution'
+    end
+
+    def failed_ioj?
+      decision.interests_of_justice&.result == 'failed'
+    end
+  end
+end

--- a/app/components/decision_overall_result_component.rb
+++ b/app/components/decision_overall_result_component.rb
@@ -1,4 +1,6 @@
 class DecisionOverallResultComponent < ViewComponent::Base
+  include AppTextHelper
+
   with_collection_parameter :decision
 
   def initialize(decision:)
@@ -10,7 +12,7 @@ class DecisionOverallResultComponent < ViewComponent::Base
   def call
     return if overall_result.nil?
 
-    govuk_tag(text: overall_result, colour: colour)
+    govuk_tag(text: value_text(overall_result, scope: :decision_overall_result), colour: colour)
   end
 
   private

--- a/app/models/decisions/draft.rb
+++ b/app/models/decisions/draft.rb
@@ -5,6 +5,14 @@ module Decisions
     attribute? :application_id, Types::Uuid
     attribute? :court_type, Types::CourtType.optional
 
+    # NOTE: Allow strings for the overall result in draft decisions
+    # instead of restricting them to `Types::OverallResult`.
+    # This flexibility enables storing the `Maat::Decision` overall_result
+    # in the event, allowing comparison during the initial phase of
+    # the Outcome Playback release. However, only the `OverallResult` type,
+    # not the MAAT value, is stored in the datastore.
+    attribute? :overall_result, Types::String.optional
+
     def to_param
       { crime_application_id: application_id, decision_id: decision_id }
     end

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -479,9 +479,12 @@ en:
       refused: Refused
     decision_overall_result:
       granted: Granted
-      refused: Refused
-      granted_failed_means: Granted - failed means test
       granted_with_contribution: Granted - with contribution
+      granted_failed_means: Granted - failed means
+      refused: Refused
+      refused_failed_ioj: Refused - failed IoJ
+      refused_failed_ioj_and_means: Refused - failed IoJ & means
+      refused_failed_means: Refused - failed means
     either_way: Either way
     esa: Income-related Employment and Support Allowance (ESA)
     guarantee_pension: Guarantee Credit element of Pension Credit

--- a/spec/aggregates/deciding/overall_result_calculator_spec.rb
+++ b/spec/aggregates/deciding/overall_result_calculator_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe Deciding::OverallResultCalculator do
+  describe '#calculate' do
+    subject do
+      described_class.new(decision).calculate
+    end
+
+    let(:decision) do
+      instance_double(
+        LaaCrimeSchemas::Structs::Decision,
+        means: instance_double(
+          LaaCrimeSchemas::Structs::TestResult, result: means_result
+        ),
+        funding_decision: funding_decision,
+        interests_of_justice: instance_double(
+          LaaCrimeSchemas::Structs::TestResult, result: ioj_result
+        )
+      )
+    end
+
+    context 'when funding is granted' do
+      let(:funding_decision) { 'granted' }
+
+      context 'when means test is failed' do
+        let(:ioj_result) { 'passed' }
+        let(:means_result) { 'failed' }
+
+        it { is_expected.to eq('granted_failed_means') }
+      end
+
+      context 'when means test passed with contribution' do
+        let(:ioj_result) { 'passed' }
+        let(:means_result) { 'passed_with_contribution' }
+
+        it { is_expected.to eq('granted_with_contribution') }
+      end
+
+      context 'when means test fully passed' do
+        let(:ioj_result) { 'passed' }
+        let(:means_result) { 'passed' }
+
+        it { is_expected.to eq('granted') }
+      end
+    end
+
+    context 'when funding is refused' do
+      let(:funding_decision) { 'refused' }
+
+      context 'when both means and IoJ tests failed' do
+        let(:ioj_result) { 'failed' }
+        let(:means_result) { 'failed' }
+
+        it { is_expected.to eq('refused_failed_ioj_and_means') }
+      end
+
+      context 'when only IoJ test failed' do
+        let(:ioj_result) { 'failed' }
+        let(:means_result) { 'passed' }
+
+        it { is_expected.to eq('refused_failed_ioj') }
+      end
+
+      context 'when only means test failed' do
+        let(:ioj_result) { 'passed' }
+        let(:means_result) { 'failed' }
+
+        it { is_expected.to eq('refused_failed_means') }
+      end
+
+      context 'when neither test failed' do
+        let(:ioj_result) { 'passed' }
+        let(:means_result) { 'passed' }
+
+        it { is_expected.to eq('refused') }
+      end
+    end
+  end
+end

--- a/spec/aggregates/reviewing/complete_spec.rb
+++ b/spec/aggregates/reviewing/complete_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Reviewing::Complete do
           decision_id: decision_id,
           application_id: application_id,
           court_type: nil,
-          overall_result: 'Failed IoJ'
+          overall_result: 'refused'
         ).as_json
       ]
     end

--- a/spec/components/decision_component_spec.rb
+++ b/spec/components/decision_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DecisionComponent, type: :component do
       interests_of_justice: nil,
       means: nil,
       funding_decision: 'granted',
-      overall_result: 'Granted',
+      overall_result: 'granted',
       comment: nil,
       maat_id: nil
     )

--- a/spec/components/decision_overall_result_component_spec.rb
+++ b/spec/components/decision_overall_result_component_spec.rb
@@ -16,15 +16,15 @@ RSpec.describe DecisionOverallResultComponent, type: :component do
       let(:funding_decision) { 'granted' }
       let(:overall_result) { Types::OverallResult['granted_with_contribution'] }
 
-      it { is_expected.to have_text('Granted') }
+      it { is_expected.to have_text('Granted - with contribution', exact: true) }
       it { is_expected.to have_css('.govuk-tag--green') }
     end
 
     context 'when funding is "refused"' do
       let(:funding_decision) { 'refused' }
-      let(:overall_result) { 'refused' }
+      let(:overall_result) { 'refused_failed_ioj_and_means' }
 
-      it { is_expected.to have_text('Refused') }
+      it { is_expected.to have_text('Refused - failed IoJ & means', exact: true) }
       it { is_expected.to have_css('.govuk-tag--red') }
     end
 
@@ -32,7 +32,7 @@ RSpec.describe DecisionOverallResultComponent, type: :component do
       let(:funding_decision) { 'refused' }
       let(:overall_result) { nil }
 
-      it { is_expected.to have_text('') }
+      it { is_expected.to have_text('', exact: true) }
       it { is_expected.not_to have_css('.govuk-tag') }
     end
 

--- a/spec/components/decision_overall_result_component_spec.rb
+++ b/spec/components/decision_overall_result_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DecisionOverallResultComponent, type: :component do
 
     context 'when funding is "granted"' do
       let(:funding_decision) { 'granted' }
-      let(:overall_result) { 'Granted - Passed Means Test' }
+      let(:overall_result) { Types::OverallResult['granted_with_contribution'] }
 
       it { is_expected.to have_text('Granted') }
       it { is_expected.to have_css('.govuk-tag--green') }
@@ -22,9 +22,9 @@ RSpec.describe DecisionOverallResultComponent, type: :component do
 
     context 'when funding is "refused"' do
       let(:funding_decision) { 'refused' }
-      let(:overall_result) { 'Refused - Ineligible' }
+      let(:overall_result) { 'refused' }
 
-      it { is_expected.to have_text('Refused - Ineligible') }
+      it { is_expected.to have_text('Refused') }
       it { is_expected.to have_css('.govuk-tag--red') }
     end
 
@@ -34,6 +34,22 @@ RSpec.describe DecisionOverallResultComponent, type: :component do
 
       it { is_expected.to have_text('') }
       it { is_expected.not_to have_css('.govuk-tag') }
+    end
+
+    describe 'overall result text' do
+      [
+        'granted', 'Granted',
+        'granted_with_contribution', 'Granted - with contribution',
+        'granted_failed_means', 'Granted - failed means',
+        'refused', 'Refused',
+        'refused_failed_ioj', 'Refused - failed IoJ',
+        'refused_failed_ioj_and_means', 'Refused - failed IoJ & means',
+        'refused_failed_means', 'Refused - failed means'
+      ].each_slice(2).each do |type, text|
+        it "translates #{type} to #{text}" do
+          expect(I18n.t(type, scope: [:values, :decision_overall_result])).to eq(text)
+        end
+      end
     end
   end
 end

--- a/spec/system/casework/deciding/adding_a_maat_decision_by_maat_id_spec.rb
+++ b/spec/system/casework/deciding/adding_a_maat_decision_by_maat_id_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Adding a decision by MAAT ID' do
         'Means test result', 'Failed',
         'Means test caseworker', 'Jan Blogs',
         'Means test date', '02/02/2024',
-        'Overall result', 'Failed Means & IoJ'
+        'Overall result', 'Refused - failed IoJ & means'
       )
 
       expect(current_path).to eq(

--- a/spec/system/casework/deciding/submitting_a_non_means_decision_spec.rb
+++ b/spec/system/casework/deciding/submitting_a_non_means_decision_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Submitting a Non-means decision' do
             },
             'means' => nil,
             'funding_decision' => 'refused',
-            'overall_result' => 'Failed IoJ',
+            'overall_result' => Types::OverallResult['refused_failed_ioj'],
             'comment' => 'Test comment'
           }
         ]
@@ -56,7 +56,7 @@ RSpec.describe 'Submitting a Non-means decision' do
       expect(page).to have_content('Your list (1)')
       expect(summary_card('Case')).to have_rows(
         'Interests of justice (IoJ) test result', 'Failed',
-        'Overall result', 'Failed IoJ'
+        'Overall result', 'Refused - failed IoJ'
       )
       choose_answer(send_decisions_form_prompt, 'Send decision to provider')
       save_and_continue
@@ -75,7 +75,7 @@ RSpec.describe 'Submitting a Non-means decision' do
         'IoJ comments', 'reason',
         'IoJ caseworker', 'Test User',
         'IoJ test date', '01/10/2024',
-        'Overall result', 'Failed IoJ',
+        'Overall result', 'Refused - failed IoJ',
         'Comments', 'Test comment'
       )
     end


### PR DESCRIPTION
## Description of change
Store the overall result as a type. 

## Link to relevant ticket

[CRIMAPP-1597](https://dsdmoj.atlassian.net/browse/CRIMAPP-1597)

## Notes for reviewer

The initial plan was to store MAAT strings directly in the datastore overall_result, as MAAT is the source of truth for decisions and its logic is complex. However, testing has shown that these strings do not fully meet providers' needs and may cause confusion.

Instead, we will store a constant representing the overall result, which clients can translate into text as needed. This result will combine the funding_decision with any relevant qualifications that help providers understand the next steps.

The overall result is now displayed to the user in the format funding_decision - qualification, e.g., "Granted - with contribution" or "Refused - failed IoJ". In the datastore, these values are stored as types, such as `granted_with_contribution` and `refused_failed_ioj`.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1597]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ