### PR TITLE
[CRIMAPP-1523] Target AWS secrets on production

### DIFF
--- a/config/kubernetes/production/deployment.tpl
+++ b/config/kubernetes/production/deployment.tpl
@@ -71,7 +71,7 @@ spec:
           - configMapRef:
               name: configmap-production
           - secretRef:
-              name: secrets-production
+              name: laa-review-criminal-legal-aid-secrets
         env:
           # secrets created by terraform
           - name: DATABASE_URL


### PR DESCRIPTION
## Description of change

Update to the deployment file to target the new secrets generated by AWS Secrets Manager on production.

## Link to relevant ticket
[CRIMAPP-1523](https://dsdmoj.atlassian.net/browse/CRIMAPP-1523)

[CRIMAPP-1523]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ