### PR TITLE
[CRIMAPP-1589] unlink draft decisions on return to provider

### DIFF
--- a/app/aggregates/deciding.rb
+++ b/app/aggregates/deciding.rb
@@ -23,4 +23,12 @@ module Deciding
       "Deciding$#{decision_id}"
     end
   end
+
+  class Configuration
+    def call(event_store)
+      event_store.subscribe(to: [Reviewing::DecisionRemoved]) do |event|
+        Deciding::Unlink.call(event.data.slice(:application_id, :decision_id, :user_id))
+      end
+    end
+  end
 end

--- a/app/aggregates/deciding/commands/unlink.rb
+++ b/app/aggregates/deciding/commands/unlink.rb
@@ -6,10 +6,7 @@ module Deciding
 
     def call
       with_decision do |decision|
-        ActiveRecord::Base.transaction do
-          decision.unlink(application_id:, user_id:)
-          Reviewing::RemoveDecision.call(decision_id:, application_id:, user_id:)
-        end
+        decision.unlink(application_id:, user_id:)
       end
     end
   end

--- a/app/aggregates/reviewing/commands/send_back.rb
+++ b/app/aggregates/reviewing/commands/send_back.rb
@@ -10,15 +10,19 @@ module Reviewing
           review.send_back(user_id:, reason:)
         end
 
-        DatastoreApi::Requests::UpdateApplication.new(
-          application_id: application_id,
-          payload: { return_details: },
-          member: :return
-        ).call
+        update_datastore
       end
     end
 
     private
+
+    def update_datastore
+      DatastoreApi::Requests::UpdateApplication.new(
+        application_id: application_id,
+        payload: { return_details: },
+        member: :return
+      ).call
+    end
 
     def reason
       return_details.fetch(:reason)

--- a/app/controllers/casework/maat_decisions_controller.rb
+++ b/app/controllers/casework/maat_decisions_controller.rb
@@ -52,7 +52,7 @@ module Casework
     end
 
     def destroy
-      Deciding::Unlink.call(
+      Reviewing::RemoveDecision.call(
         application_id: @crime_application.id,
         user_id: current_user_id,
         decision_id: @decision.decision_id

--- a/app/controllers/casework/returns_controller.rb
+++ b/app/controllers/casework/returns_controller.rb
@@ -1,21 +1,19 @@
 module Casework
   class ReturnsController < Casework::BaseController
     before_action :set_crime_application
+    before_action :set_return_details
 
-    def new
-      @return_details = ReturnDetails.new
-    end
+    def new; end
 
     def create
-      @return_details = ReturnDetails.new(return_params)
-
       @return_details.validate!
 
-      Reviewing::SendBack.new(
-        application_id: params[:crime_application_id],
-        user_id: current_user_id,
-        return_details: @return_details.attributes
-      ).call
+      @crime_application.decision_ids.each do |decision_id|
+        Reviewing::RemoveDecision.call(application_id:, user_id:, decision_id:)
+      end
+
+      return_details = @return_details.attributes
+      Reviewing::SendBack.call(application_id:, user_id:, return_details:)
 
       flash_and_redirect :success, :sent_back
     rescue ActiveModel::ValidationError
@@ -25,6 +23,12 @@ module Casework
     end
 
     private
+
+    alias user_id current_user_id
+
+    def application_id
+      @crime_application.id
+    end
 
     def flash_and_redirect(key, message)
       flash[key] = I18n.t(message, scope: [:flash, key])
@@ -36,7 +40,13 @@ module Casework
     end
 
     def return_params
+      return {} unless params[:return_details]
+
       params[:return_details].permit(:reason, :details)
+    end
+
+    def set_return_details
+      @return_details = ReturnDetails.new(return_params)
     end
   end
 end

--- a/app/views/casework/returns/new.html.erb
+++ b/app/views/casework/returns/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('.page_title') %>
+<% title t('.header', applicant_name: @crime_application.applicant.full_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -19,9 +19,10 @@
       <% end %>
 
       <%= f.govuk_text_area :details,
-                            label: { text: t(:return_reason_details_legend, scope: 'labels'), class: 'govuk-label--m' },
-                            hint: { text: t(:return_reason_details, scope: 'labels') },
+                            label: { text: label_text(:return_reason_details_legend), class: 'govuk-label--m' },
                             autocomplete: 'off' %>
+
+      <%= govuk_inset_text(text: label_text(:return_unlink_notice)) if @crime_application.draft_decisions.any? %>
 
       <%= f.govuk_submit t(:send_back, scope: 'calls_to_action') %>
     <% end %>

--- a/config/initializers/event_store.rb
+++ b/config/initializers/event_store.rb
@@ -1,10 +1,13 @@
 Rails.configuration.to_prepare do
   event_store = Rails.configuration.event_store = RailsEventStore::Client.new
 
-  #Notifying
+  # Notifying
   NotifierConfiguration.new.call(event_store)
-  
-  #Read Models
+
+  # Deciding
+  Deciding::Configuration.new.call(event_store)
+
+  # Read Models
   CurrentAssignments::Configuration.new.call(event_store)
   ReceivedOnReports::Configuration.new.call(event_store)
   Reviews::Configuration.new.call(event_store)

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -342,8 +342,8 @@ en:
     relationship_to_client: Relationship to client
     relationship_to_owner_of_usual_home_address: Relationship to client
     residence_type: Where the client usually lives
-    return_reason_details: We'll share this information with the provider
-    return_reason_details_legend: Give further details
+    return_reason_details_legend: Give details
+    return_unlink_notice: Any linked MAAT IDs will be removed.
     same_court_as_first_hearing: Same court as first hearing?
     saving_account_balance: Account balance
     saving_account_holder: Name the account is in
@@ -360,7 +360,7 @@ en:
     savings_and_investments: "Capital: Savings and investments"
     search_criteria: Search criteria
     search_text: Reference number or applicant's first or last name
-    select_return_reason: Select the reason for returning this application
+    select_return_reason: Why are you returning this application?
     separation_date: Date client separated from partner
     start_on: Date from
     supporting_evidence: Supporting evidence and information
@@ -562,12 +562,12 @@ en:
       assigned: All assigned
       unassigned: Unassigned
     return_reason:
-      clarification_required: Clarification required
+      clarification_required: Need clarification
       evidence_issue: Evidence issue
       duplicate_application: Duplicate application
-      case_concluded: Case has already concluded
+      case_concluded: Case already concluded
       provider_request: Provider request
-      split_case: The case has been split, so we need justification for all offences
+      split_case: Split case, so justification needed for all offences
     color:
       submitted: blue
       open: blue
@@ -769,8 +769,7 @@ en:
 
     returns:
       new:
-        page_title: Send back application
-        header: "Send %{applicant_name}'s application back to the provider"
+        header: "Return %{applicant_name}'s application to provider"
 
     completes:
       show:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,6 +73,7 @@ RSpec.configure do |config|
     CurrentAssignments::Configuration.new.call(event_store)
     Reviews::Configuration.new.call(event_store)
     CaseworkerReports::Configuration.new.call(event_store)
+    Deciding::Configuration.new.call(event_store)
   end
 
   # Use production error handling in these specs

--- a/spec/system/casework/deciding/adding_another_maat_decision_spec.rb
+++ b/spec/system/casework/deciding/adding_another_maat_decision_spec.rb
@@ -71,4 +71,17 @@ RSpec.describe 'Adding another MAAT decision' do
 
     expect(current_path).to eq(assigned_applications_path)
   end
+
+  it 'removes the decisions if application is returned to provider' do
+    click_link 'View application'
+    click_link 'Send back to provider'
+
+    expect(page).to have_content('Any linked MAAT IDs will be removed.')
+    choose 'Evidence issue'
+    fill_in 'return-details-details-field', with: 'As requested'
+
+    expect { click_button('Send back to provider') }
+      .to(change { Deciding::LoadDecision.call(decision_id: maat_id).application_id }.to(nil)
+        .and(change { Deciding::LoadDecision.call(decision_id: maat_id2).application_id }.to(nil)))
+  end
 end

--- a/spec/system/casework/reviewing/send_back_to_provider_spec.rb
+++ b/spec/system/casework/reviewing/send_back_to_provider_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Send an application back to the provider' do
       end
 
       it 'shows the applicant name in the heading' do
-        expect(page).to have_content "Send Kit Pound's application back to the provider"
+        expect(page).to have_content "Return Kit Pound's application to provider"
       end
 
       it 'requires further details' do


### PR DESCRIPTION
## Description of change

Unlink draft decisions on return to provider
Content updates to the return to provider confirm page

## Link to relevant ticket

[CRIMAPP-1589](https://dsdmoj.atlassian.net/browse/CRIMAPP-1589)

## Notes for reviewer
Otherwise resubmissions will not be able to link decisions linked to the original application.

## Screenshots of changes (if applicable)

### Before changes:

<img width="686" alt="Screenshot 2025-02-07 at 17 31 39" src="https://github.com/user-attachments/assets/e0795993-3801-4951-9b21-f7a994078766" />


### After changes:

<img width="652" alt="Screenshot 2025-02-07 at 17 31 04" src="https://github.com/user-attachments/assets/0aee5466-00bf-4382-a244-5b512230981b" />


## How to manually test the feature


[CRIMAPP-1589]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ