### PR TITLE
[CRIMAPP-1606] Content updates

### DIFF
--- a/app/views/casework/decisions/comments/edit.html.erb
+++ b/app/views/casework/decisions/comments/edit.html.erb
@@ -26,7 +26,7 @@
   <% if @decision.complete? %>
     <div class="govuk-grid-column-two-thirds">
       <%= form_with model: @form_object, url: crime_application_decision_comment_path, method: :put do |f| %>
-        <%= f.govuk_text_area :comment, label: { size: 'm' } %>
+        <%= f.govuk_text_area :comment, label: { tag: 'h3', size: 'm' } %>
         <div class="govuk-button-group govuk-!-margin-bottom-6">
           <%= f.govuk_submit %>
           <%= govuk_button_link_to action_text(:save_and_come_back), assigned_applications_path, secondary: true %>

--- a/app/views/casework/decisions/interests_of_justices/edit.html.erb
+++ b/app/views/casework/decisions/interests_of_justices/edit.html.erb
@@ -7,13 +7,11 @@
       <%= govuk_link_to(t('calls_to_action.view_application'), crime_application_path(@crime_application), no_visited_state: true) %>
     </p>
 
-    <h2 class="govuk-heading-xl govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
       <%= @crime_application.applicant.full_name %>
-    </h2>
-
-    <h1 class="govuk-heading-xl">
-      <%= t '.title' %>
     </h1>
+
+    <h2 class="govuk-heading-l"> <%= t '.title' %> </h2>
 
     <%= form_with model: @form_object,
                   url: crime_application_decision_interests_of_justice_path, method: :put do |f| %>
@@ -22,10 +20,11 @@
 
       <%= f.govuk_collection_radio_buttons :result,
                                            @form_object.possible_results,
-                                           :to_s %>
-      <%= f.govuk_text_area :details %>
-      <%= f.govuk_text_field :assessed_by, autocomplete: 'off' %>
-      <%= f.govuk_date_field :assessed_on, maxlength_enabled: true, autocomplete: 'off' %>
+                                           :to_s,
+                                           legend: { tag: 'h3', size: 'm' } %>
+      <%= f.govuk_text_area :details, label: { tag: 'h3', size: 'm' } %>
+      <%= f.govuk_text_field :assessed_by, autocomplete: 'off', label: { tag: 'h3', size: 'm' }  %>
+      <%= f.govuk_date_field :assessed_on, maxlength_enabled: true, autocomplete: 'off', legend: { tag: 'h3', size: 'm' }  %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/casework/decisions/overall_results/edit.html.erb
+++ b/app/views/casework/decisions/overall_results/edit.html.erb
@@ -11,14 +11,12 @@
       <%= @crime_application.applicant.full_name %>
     </h2>
 
-    <h1 class="govuk-heading-xl">
-      <%= t '.title' %>
-    </h1>
+    <h2 class="govuk-heading-l"> <%= t '.title' %> </h2>
 
     <%= form_with model: @form_object,
                   url: crime_application_decision_overall_result_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_collection_radio_buttons :funding_decision, @form_object.possible_decisions, :to_s %>
+      <%= f.govuk_collection_radio_buttons :funding_decision, @form_object.possible_decisions, :to_s, legend: { tag: 'h3', size: 'm' } %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/casework/maat_decisions/new.html.erb
+++ b/app/views/casework/maat_decisions/new.html.erb
@@ -7,15 +7,13 @@
       <%= govuk_link_to(t('calls_to_action.view_application'), crime_application_path(@crime_application), no_visited_state: true) %>
     </p>
 
-    <h2 class="govuk-heading-xl govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
       <%= @crime_application.applicant.full_name %>
-    </h2>
+    </h1>
 
     <%= govuk_error_summary(@form_object) %>
 
-    <h1 class="govuk-heading-xl">
-      <%= t '.title' %>
-    </h1>
+    <h2 class="govuk-heading-l"> <%= t '.title' %> </h2>
 
     <%= form_with model: @form_object,
                   url: crime_application_maat_decisions_path do |f| %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -12,7 +12,7 @@ en:
   flash:
     success:
       assigned_to_self: You assigned this application to your list
-      completed: You marked the application as complete # TODO: CRIMAPP-1606
+      completed: You marked the application as complete
       completed_with_decisions: Application complete. Decision sent to provider.
       decision_removed: Decision removed
       marked_as_ready: Application ready for assessment in MAAT.

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -12,10 +12,10 @@ en:
   flash:
     success:
       assigned_to_self: You assigned this application to your list
-      completed: You marked the application as complete
+      completed: You marked the application as complete # TODO: CRIMAPP-1606
       completed_with_decisions: Application complete. Decision sent to provider.
       decision_removed: Decision removed
-      marked_as_ready: You marked the application as ready for assessment
+      marked_as_ready: Application ready for assessment in MAAT.
       sent_back: You sent the application back to the provider
       unassigned_from_self: You removed the application from your list
       maat_decision_linked:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -7,13 +7,13 @@ en:
       add_another_decision:
         inclusion: Select yes to add another case
       assessed_by: 
-        blank: Enter the name of the caseworker who assessed this
+        blank: Enter the caseworker name
       assessed_on: 
-        blank: Enter the date of assessment
+        blank: Enter the date of the test
       base: 
         incomplete_decisions: Complete decision details first
       details:
-        blank: Give further details
+        blank: Enter a reason for the result
       email:
         blank: Enter an email
         invalid: Invalid email format
@@ -24,8 +24,8 @@ en:
       reason:
         inclusion: Choose a reason
       result: 
-        blank: Select the test result
-        inclusion: Select the test result
+        blank: Select a result for the Interest of justice test
+        inclusion: Select a result for the Interest of justice test
       maat_id:
         blank: &invalid_maat_id "Enter a valid MAAT ID"
         greated_than: *invalid_maat_id

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -9,7 +9,7 @@ en:
       assessed_by: 
         blank: Enter the name of the caseworker who assessed this
       assessed_on: 
-        blank: Enter the date of assessemnt
+        blank: Enter the date of assessment
       base: 
         incomplete_decisions: Complete decision details first
       details:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -12,8 +12,8 @@ en:
 
     legend:
       decisions_interests_of_justice_form:
-        result: What is the interests of justice test result?
-        assessed_on: Enter the date of assessment
+        result: Interests of justice test result
+        assessed_on: Date of test
       decisions_overall_result_form:
         funding_decision: What is the funding decision for this application?
       decisions_comment_form:
@@ -30,8 +30,8 @@ en:
         result_options:
           passed: Passed
           failed: Failed
-        details: What is the reason for this?
-        assessed_by: What is the name of the caseworker who assessed this?
+        details: Reason for result
+        assessed_by: Caseworker name
       decisions_overall_result_form:
         funding_decision_options:
           granted: Granted

--- a/config/locales/en/reporting.yml
+++ b/config/locales/en/reporting.yml
@@ -36,7 +36,7 @@ en:
       weekly: week 
       daily: day 
   table_headings:
-    application_type: Type of application
+    application_type: Application type
     applications_closed: Number of closed applications
     applications_received: Applications received
     assigned_to_user: "from<br>list"

--- a/spec/support/decision_form_helpers.rb
+++ b/spec/support/decision_form_helpers.rb
@@ -1,9 +1,9 @@
 module DecisionFormHelpers
   def complete_ioj_form(result = 'Passed')
-    choose_answer('What is the interests of justice test result?', result)
-    fill_in('What is the reason for this?', with: 'Test result reason details')
-    fill_in('What is the name of the caseworker who assessed this?', with: 'Zoe Blogs')
-    fill_date('Enter the date of assessment', with: Date.new(2024, 2, 1))
+    choose_answer('Interests of justice test result', result)
+    fill_in('Reason for result', with: 'Test result reason details')
+    fill_in('Caseworker name', with: 'Zoe Blogs')
+    fill_date('Date of test', with: Date.new(2024, 2, 1))
     save_and_continue
   end
 

--- a/spec/system/casework/assigning/viewing_your_assigned_applications_spec.rb
+++ b/spec/system/casework/assigning/viewing_your_assigned_applications_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'Viewing your assigned application' do
       column_headings = page.all('thead tr th.govuk-table__header').map(&:text)
 
       expect(column_headings).to contain_exactly(
-        "Applicant's name", 'Reference number', 'Type of application', 'Type of work', 'Date received',
+        "Applicant's name", 'Reference number', 'Application type', 'Type of work', 'Date received',
         'Business days since received'
       )
     end
@@ -85,7 +85,7 @@ RSpec.describe 'Viewing your assigned application' do
     it_behaves_like 'a table with sortable headers' do
       let(:active_sort_headers) { ['Date received', 'Business days since received'] }
       let(:active_sort_direction) { 'ascending' }
-      let(:inactive_sort_headers) { ['Applicant\'s name', 'Type of application'] }
+      let(:inactive_sort_headers) { ['Applicant\'s name', 'Application type'] }
     end
   end
 

--- a/spec/system/casework/closed_applications_dashboard_spec.rb
+++ b/spec/system/casework/closed_applications_dashboard_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Closed Applications' do
     expected_headings = [
       "Applicant's name",
       'Reference number',
-      'Type of application',
+      'Application type',
       'Date received',
       'Date closed',
       'Closed by',
@@ -86,7 +86,7 @@ RSpec.describe 'Closed Applications' do
   it_behaves_like 'a table with sortable headers' do
     let(:active_sort_headers) { ['Date closed'] }
     let(:active_sort_direction) { 'descending' }
-    let(:inactive_sort_headers) { ['Applicant\'s name', 'Date received', 'Type of application'] }
+    let(:inactive_sort_headers) { ['Applicant\'s name', 'Date received', 'Application type'] }
   end
 
   context 'when work stream feature flag is enabled' do

--- a/spec/system/casework/deciding/adding_a_non_means_decision_spec.rb
+++ b/spec/system/casework/deciding/adding_a_non_means_decision_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe 'Adding a Non-means application' do
       save_and_continue
 
       expect(page).to have_errors(
-        'Caseworker name', 'Enter the name of the caseworker who assessed this',
-        'Interests of justice test result', 'Select the test result',
-        'Reason for result', 'Give further details',
-        'Date of test', 'Enter the date of assessment'
+        'Caseworker name', 'Enter the caseworker name',
+        'Interests of justice test result', 'Select a result for the Interest of justice test',
+        'Reason for result', 'Enter a reason for the result',
+        'Date of test', 'Enter the date of the test'
       )
     end
 

--- a/spec/system/casework/deciding/adding_a_non_means_decision_spec.rb
+++ b/spec/system/casework/deciding/adding_a_non_means_decision_spec.rb
@@ -32,13 +32,10 @@ RSpec.describe 'Adding a Non-means application' do
       save_and_continue
 
       expect(page).to have_errors(
-        'What is the name of the caseworker who assessed this?',
-        'Enter the name of the caseworker who assessed this',
-        'What is the interests of justice test result?',
-        'Select the test result',
-        'What is the name of the caseworker who assessed this?',
-        'Enter the name of the caseworker who assessed this',
-        'Enter the date of assessment', 'Enter the date of assessemnt'
+        'Caseworker name', 'Enter the name of the caseworker who assessed this',
+        'Interests of justice test result', 'Select the test result',
+        'Reason for result', 'Give further details',
+        'Date of test', 'Enter the date of assessment'
       )
     end
 

--- a/spec/system/casework/open_applications_dashboard_spec.rb
+++ b/spec/system/casework/open_applications_dashboard_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Open Applications' do
   it 'includes the correct headings' do
     column_headings = page.all('.app-table thead tr th.govuk-table__header').map(&:text)
 
-    expect(column_headings).to eq(["Applicant's name", 'Reference number', 'Type of application', 'Date received',
+    expect(column_headings).to eq(["Applicant's name", 'Reference number', 'Application type', 'Date received',
                                    'Business days since received', 'Caseworker'])
   end
 
@@ -58,7 +58,7 @@ RSpec.describe 'Open Applications' do
   it_behaves_like 'a table with sortable headers' do
     let(:active_sort_headers) { ['Date received', 'Business days since received'] }
     let(:active_sort_direction) { 'ascending' }
-    let(:inactive_sort_headers) { ['Applicant\'s name', 'Type of application'] }
+    let(:inactive_sort_headers) { ['Applicant\'s name', 'Application type'] }
   end
 
   it 'includes tabs for work streams' do

--- a/spec/system/casework/reviewing/mark_application_as_ready_spec.rb
+++ b/spec/system/casework/reviewing/mark_application_as_ready_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Marking an application as ready for assessment' do
 
     it 'shows success flash message' do
       click_button(ready_for_assessment_cta)
-      expect(page).to have_content('You marked the application as ready for assessment')
+      expect(page).to have_content('Application ready for assessment in MAAT.')
     end
 
     context 'with errors Reviewing::' do

--- a/spec/system/casework/reviewing/send_back_to_provider_spec.rb
+++ b/spec/system/casework/reviewing/send_back_to_provider_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Send an application back to the provider' do
         click_button(send_back_cta)
 
         within '.govuk-error-summary__body' do
-          expect(page).to have_content 'Give further details'
+          expect(page).to have_content 'Enter a reason for the result'
         end
       end
 

--- a/spec/system/casework/searching/search_filters_and_results_spec.rb
+++ b/spec/system/casework/searching/search_filters_and_results_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Search Page' do
     column_headings = page.all('.app-table thead tr th.govuk-table__header').map(&:text)
 
     expect(column_headings).to eq(
-      ["Applicant's name", 'Reference number', 'Type of application', 'Case type', 'Date received', 'Date closed',
+      ["Applicant's name", 'Reference number', 'Application type', 'Case type', 'Date received', 'Date closed',
        'Caseworker', 'Status']
     )
   end

--- a/spec/system/casework/searching/sorting_search_results_spec.rb
+++ b/spec/system/casework/searching/sorting_search_results_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Sorting search results' do
   it_behaves_like 'a table with sortable headers' do
     let(:active_sort_headers) { ['Date received'] }
     let(:active_sort_direction) { 'ascending' }
-    let(:inactive_sort_headers) { ['Applicant\'s name', 'Case type', 'Date closed', 'Type of application'] }
+    let(:inactive_sort_headers) { ['Applicant\'s name', 'Case type', 'Date closed', 'Application type'] }
   end
 
   describe 'Search results remain after sorting' do


### PR DESCRIPTION
## Description of change
Makes content updates ahead of outcome playback release. Updates: 

- Link this application to a MAAT ID needs to be H2 heading (to not conflict with the applicant’s name that’s already an H1 heading)
- Success message after linking to MAAT currently says: ‘You marked the application as ready for assessment’ - change to: >> ‘Application ready for assessment in MAAT.’
- Change tab heading Type of application >> Application type
- In manual funding decision flow, correct headings to: 
	- [client’s name] = h1
	- Interest of justice test / Means test / Overall result = h2 
	- Reason for result [h3]
	- Caseworker name [h3]
	- Date of test  [h3]

- In manual funding decision flow, correct error messages to:
	- Interest of justice test / Means test / Overall result = Select a result for the [Interest of justice test / Means test / Overall result]
	- Reason for result = Enter a reason for the result
	- Caseworker name = Enter the caseworker name
	- Date of test = Enter the date of the test

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1606

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1033" alt="Screenshot 2025-02-10 at 16 20 31" src="https://github.com/user-attachments/assets/8ee8218c-23e4-4ea1-8b2b-8f178d2670f6" />
<img width="1216" alt="Screenshot 2025-02-10 at 14 46 35" src="https://github.com/user-attachments/assets/f276c689-cc75-48ce-b4ac-5a24701bb244" />
<img width="833" alt="Screenshot 2025-02-10 at 15 43 55" src="https://github.com/user-attachments/assets/395705f2-b266-4773-8920-d5d485bcd9ad" />
<img width="236" alt="Screenshot 2025-02-10 at 15 44 14" src="https://github.com/user-attachments/assets/6d309da9-baf1-4b52-b39f-a2b1411dda55" />
<img width="1033" alt="Screenshot 2025-02-11 at 10 26 32" src="https://github.com/user-attachments/assets/67f59103-6b11-4684-9f3a-f7a3d89d8ca5" />


## How to manually test the feature
