### PR TITLE
[CRIMAPP-1543] Hide link if no JS & link copy announcement

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -128,3 +128,10 @@ html {
     display: inline;
   }
 }
+
+// Hide Copy reference number link if Javascript is disabled
+a#copy-reference-number { display: none }
+
+body.js-enabled {
+  a#copy-reference-number { display: inline }
+}

--- a/app/javascript/local/copy_text.js
+++ b/app/javascript/local/copy_text.js
@@ -1,17 +1,21 @@
 function copyText(textElementId, copyLinkElementId) {
     let textElement = document.querySelector(textElementId);
     let copyLink = document.querySelector(copyLinkElementId);
-  
+    let referenceNumberAlert = document.getElementById("copy-reference-number-alert");
+
     if (textElement && copyLink) {
       copyLink.addEventListener('click', (e) => {
         e.preventDefault();
-  
+
         let text = textElement.textContent.trim();
+
         window.navigator.clipboard.writeText(text);
+        referenceNumberAlert.textContent = "Reference number copied";
+
         copyLink.blur();
         return true;
       });
     }
   }
-  
+
   export default copyText;

--- a/app/javascript/local/copy_text.js
+++ b/app/javascript/local/copy_text.js
@@ -8,7 +8,6 @@ function copyText(textElementId, copyLinkElementId) {
         e.preventDefault();
 
         let text = textElement.textContent.trim();
-
         window.navigator.clipboard.writeText(text);
         referenceNumberAlert.textContent = "Reference number copied";
 

--- a/app/javascript/local/copy_text.js
+++ b/app/javascript/local/copy_text.js
@@ -11,6 +11,10 @@ function copyText(textElementId, copyLinkElementId) {
         window.navigator.clipboard.writeText(text);
         referenceNumberAlert.textContent = "Reference number copied";
 
+        setTimeout(() => {
+            referenceNumberAlert.textContent = "";
+        }, 2000);
+
         copyLink.blur();
         return true;
       });

--- a/app/views/casework/crime_applications/_review_overview.html.erb
+++ b/app/views/casework/crime_applications/_review_overview.html.erb
@@ -9,7 +9,8 @@
         <%= crime_application.reference %>
       </span>
       <% unless crime_application.superseded? %>
-        <%=link_to t('calls_to_action.copy_reference_number'), '', id: 'copy-reference-number', class: 'govuk-link--no-visited-state' %>
+        <%= link_to t('calls_to_action.copy_reference_number'), '', id: 'copy-reference-number', class: 'govuk-link--no-visited-state' %>
+        <p id="copy-reference-number-alert" class="govuk-visually-hidden" aria-live="polite"></p>
       <% end %>
     </p>
 

--- a/app/views/casework/crime_applications/_review_overview.html.erb
+++ b/app/views/casework/crime_applications/_review_overview.html.erb
@@ -10,7 +10,7 @@
       </span>
       <% unless crime_application.superseded? %>
         <%= link_to t('calls_to_action.copy_reference_number'), '', id: 'copy-reference-number', class: 'govuk-link--no-visited-state' %>
-        <p id="copy-reference-number-alert" class="govuk-visually-hidden" aria-live="polite"></p>
+        <p id="copy-reference-number-alert" class="govuk-visually-hidden" aria-live="assertive"></p>
       <% end %>
     </p>
 


### PR DESCRIPTION
## Description of change
If the browser has Javascript disabled. The "Copy reference number" link is hidden.  When the link is selected, the screen reader announces this.

## Link to relevant ticket
https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMAPP/boards/1375?selectedIssue=CRIMAPP-1543

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="983" alt="Screenshot 2025-03-05 at 14 44 30" src="https://github.com/user-attachments/assets/469f57f8-7698-4b79-aa48-ff73efc44571" />
<img width="522" alt="Screenshot 2025-03-06 at 08 23 42" src="https://github.com/user-attachments/assets/62400900-e056-4e10-bff1-869e3e20b407" />

## How to manually test the feature
To disable Javascript on chrome, go to chrome://settings/content/javascript and select "dont allow sites to use Javascript".
Activate MacOS Voiceover using CMD + Fn + F5
You can tab into the "copy reference number" link then press CTRL + OPT + SPACE (MacOs)

<img width="568" alt="Screenshot 2025-03-06 at 08 23 52" src="https://github.com/user-attachments/assets/c8f7457d-0f93-48b4-af40-e7c794ceb581" />
