### PR TITLE
[CRIMAPP-1677] remove OWASP 942360 from return reasons

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -35,33 +35,35 @@ metadata:
         ctl:ruleRemoveById=932110,\
         ctl:ruleRemoveById=932115,\
         ctl:ruleRemoveById=933160,\
-        ctl:ruleRemoveById=942230"
+        ctl:ruleRemoveById=942230,\
+        ctl:ruleRemoveById=942360"
+
 spec:
   ingressClassName: modsec
   tls:
-  - hosts:
-    - laa-review-criminal-legal-aid-production.apps.live.cloud-platform.service.justice.gov.uk
-  - hosts:
-    - review-criminal-legal-aid.service.justice.gov.uk
-    secretName: domain-tls-certificate-production
+    - hosts:
+        - laa-review-criminal-legal-aid-production.apps.live.cloud-platform.service.justice.gov.uk
+    - hosts:
+        - review-criminal-legal-aid.service.justice.gov.uk
+      secretName: domain-tls-certificate-production
   rules:
-  - host: laa-review-criminal-legal-aid-production.apps.live.cloud-platform.service.justice.gov.uk
-    http:
-      paths:
-      - path: /
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: service-production
-            port:
-              number: 80
-  - host: review-criminal-legal-aid.service.justice.gov.uk
-    http:
-      paths:
-      - path: /
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: service-production
-            port:
-              number: 80
+    - host: laa-review-criminal-legal-aid-production.apps.live.cloud-platform.service.justice.gov.uk
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service-production
+                port:
+                  number: 80
+    - host: review-criminal-legal-aid.service.justice.gov.uk
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service-production
+                port:
+                  number: 80

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -24,7 +24,7 @@ metadata:
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
       SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
-      
+
       SecRule REQUEST_URI "@beginsWith /api/events" "id:555001, phase:1, pass, t:none, nolog, chain" \
         SecRule REQUEST_METHOD "@streq POST" "chain" \
           SecRule REQUEST_HEADERS:Content-Type "@rx [\s]*text/plain[\s]*" "ctl:ruleRemoveById=920420"
@@ -35,33 +35,34 @@ metadata:
         ctl:ruleRemoveById=932110,\
         ctl:ruleRemoveById=932115,\
         ctl:ruleRemoveById=933160,\
-        ctl:ruleRemoveById=942230"
+        ctl:ruleRemoveById=942230,\
+        ctl:ruleRemoveById=942360"
 spec:
   ingressClassName: modsec
   tls:
-  - hosts:
-    - laa-review-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk
-  - hosts:
-    - staging.review-criminal-legal-aid.service.justice.gov.uk
-    secretName: domain-tls-certificate-staging
+    - hosts:
+        - laa-review-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk
+    - hosts:
+        - staging.review-criminal-legal-aid.service.justice.gov.uk
+      secretName: domain-tls-certificate-staging
   rules:
-  - host: laa-review-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk
-    http:
-      paths:
-      - path: /
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: service-staging
-            port:
-              number: 80
-  - host: staging.review-criminal-legal-aid.service.justice.gov.uk
-    http:
-      paths:
-      - path: /
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: service-staging
-            port:
-              number: 80
+    - host: laa-review-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service-staging
+                port:
+                  number: 80
+    - host: staging.review-criminal-legal-aid.service.justice.gov.uk
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service-staging
+                port:
+                  number: 80


### PR DESCRIPTION
## Description of change

Remove OWASP 942360 from return reasons

## Link to relevant ticket

[CRIMAPP-1677](https://dsdmoj.atlassian.net/browse/CRIMAPP-1677)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1677]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ