### PR TITLE
Fix phase banner colour and global style config

### DIFF
--- a/app/assets/stylesheets/local/govuk.scss
+++ b/app/assets/stylesheets/local/govuk.scss
@@ -1,7 +1,7 @@
 // GOV.UK Frontend
 //
-$govuk-new-link-styles: true;
-$govuk-global-styles: true;
-$govuk-assets-path: 'govuk-frontend/dist/govuk/assets/';
 
-@use "govuk-frontend/dist/govuk";
+@forward "govuk-frontend/dist/govuk" with(
+  $govuk-global-styles: true,
+  $govuk-assets-path: 'govuk-frontend/dist/govuk/assets/',
+);

--- a/app/assets/stylesheets/local/phase_banner.scss
+++ b/app/assets/stylesheets/local/phase_banner.scss
@@ -1,3 +1,4 @@
+@use "govuk-frontend/dist/govuk" as *;
 // Overrides default colour for non prod envs
 $colours: ("staging": govuk-colour("orange"), "local": govuk-colour("green"));
 


### PR DESCRIPTION
## Description of change

Fix phase banner colour regression.
Fix configuration of global styles for GOVUK Frontend

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
[
<img width="921" alt="Screenshot 2025-03-14 at 14 12 21" src="https://github.com/user-attachments/assets/08d13055-b565-4655-b0c0-fd91d91d9a9a" />
](url)

<img width="290" alt="Screenshot 2025-03-14 at 14 12 28" src="https://github.com/user-attachments/assets/e94a4ba1-82d9-462a-a8f8-0ba33c9d8277" />


### After changes:

<img width="330" alt="Screenshot 2025-03-14 at 14 10 43" src="https://github.com/user-attachments/assets/ff40c162-36df-45eb-a60f-c975e215662f" />
<img width="919" alt="Screenshot 2025-03-14 at 14 10 33" src="https://github.com/user-attachments/assets/08171e8a-b5e0-4a29-bc44-bf5ec36711a5" />


## How to manually test the feature
