### PR TITLE
[CRIMAPP-1295] Caseworker reports show empty %

### DIFF
--- a/app/read_models/caseworker_reports/row.rb
+++ b/app/read_models/caseworker_reports/row.rb
@@ -36,19 +36,19 @@ module CaseworkerReports
     end
 
     def percentage_unassigned_from_user
-      return nil if total_assigned_to_user.zero?
+      return 0 if total_assigned_to_user.zero?
 
       (Rational(total_unassigned_from_user, total_assigned_to_user) * 100).round
     end
 
     def percentage_closed_by_user
-      return nil if total_assigned_to_user.zero?
+      return 0 if total_assigned_to_user.zero?
 
       (Rational(total_closed_by_user, total_assigned_to_user) * 100).round
     end
 
     def percentage_closed_sent_back
-      return nil if total_closed_by_user.zero?
+      return 0 if total_closed_by_user.zero?
 
       (Rational(sent_back_by_user, total_closed_by_user) * 100).round
     end


### PR DESCRIPTION
## Description of change
This issue is prevalent on all 3 percentage columns if the the guard clause return true. Changing `nil` to `0`ensures a value will be displayed

## Link to relevant ticket
https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMAPP/boards/1375?selectedIssue=CRIMAPP-1295

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="982" alt="Screenshot 2025-03-18 at 09 25 18" src="https://github.com/user-attachments/assets/7bcc35d1-9d88-4139-b8f1-dcdbdeb6401a" />

## How to manually test the feature
