### PR TITLE
[CRIMAPP-1690] Fix copy urn link

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -11,6 +11,7 @@ import copyText from './local/copy_text'
 import { initAll } from 'govuk-frontend'
 initAll()
 
-// used on application show page
+// used on application details page
 copyText('#reference-number','#copy-reference-number')
-copyText('#urn','#copy-urn-reference-number')
+copyText('#overview-urn','#copy-overview-urn')
+copyText('#case-details-urn','#copy-case-details-urn')

--- a/app/views/casework/crime_applications/_case_details.html.erb
+++ b/app/views/casework/crime_applications/_case_details.html.erb
@@ -9,11 +9,11 @@
         <%= label_text(:urn) %>
       </dt>
       <dd class="govuk-summary-list__value">
-      <span id="urn">
+      <span id="case-details-urn">
         <%= case_details.urn.presence || t(:none, scope: 'values') %>
       </span>
         <% if case_details.urn.presence && !crime_application.superseded? %>
-          <%= link_to t('calls_to_action.copy_urn'), '', id: 'copy-urn-reference-number', class: 'govuk-link--no-visited-state' %>
+          <%= link_to t('calls_to_action.copy_urn'), '', id: 'copy-case-details-urn', class: 'govuk-link--no-visited-state' %>
         <% end %>
       </dd>
     </div>

--- a/app/views/casework/crime_applications/_overview.html.erb
+++ b/app/views/casework/crime_applications/_overview.html.erb
@@ -86,11 +86,11 @@
             <%= label_text(:urn) %>
           </dt>
           <dd class="govuk-summary-list__value">
-          <span id="urn">
+          <span id="overview-urn">
             <%= overview.case_details.urn.presence || t(:none, scope: 'values') %>
           </span>
             <% if overview.case_details.urn.presence && !overview.superseded? %>
-              <%= link_to t('calls_to_action.copy_urn'), '', id: 'copy-urn-reference-number', class: 'govuk-link--no-visited-state' %>
+              <%= link_to t('calls_to_action.copy_urn'), '', id: 'copy-overview-urn', class: 'govuk-link--no-visited-state' %>
             <% end %>
           </dd>
         </div>


### PR DESCRIPTION
## Description of change
Fixes bug with copy urn link in the case details section which was not working 
This is because there were duplicate IDs for the copy urn links on the page 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1690

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
