### PR TITLE
[CRIMAPP-1701] QA content updates

### DIFF
--- a/app/models/reporting/monthly_report.rb
+++ b/app/models/reporting/monthly_report.rb
@@ -2,10 +2,10 @@ module Reporting
   class MonthlyReport < TemporalReport
     PARAM_FORMAT = '%Y-%B'.freeze
     INTERVAL = Types::TemporalInterval['monthly']
-    PERIOD_NAME_FORMAT = '%B, %Y'.freeze
+    PERIOD_NAME_FORMAT = '%B %Y'.freeze
 
     def period_text
-      time_period.starts_on.strftime('%A %-d — ') + time_period.ends_on.strftime('%A %-d %B %Y')
+      time_period.starts_on.strftime('%A %-d to ') + time_period.ends_on.strftime('%A %-d %B %Y')
     end
   end
 end

--- a/app/models/reporting/weekly_report.rb
+++ b/app/models/reporting/weekly_report.rb
@@ -6,9 +6,17 @@ module Reporting
 
     def period_text
       [
-        I18n.l(time_period.starts_on, format: '%A %-d %B'),
+        I18n.l(time_period.starts_on, format: start_date_format),
         I18n.l(time_period.ends_on, format: :reporting_long)
       ].join(' to ')
+    end
+
+    private
+
+    def start_date_format
+      return :reporting_long if time_period.starts_on.year != time_period.ends_on.year
+
+      '%A %-d %B'
     end
   end
 end

--- a/app/models/reporting/weekly_report.rb
+++ b/app/models/reporting/weekly_report.rb
@@ -6,9 +6,9 @@ module Reporting
 
     def period_text
       [
-        I18n.l(time_period.starts_on, format: :reporting_long),
+        I18n.l(time_period.starts_on, format: '%A %-d %B'),
         I18n.l(time_period.ends_on, format: :reporting_long)
-      ].join(' — ')
+      ].join(' to ')
     end
   end
 end

--- a/app/views/reporting/temporal_reports/_return_reasons_report.en.html.erb
+++ b/app/views/reporting/temporal_reports/_return_reasons_report.en.html.erb
@@ -1,8 +1,6 @@
 <% if report.rows.size > 0 && !report.current? %>
   <p>
-    <%= pluralize(report.total_count, 'applications') %>
-    were sent back to providers this
-    <%= label_text [:period, report.time_period.interval].join('.') %>
+    <%= pluralize(report.total_count, 'applications') %> were sent back to providers
   </p>
 <% end %>
 

--- a/app/views/reporting/temporal_reports/_return_reasons_report.en.html.erb
+++ b/app/views/reporting/temporal_reports/_return_reasons_report.en.html.erb
@@ -1,6 +1,6 @@
 <% if report.rows.size > 0 && !report.current? %>
   <p>
-    <%= pluralize(report.total_count, 'applications') %> were sent back to providers
+    <%= pluralize(report.total_count, 'applications') %> were sent back to providers.
   </p>
 <% end %>
 

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -428,9 +428,9 @@ en:
     pre_cifc_usn: USN of original application
     pre_cifc_reason: Changes in client's financial circumstances
 
-  table_headings: &TABLE_HEADINGS
+  table_headings:
     applicant_name: Applicant's name
-    reference: Reference number
+    reference: LAA reference
     time_passed: Business days since received
     received_at: Date received
     submitted_at: Date received

--- a/spec/models/reporting/monthly_report_spec.rb
+++ b/spec/models/reporting/monthly_report_spec.rb
@@ -10,11 +10,11 @@ describe Reporting::MonthlyReport do
   it_behaves_like 'a temporal report' do
     let(:date) { Date.new(2023, 8, 1) }
     let(:expected_stream_name) { 'MonthlyCaseworker$2023-08' }
-    let(:expected_period_text) { 'Tuesday 1 — Thursday 31 August 2023' }
-    let(:expected_title) { 'Caseworker monthly: August, 2023' }
+    let(:expected_period_text) { 'Tuesday 1 to Thursday 31 August 2023' }
+    let(:expected_title) { 'Caseworker monthly: August 2023' }
     let(:expected_id) { 'caseworker_report_monthly_2023-August' }
     let(:expected_to_param) { { interval: 'monthly', period: '2023-August', report_type: 'caseworker_report' } }
-    let(:expected_period_name) { 'August, 2023' }
+    let(:expected_period_name) { 'August 2023' }
     let(:expected_next_report_date) { Date.new(2023, 9, 1) }
     let(:expected_previous_report_date) { Date.new(2023, 7, 1) }
   end

--- a/spec/models/reporting/temporal_report_spec.rb
+++ b/spec/models/reporting/temporal_report_spec.rb
@@ -10,7 +10,7 @@ describe Reporting::TemporalReport do
     end
 
     it 'returns the correct report from the param' do
-      expect(report_from_param.title).to eq('Return reasons monthly: August, 2023')
+      expect(report_from_param.title).to eq('Return reasons monthly: August 2023')
     end
   end
 
@@ -20,7 +20,7 @@ describe Reporting::TemporalReport do
     end
 
     it 'returns the correct report from the param' do
-      expected = described_class._current_date.strftime('Caseworker monthly: %B, %Y')
+      expected = described_class._current_date.strftime('Caseworker monthly: %B %Y')
       expect(curent_report.title).to eq expected
     end
   end

--- a/spec/models/reporting/weekly_report_spec.rb
+++ b/spec/models/reporting/weekly_report_spec.rb
@@ -11,7 +11,7 @@ describe Reporting::WeeklyReport do
   it_behaves_like 'a temporal report' do
     let(:date) { Date.new(2023, 8, 1) }
     let(:expected_stream_name) { 'WeeklyCaseworker$2023-31' }
-    let(:expected_period_text) { 'Monday 31 July 2023 — Sunday 6 August 2023' }
+    let(:expected_period_text) { 'Monday 31 July to Sunday 6 August 2023' }
     let(:expected_title) { 'Caseworker weekly: Week 31, 2023' }
     let(:expected_id) { 'caseworker_report_weekly_2023-31' }
     let(:expected_to_param) { { interval: 'weekly', period: '2023-31', report_type: report_type } }

--- a/spec/system/casework/assigning/viewing_your_assigned_applications_spec.rb
+++ b/spec/system/casework/assigning/viewing_your_assigned_applications_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'Viewing your assigned application' do
       column_headings = page.all('thead tr th.govuk-table__header').map(&:text)
 
       expect(column_headings).to contain_exactly(
-        "Applicant's name", 'Reference number', 'Application type', 'Type of work', 'Date received',
+        "Applicant's name", 'LAA reference', 'Application type', 'Type of work', 'Date received',
         'Business days since received'
       )
     end

--- a/spec/system/casework/closed_applications_dashboard_spec.rb
+++ b/spec/system/casework/closed_applications_dashboard_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Closed Applications' do
 
     expected_headings = [
       "Applicant's name",
-      'Reference number',
+      'LAA reference',
       'Application type',
       'Date received',
       'Date closed',

--- a/spec/system/casework/open_applications_dashboard_spec.rb
+++ b/spec/system/casework/open_applications_dashboard_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Open Applications' do
   it 'includes the correct headings' do
     column_headings = page.all('.app-table thead tr th.govuk-table__header').map(&:text)
 
-    expect(column_headings).to eq(["Applicant's name", 'Reference number', 'Application type', 'Date received',
+    expect(column_headings).to eq(["Applicant's name", 'LAA reference', 'Application type', 'Date received',
                                    'Business days since received', 'Caseworker'])
   end
 

--- a/spec/system/casework/searching/search_filters_and_results_spec.rb
+++ b/spec/system/casework/searching/search_filters_and_results_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Search Page' do
     column_headings = page.all('.app-table thead tr th.govuk-table__header').map(&:text)
 
     expect(column_headings).to eq(
-      ["Applicant's name", 'Reference number', 'Application type', 'Case type', 'Date received', 'Date closed',
+      ["Applicant's name", 'LAA reference', 'Application type', 'Case type', 'Date received', 'Date closed',
        'Caseworker', 'Status']
     )
   end

--- a/spec/system/reporting/monthly_reports_spec.rb
+++ b/spec/system/reporting/monthly_reports_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe 'Monthly Reports' do
 
     it 'includes a link to the next month\'s report' do
       expect { click_link 'Next' }.to change { page.first('h2').text }.from(
-        'December, 2022'
+        'December 2022'
       ).to(
-        'January, 2023'
+        'January 2023'
       )
     end
   end
@@ -35,9 +35,9 @@ RSpec.describe 'Monthly Reports' do
 
   it 'includes a link to the previous month\'s report' do
     expect { click_link 'Previous' }.to change { page.first('h2').text }.from(
-      'January, 2023'
+      'January 2023'
     ).to(
-      'December, 2022'
+      'December 2022'
     )
   end
 

--- a/spec/system/reporting/return_reasons_report_spec.rb
+++ b/spec/system/reporting/return_reasons_report_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Return Reasons Report' do
 
   it 'shows the report\'s period range' do
     heading_text = page.first('h2 + h3').text
-    expect(heading_text).to eq('Monday 2 January 2023 — Sunday 8 January 2023')
+    expect(heading_text).to eq('Monday 2 January to Sunday 8 January 2023')
   end
 
   it 'shows the correct column headers' do # rubocop:disable RSpec/ExampleLength
@@ -54,7 +54,7 @@ RSpec.describe 'Return Reasons Report' do
       'Closed by',
       'Date returned',
       'Return reason',
-      'Reference number',
+      'LAA reference',
       'Office code',
       'Legal representative'
     ]
@@ -129,7 +129,7 @@ RSpec.describe 'Return Reasons Report' do
   it_behaves_like 'a table with sortable headers' do
     let(:active_sort_headers) { ['Date returned'] }
     let(:active_sort_direction) { 'ascending' }
-    let(:inactive_sort_headers) { ['Return reason', 'Reference number', 'Office code'] }
+    let(:inactive_sort_headers) { ['Return reason', 'LAA reference', 'Office code'] }
   end
 
   it 'can navigate to the monthly view' do

--- a/spec/system/reporting/weekly_reports_spec.rb
+++ b/spec/system/reporting/weekly_reports_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Weekly Reports' do
   end
 
   it 'shows the reports date range' do
-    expect(page.first('h3')).to have_text('Monday 26 December 2022 — Sunday 1 January 2023')
+    expect(page.first('h3')).to have_text('Monday 26 December to Sunday 1 January 2023')
   end
 
   it 'shows the caseworker report table for the given week' do

--- a/spec/system/reporting/weekly_reports_spec.rb
+++ b/spec/system/reporting/weekly_reports_spec.rb
@@ -12,7 +12,15 @@ RSpec.describe 'Weekly Reports' do
   end
 
   it 'shows the reports date range' do
-    expect(page.first('h3')).to have_text('Monday 26 December to Sunday 1 January 2023')
+    expect(page.first('h3')).to have_text('Monday 26 December 2022 to Sunday 1 January 2023')
+  end
+
+  context 'when viewing report date range within the same year' do
+    let(:period) { '2022-51' }
+
+    it 'displays the year for both dates' do
+      expect(page.first('h3')).to have_text('Monday 19 December to Sunday 25 December 2022')
+    end
   end
 
   it 'shows the caseworker report table for the given week' do


### PR DESCRIPTION
## Description of change
Updates the weekly report date formatting to display the year of both dates when the week spans a new year

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1701

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1206" alt="Screenshot 2025-03-26 at 12 24 17" src="https://github.com/user-attachments/assets/41efef83-313e-4e15-9d76-2b71d9d13ec1" />
<img width="1206" alt="Screenshot 2025-03-26 at 12 24 24" src="https://github.com/user-attachments/assets/893596f7-341d-4316-a622-eb41226dde13" />


## How to manually test the feature
