### PR TITLE
[CRIMAPP-1701] Amend weekly report date formatting

### DIFF
--- a/app/models/reporting/weekly_report.rb
+++ b/app/models/reporting/weekly_report.rb
@@ -6,9 +6,17 @@ module Reporting
 
     def period_text
       [
-        I18n.l(time_period.starts_on, format: '%A %-d %B'),
+        I18n.l(time_period.starts_on, format: start_date_format),
         I18n.l(time_period.ends_on, format: :reporting_long)
       ].join(' to ')
+    end
+
+    private
+
+    def start_date_format
+      return :reporting_long if time_period.starts_on.year != time_period.ends_on.year
+
+      '%A %-d %B'
     end
   end
 end

--- a/app/views/reporting/temporal_reports/_return_reasons_report.en.html.erb
+++ b/app/views/reporting/temporal_reports/_return_reasons_report.en.html.erb
@@ -1,6 +1,6 @@
 <% if report.rows.size > 0 && !report.current? %>
   <p>
-    <%= pluralize(report.total_count, 'applications') %> were sent back to providers
+    <%= pluralize(report.total_count, 'applications') %> were sent back to providers.
   </p>
 <% end %>
 

--- a/spec/system/reporting/weekly_reports_spec.rb
+++ b/spec/system/reporting/weekly_reports_spec.rb
@@ -12,7 +12,15 @@ RSpec.describe 'Weekly Reports' do
   end
 
   it 'shows the reports date range' do
-    expect(page.first('h3')).to have_text('Monday 26 December to Sunday 1 January 2023')
+    expect(page.first('h3')).to have_text('Monday 26 December 2022 to Sunday 1 January 2023')
+  end
+
+  context 'when viewing report date range within the same year' do
+    let(:period) { '2022-51' }
+
+    it 'displays the year for both dates' do
+      expect(page.first('h3')).to have_text('Monday 19 December to Sunday 25 December 2022')
+    end
   end
 
   it 'shows the caseworker report table for the given week' do


### PR DESCRIPTION
## Description of change
Updates the weekly report date formatting to display the year of both dates when the week spans a new year

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1701

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1206" alt="Screenshot 2025-03-26 at 12 24 17" src="https://github.com/user-attachments/assets/41efef83-313e-4e15-9d76-2b71d9d13ec1" />
<img width="1206" alt="Screenshot 2025-03-26 at 12 24 24" src="https://github.com/user-attachments/assets/893596f7-341d-4316-a622-eb41226dde13" />

## How to manually test the feature
