### PR TITLE
[CRIMAPP-1725] Change undetermined offence class tag spacing

### DIFF
--- a/app/components/offence_class_component.rb
+++ b/app/components/offence_class_component.rb
@@ -20,7 +20,9 @@ class OffenceClassComponent < ViewComponent::Base
   end
 
   def not_determined_tag
-    govuk_tag(text: I18n.t('values.class_not_determined'), colour: 'red')
+    tag.span(class: 'offence_class') do
+      govuk_tag(text: I18n.t('values.class_not_determined'), colour: 'red', classes: 'govuk-!-margin-top-0')
+    end
   end
 
   def offence_class


### PR DESCRIPTION
## Description of change
This change moves the 'Not determined' offence class tag to a new line. This fixes the issue where the tag gets selected when caseworkers double-click the text to copy the offence name.

## Link to relevant ticket
[CRIMAPP-1725](https://dsdmoj.atlassian.net/browse/CRIMAPP-1725)

## Screenshots of changes

### Before changes:
![image](https://github.com/user-attachments/assets/6fd07fa5-7231-41a4-8531-0268d8f748d4)

### After changes:
![image](https://github.com/user-attachments/assets/29b22ef0-7b60-4bef-8da9-78685fcef4ed)


[CRIMAPP-1725]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ