### PR TITLE
[CRIMAPP-1725] Update offence summary card

### DIFF
--- a/app/components/offence_class_component.rb
+++ b/app/components/offence_class_component.rb
@@ -20,14 +20,10 @@ class OffenceClassComponent < ViewComponent::Base
   end
 
   def not_determined_tag
-    tag.span(class: 'offence_class') do
-      govuk_tag(text: I18n.t('values.class_not_determined'), colour: 'red', classes: 'govuk-!-margin-top-0')
-    end
+    govuk_tag(text: I18n.t('values.class_not_determined'), colour: 'red')
   end
 
   def offence_class
-    tag.span(class: 'govuk-caption-m') do
-      tag.span [t('values.class'), offence.offence_class].join(' ')
-    end
+    safe_join([t('values.class'), offence.offence_class], ' ')
   end
 end

--- a/app/views/casework/crime_applications/_offences.html.erb
+++ b/app/views/casework/crime_applications/_offences.html.erb
@@ -1,8 +1,12 @@
 <%= app_card_list(items: offences, item_name: label_text(:offence)) do |card|
       govuk_summary_list(actions: false) do |list|
         list.with_row do |row|
-          row.with_key { label_text(:offence_type_and_class) }
-          row.with_value { safe_join([card.item.name, offence_class(card.item)]) }
+          row.with_key { label_text(:offence_type) }
+          row.with_value { card.item.name }
+        end
+        list.with_row do |row|
+          row.with_key { label_text(:offence_class) }
+          row.with_value { offence_class(card.item) }
         end
         list.with_row do |row|
           row.with_key { label_text(:offence_date) }

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -281,8 +281,9 @@ en:
     no_files_uploaded: No files were uploaded
     number_of_dependants: Number of dependants aged %{age_range} on next birthday
     offence: Offence
-    offence_date: Offence date
-    offence_type_and_class: Offence type and class
+    offence_type: Type
+    offence_class: Class
+    offence_date: Date
     office_account_number: Office account number
     other_benefits_details: Other benefits details
     other_capital_details: Other capital

--- a/spec/system/casework/viewing_an_application/application_details/offences_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/offences_spec.rb
@@ -13,10 +13,11 @@ RSpec.describe 'Viewing the offences listed in an application' do
           .ancestor('div.govuk-summary-card')
     end
 
-    it 'shows offence details' do
+    it 'shows offence details' do # rubocop:disable RSpec/MultipleExpectations
       within(offence_card) do |card|
-        expect(card).to have_summary_row 'Offence type and class', 'Attempt robberyClass C'
-        expect(card).to have_summary_row 'Offence date', '11/05/2020 – 12/05/2020 11/08/2020'
+        expect(card).to have_summary_row 'Type', 'Attempt robbery'
+        expect(card).to have_summary_row 'Class', 'Class C'
+        expect(card).to have_summary_row 'Date', '11/05/2020 – 12/05/2020 11/08/2020'
       end
     end
   end
@@ -27,10 +28,11 @@ RSpec.describe 'Viewing the offences listed in an application' do
           .ancestor('div.govuk-summary-card')
     end
 
-    it 'shows offence details' do
+    it 'shows offence details' do # rubocop:disable RSpec/MultipleExpectations
       within(offence_card) do |card|
-        expect(card).to have_summary_row 'Offence type and class', 'Non-listed offence, manually enteredNot determined'
-        expect(card).to have_summary_row 'Offence date', '15/09/2020'
+        expect(card).to have_summary_row 'Type', 'Non-listed offence, manually entered'
+        expect(card).to have_summary_row 'Class', 'Not determined'
+        expect(card).to have_summary_row 'Date', '15/09/2020'
       end
     end
   end


### PR DESCRIPTION
## Description of change
This updates the offence summary card text and splits the 'Offence type and class' row into two to match the designs in Figma. This also solves the issue where the offence class would get selected when caseworkers double-clicked to offence name, intending to only copy the name and not the class.

## Link to relevant ticket
[CRIMAPP-1725](https://dsdmoj.atlassian.net/browse/CRIMAPP-1725)
[Figma design](https://www.figma.com/design/TELZW9jdNqFcrI4yZoH7BV/Crime-Review?node-id=7877-4401&t=5gA6k9toOvWaOJVL-1)

## Screenshots of changes
### Before changes:
![image](https://github.com/user-attachments/assets/e11b9a02-d41c-4f70-a884-c288921c3a84)

### After changes:
![image](https://github.com/user-attachments/assets/e4fad432-c562-40df-a192-2c8a92e57ed3)


[CRIMAPP-1725]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ