### PR TITLE
[CRIMAPP-1675] Fully sanitize HTML

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -84,6 +84,9 @@ module LaaReviewCriminalLegalAid
       'ApplicationController::ForbiddenError' => :forbidden
     )
 
+    # Prohibit all HTML tags
+    config.action_view.sanitized_allowed_tags = []
+
     config.x.maat_api.oauth_url = ENV.fetch('MAAT_API_OAUTH_URL', nil)
     config.x.maat_api.client_id = ENV.fetch('MAAT_API_CLIENT_ID', nil)
     config.x.maat_api.client_secret = ENV.fetch('MAAT_API_CLIENT_SECRET', nil)


### PR DESCRIPTION
## Description of change
This addresses the issue discovered by the latest AppSec test where the HTML tags allowed by `Rails::HTML5::SafeListSanitizer` may be used in our text boxes to alter the HTML of user input when it is rendered, for example in our summary cards.

## Link to relevant ticket
[CRIMAPP-1675](https://dsdmoj.atlassian.net/browse/CRIMAPP-1675)

## Notes for reviewer
Many of the affected fields already call `simple_format`, which sanitizes input by default. Other fields that are affected on Apply, such as client and partner names and addresses, seem to output HTML tags as text. The config change ensures that no HTML tags are allowed.

## Screenshots of changes

### Before changes:
![image](https://github.com/user-attachments/assets/7f06db4a-756d-49ab-a97f-66a6adf939d6)

### After changes:
![image](https://github.com/user-attachments/assets/c3a1c6b9-8b0a-4b71-ba9e-75f762df27a6)

[CRIMAPP-1675]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ