### PR TITLE
[CRIMAPP-1727] Disable ModSec rule 932380

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -34,6 +34,7 @@ metadata:
         ctl:ruleRemoveById=932100,\
         ctl:ruleRemoveById=932110,\
         ctl:ruleRemoveById=932115,\
+        ctl:ruleRemoveById=932380,\
         ctl:ruleRemoveById=933160,\
         ctl:ruleRemoveById=942230,\
         ctl:ruleRemoveById=942360"

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -34,6 +34,7 @@ metadata:
         ctl:ruleRemoveById=932100,\
         ctl:ruleRemoveById=932110,\
         ctl:ruleRemoveById=932115,\
+        ctl:ruleRemoveById=932380,\
         ctl:ruleRemoveById=933160,\
         ctl:ruleRemoveById=942230,\
         ctl:ruleRemoveById=942360"


### PR DESCRIPTION
## Description of change
Disable ModSec rule 932380 to prevent false positives on the `{application_id}/return` endpoint.

This rule was triggered by text that has CRLF line breaks (\r\n), followed by the words 'if' and 'for', making ModSec think it was a Windows Command Injection.

## Link to relevant ticket
[CRIMAPP-1727](https://dsdmoj.atlassian.net/browse/CRIMAPP-1727)

## How to manually test the feature
Attempt to return an application and have the return reason contain text with CRLF line breaks followed by 'if' and 'for'. The rule should not be triggered and you should be able to return the application.

[CRIMAPP-1727]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ