### PR TITLE
[CRIMAPP-1675] Summary card answer formatting fix

### DIFF
--- a/app/views/casework/crime_applications/sections/_income_benefits.html.erb
+++ b/app/views/casework/crime_applications/sections/_income_benefits.html.erb
@@ -24,7 +24,7 @@
                 <%= label_text(:other_benefits_details) %>
               </dt>
               <dd class="govuk-summary-list__value">
-                <%= value.metadata.details %>
+                <%= simple_format(value.metadata.details) %>
               </dd>
             </div>
           <% end %>

--- a/app/views/casework/crime_applications/sections/_income_benefits_partner.html.erb
+++ b/app/views/casework/crime_applications/sections/_income_benefits_partner.html.erb
@@ -24,7 +24,7 @@
                 <%= label_text(:other_benefits_details) %>
               </dt>
               <dd class="govuk-summary-list__value">
-                <%= value.metadata.details %>
+                <%= simple_format(value.metadata.details) %>
               </dd>
             </div>
           <% end %>

--- a/app/views/casework/crime_applications/sections/_income_payments.html.erb
+++ b/app/views/casework/crime_applications/sections/_income_payments.html.erb
@@ -24,7 +24,7 @@
                 <%= label_text(:other_payment_details) %>
               </dt>
               <dd class="govuk-summary-list__value">
-                <%= value.metadata.details %>
+                <%= simple_format(value.metadata.details) %>
               </dd>
             </div>
           <% end %>

--- a/app/views/casework/crime_applications/sections/_income_payments_partner.html.erb
+++ b/app/views/casework/crime_applications/sections/_income_payments_partner.html.erb
@@ -24,7 +24,7 @@
                 <%= label_text(:other_payment_details) %>
               </dt>
               <dd class="govuk-summary-list__value">
-                <%= value.metadata.details %>
+                <%= simple_format(value.metadata.details) %>
               </dd>
             </div>
           <% end %>

--- a/spec/system/casework/viewing_an_application/application_details/income_benefits_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_benefits_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Viewing the income benefits of an application' do
       expect(page).to have_content('Industrial Injuries Disablement Benefit Does not get')
       expect(page).to have_content("Contribution-based Jobseeker's Allowance Does not get")
       expect(page).to have_content('Other benefits £18.84 every 2 weeks')
-      expect(page).to have_content('Other benefits details Top up')
+      expect(page).to have_content("Other benefits details\nTop up")
     end
     # rubocop:enable RSpec/MultipleExpectations
   end

--- a/spec/system/casework/viewing_an_application/application_details/income_payments_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_payments_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Viewing the income payments of an application' do
       )
       expect(page).to have_content('Money from friends or family Does not get')
       expect(page).to have_content('Other sources of income £25.00 every year')
-      expect(page).to have_content('Other sources of income details Book royalty')
+      expect(page).to have_content("Other sources of income details\nBook royalty")
     end
     # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
   end


### PR DESCRIPTION
## Description of change
This fixes a formatting issue in the summary cards for income payments and benefits where line breaks are removed in user input and HTML tags are left in.

## Link to relevant ticket
[CRIMAPP-1675](https://dsdmoj.atlassian.net/browse/CRIMAPP-1675)

## Screenshots of changes

### Before changes:
![image](https://github.com/user-attachments/assets/cb67d7e2-145d-458f-b1d0-4c5e576d4173)
![image](https://github.com/user-attachments/assets/335f393a-5273-488a-abfc-1ea464d45dae)


### After changes:
![image](https://github.com/user-attachments/assets/6214a108-5512-465e-b901-11c082b599b4)
![image](https://github.com/user-attachments/assets/b049ad61-d170-4d09-b58a-1ffbb0160227)


[CRIMAPP-1675]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ