### PR TITLE
[CRIMAPP-1679] Add Sidekiq

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -34,3 +34,5 @@ PORT=3001
 # If set, enables prometheus middleware and server
 # ENABLE_PROMETHEUS_EXPORTER=true
 # PROMETHEUS_EXPORTER_VERBOSE=false
+
+REDIS_URL=redis://localhost:6379

--- a/Gemfile
+++ b/Gemfile
@@ -87,3 +87,6 @@ gem 'cssbundling-rails', '~> 1.4'
 gem 'csv', '~> 3.3'
 
 gem 'ostruct', '~> 0.6.1'
+
+gem 'sidekiq', '~> 7.0'
+gem 'sidekiq-scheduler', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,12 +227,17 @@ GEM
       rubocop (>= 1)
       smart_properties
     erubi (1.13.1)
+    et-orbi (1.2.11)
+      tzinfo
     faraday (2.9.2)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
     faraday-net_http (3.1.0)
       net-http
+    fugit (1.11.1)
+      et-orbi (~> 1, >= 1.2.11)
+      raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
     govuk-components (5.7.1)
@@ -387,6 +392,7 @@ GEM
     public_suffix (6.0.1)
     puma (6.6.0)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (2.2.13)
     rack-oauth2 (2.2.1)
@@ -450,6 +456,8 @@ GEM
     rake (13.2.1)
     rdoc (6.11.0)
       psych (>= 4.0.0)
+    redis-client (0.24.0)
+      connection_pool
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
@@ -509,6 +517,8 @@ GEM
       rack
       ruby_event_store (= 2.15.0)
     rubyzip (2.3.2)
+    rufus-scheduler (3.9.2)
+      fugit (~> 1.1, >= 1.11.1)
     securerandom (0.4.1)
     selenium-webdriver (4.23.0)
       base64 (~> 0.2)
@@ -522,6 +532,16 @@ GEM
     sentry-ruby (5.17.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    sidekiq (7.3.9)
+      base64
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
+    sidekiq-scheduler (5.0.6)
+      rufus-scheduler (~> 3.2)
+      sidekiq (>= 6, < 8)
+      tilt (>= 1.4.0, < 3)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -541,6 +561,7 @@ GEM
       faraday-follow_redirects
     thor (1.3.2)
     thread_safe (0.3.6)
+    tilt (2.6.0)
     timeout (0.4.3)
     turbo-rails (2.0.5)
       actionpack (>= 6.0.0)
@@ -638,6 +659,8 @@ DEPENDENCIES
   selenium-webdriver
   sentry-rails (>= 5.15.1)
   sentry-ruby
+  sidekiq (~> 7.0)
+  sidekiq-scheduler (~> 5.0)
   simplecov
   stackprof
   turbo-rails (>= 2.0.0)

--- a/app/notifiers/sent_back_notifier.rb
+++ b/app/notifiers/sent_back_notifier.rb
@@ -4,9 +4,13 @@ class SentBackNotifier
       application_id = event.data.fetch(:application_id)
       return_reason = event.data.fetch(:reason)
 
-      NotifyMailer.application_returned_email(
-        application_id, return_reason
-      ).deliver_now
+      if HostEnv.production?
+        # :nocov:
+        NotifyMailer.application_returned_email(application_id, return_reason).deliver_now
+        # :nocov:
+      else
+        NotifyMailer.application_returned_email(application_id, return_reason).deliver_later
+      end
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ require 'action_cable/engine'
 require 'rails/test_unit/railtie'
 
 require_relative '../app/lib/notify_mailer_interceptor'
+require_relative '../app/lib/host_env'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -44,6 +45,10 @@ module LaaReviewCriminalLegalAid
 
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid
+    end
+
+    unless HostEnv.production?
+      config.active_job.queue_adapter = :sidekiq
     end
 
     # Authentication, authorization, and session configuration

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,34 @@
+require 'host_env'
+
+return unless HostEnv.production?
+
+# For k8s readiness probe - taken from https://github.com/sidekiq/sidekiq/wiki/Kubernetes#sidekiq
+SIDEKIQ_WILL_PROCESSES_JOBS_FILE = Rails.root.join('tmp/sidekiq_process_has_started_and_will_begin_processing_jobs').freeze
+
+Sidekiq.configure_server do |config|
+  break unless ENV.fetch('ENABLE_PROMETHEUS_EXPORTER', 'false').inquiry.true?
+
+  require 'prometheus_exporter/client'
+  require 'prometheus_exporter/instrumentation'
+
+  config.server_middleware do |chain|
+    chain.add PrometheusExporter::Instrumentation::Sidekiq
+  end
+  config.death_handlers << PrometheusExporter::Instrumentation::Sidekiq.death_handler
+  config.on :startup do
+    FileUtils.touch(SIDEKIQ_WILL_PROCESSES_JOBS_FILE)
+
+    PrometheusExporter::Instrumentation::Process.start type: 'sidekiq'
+    PrometheusExporter::Instrumentation::SidekiqProcess.start
+    PrometheusExporter::Instrumentation::SidekiqQueue.start(all_queues: true)
+    PrometheusExporter::Instrumentation::SidekiqStats.start
+  end
+
+  config.on :shutdown do
+    FileUtils.rm_f(SIDEKIQ_WILL_PROCESSES_JOBS_FILE)
+  end
+
+  at_exit do
+    PrometheusExporter::Client.default.stop(wait_timeout_seconds: 10)
+  end
+end

--- a/config/kubernetes/staging/deployment-worker.yml
+++ b/config/kubernetes/staging/deployment-worker.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: deployment-staging
+  name: deployment-worker-staging
   namespace: laa-review-criminal-legal-aid-staging
 spec:
   replicas: 2
@@ -13,67 +13,54 @@ spec:
       maxSurge: 100%
   selector:
     matchLabels:
-      app: review-criminal-legal-aid-web-staging
+      app: review-criminal-legal-aid-worker-staging
   template:
     metadata:
       labels:
-        app: review-criminal-legal-aid-web-staging
-        tier: frontend
+        app: review-criminal-legal-aid-worker-staging
+        tier: worker
     spec:
       containers:
-      - name: webapp
+      - name: worker
         image: ${ECR_URL}:${IMAGE_TAG}
         imagePullPolicy: Always
-        ports:
-          - containerPort: 3000
-          - containerPort: 9394
+        command: ["bundle", "exec", "sidekiq"]
         resources:
           requests:
-            cpu: 25m
-            memory: 1Gi
+            cpu: 10m
+            memory: 512Mi
           limits:
             cpu: 500m
-            memory: 3Gi
+            memory: 1Gi
         readinessProbe:
-          httpGet:
-            path: /health
-            port: 3000
-            httpHeaders:
-              - name: X-Forwarded-Proto
-                value: https
-              - name: X-Forwarded-Ssl
-                value: "on"
-          initialDelaySeconds: 11
+          exec:
+            command:
+              - cat
+              - /tmp/sidekiq_process_has_started_and_will_begin_processing_jobs
           periodSeconds: 10
+          failureThreshold: 3
         livenessProbe:
-          httpGet:
-            path: /ping
-            port: 3000
-            httpHeaders:
-              - name: X-Forwarded-Proto
-                value: https
-              - name: X-Forwarded-Ssl
-                value: "on"
-          failureThreshold: 1
-          periodSeconds: 10
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - pgrep -f sidekiq
+          failureThreshold: 30
+          periodSeconds: 3
         startupProbe:
-          httpGet:
-            path: /ping
-            port: 3000
-            httpHeaders:
-              - name: X-Forwarded-Proto
-                value: https
-              - name: X-Forwarded-Ssl
-                value: "on"
-          failureThreshold: 20
-          periodSeconds: 10
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - pgrep -f sidekiq
+          failureThreshold: 60
+          periodSeconds: 5
         envFrom:
           - configMapRef:
               name: configmap-staging
           - secretRef:
               name: laa-review-criminal-legal-aid-secrets
         env:
-          # secrets created by terraform
           - name: DATABASE_URL
             valueFrom:
               secretKeyRef:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,13 @@ Rails.application.routes.draw do
   Rails.application.routes.draw { mount RailsEventStore::Browser => "/res" if Rails.env.development? }
   mount DatastoreApi::HealthEngine::Engine => '/datastore'
 
+  # TODO: should this be accessible in prod? By which users?
+  unless Rails.env.production?
+    require "sidekiq/web"
+    require 'sidekiq-scheduler/web'
+    mount Sidekiq::Web => "/sidekiq"
+  end
+
   get :health, to: 'healthcheck#show'
   get :ping,   to: 'healthcheck#ping'
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,5 @@
+---
+:concurrency: 5
+:queues:
+  - default
+  - mailers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
 
+  redis:
+    image: redis:7.0.7-alpine
+
   web:
     build: .
     environment:
@@ -28,8 +31,10 @@ services:
       DISABLE_HTTPS: "1"
       DEV_AUTH_ENABLED: "true"
       IS_LOCAL_DOCKER_ENV: "true"
+      REDIS_URL: redis://redis:6379
     ports:
       - "3001:3001" # puma server (rails app)
       - "9395:9395" # prometheus exporter `/metrics` endpoint
     depends_on:
       - db
+      - redis

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe 'Authorisation' do
     end
   end
 
-  def outside_the_scope_of_this_test
+  def outside_the_scope_of_this_test # rubocop:disable Metrics/MethodLength
     %w[
       _system_test_entrypoint
       api_events
@@ -256,6 +256,7 @@ RSpec.describe 'Authorisation' do
       user_azure_ad_omniauth_authorize
       user_azure_ad_omniauth_callback
       sign_out
+      sidekiq_web
     ]
   end
 

--- a/spec/shared_contexts/with_a_stubbed_mailer.rb
+++ b/spec/shared_contexts/with_a_stubbed_mailer.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.shared_context 'with a stubbed mailer' do
-  let(:mailer_double) { instance_double(ActionMailer::MessageDelivery, deliver_now: true) }
+  let(:mailer_double) { instance_double(ActionMailer::MessageDelivery, deliver_now: true, deliver_later: true) }
 
   let(:notify_mailer_method) { :application_returned_email }
 

--- a/spec/system/casework/reviewing/send_back_to_provider_spec.rb
+++ b/spec/system/casework/reviewing/send_back_to_provider_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'Send an application back to the provider' do
           expect(NotifyMailer).to have_received(:application_returned_email).with(
             crime_application_id, 'duplicate_application'
           )
-          expect(mailer_double).to have_received(:deliver_now)
+          expect(mailer_double).to have_received(:deliver_later)
         end
       end
     end


### PR DESCRIPTION
## Description of change
This change adds Sidekiq to process background jobs. This initial configuration is to be tested in staging in preparation for work to implement automatically generated monthly reports. As a first test, this change should make it so that `application_returned_email` jobs are delegated to the `mailers` queue by Sidekiq.

This relies on an ElastiCache (Redis) instance deployed on CloudPlatform.
I've added Prometheus metrics that we could use to track and set up alerts. We could also set up a Grafana dashboard, as NSCC have done [here](https://grafana.live.cloud-platform.service.justice.gov.uk/d/laa-submit-crime-forms-sidekiq-metrics/laa-non-standard-crime-claims-sidekiq-metrics?from=now-24h&to=now&timezone=browser&var-namespace=laa-assess-crime-forms-prod&var-job=SendEmailToProvider&refresh=1m), though Sidekiq comes with its own web UI we could use, but we'd need to think about how to manage access to it in production.

I tried to keep the Kubernetes setup basic and minimal. I saw some examples of pretty involved startup probe checks, but I'd like to see how the basic one I have works before making it more complex.

I've also pinned the `sidekiq` gem version to 7 as `sidekiq-scheduler`, which we may use to schedule monthly jobs, does not currently support version 8.

## Link to relevant ticket
[CRIMAPP-1679](https://dsdmoj.atlassian.net/browse/CRIMAPP-1679)

[CRIMAPP-1679]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ