### PR TITLE
[CRIMAPP-1679] Fix worker readiness probe

### DIFF
--- a/config/kubernetes/staging/deployment-worker.tpl
+++ b/config/kubernetes/staging/deployment-worker.tpl
@@ -36,7 +36,7 @@ spec:
           exec:
             command:
               - cat
-              - /tmp/sidekiq_process_has_started_and_will_begin_processing_jobs
+              - tmp/sidekiq_process_has_started_and_will_begin_processing_jobs
           periodSeconds: 10
           failureThreshold: 3
         livenessProbe:


### PR DESCRIPTION
## Description of change
A small change to fix the `deployment-worker` readiness probe, which was checking for a file in the wrong directory.

## Link to relevant ticket
[CRIMAPP-1679](https://dsdmoj.atlassian.net/browse/CRIMAPP-1679)

[CRIMAPP-1679]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ