### PR TITLE
[CRIMAPP-1679] Fix and enable Prometheus for Sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,29 +6,11 @@ return if HostEnv.production?
 SIDEKIQ_WILL_PROCESSES_JOBS_FILE = Rails.root.join('tmp/sidekiq_process_has_started_and_will_begin_processing_jobs').freeze
 
 Sidekiq.configure_server do |config|
-  break unless ENV.fetch('ENABLE_PROMETHEUS_EXPORTER', 'false').inquiry.true?
-
-  require 'prometheus_exporter/client'
-  require 'prometheus_exporter/instrumentation'
-
-  config.server_middleware do |chain|
-    chain.add PrometheusExporter::Instrumentation::Sidekiq
-  end
-  config.death_handlers << PrometheusExporter::Instrumentation::Sidekiq.death_handler
   config.on :startup do
     FileUtils.touch(SIDEKIQ_WILL_PROCESSES_JOBS_FILE)
-
-    PrometheusExporter::Instrumentation::Process.start type: 'sidekiq'
-    PrometheusExporter::Instrumentation::SidekiqProcess.start
-    PrometheusExporter::Instrumentation::SidekiqQueue.start(all_queues: true)
-    PrometheusExporter::Instrumentation::SidekiqStats.start
   end
 
   config.on :shutdown do
     FileUtils.rm_f(SIDEKIQ_WILL_PROCESSES_JOBS_FILE)
-  end
-
-  at_exit do
-    PrometheusExporter::Client.default.stop(wait_timeout_seconds: 10)
   end
 end

--- a/config/kubernetes/staging/deployment-worker.tpl
+++ b/config/kubernetes/staging/deployment-worker.tpl
@@ -25,6 +25,8 @@ spec:
       - name: worker
         image: ${ECR_URL}:${IMAGE_TAG}
         imagePullPolicy: Always
+        ports:
+          - containerPort: 9394
         command: ["bundle", "exec", "sidekiq"]
         resources:
           requests:

--- a/config/kubernetes/staging/deployment-worker.tpl
+++ b/config/kubernetes/staging/deployment-worker.tpl
@@ -19,6 +19,7 @@ spec:
       labels:
         app: review-criminal-legal-aid-worker-staging
         tier: worker
+        metrics-target: laa-review-criminal-legal-aid-staging-metrics-target
     spec:
       containers:
       - name: worker

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -19,6 +19,7 @@ spec:
       labels:
         app: review-criminal-legal-aid-web-staging
         tier: frontend
+        metrics-target: laa-review-criminal-legal-aid-staging-metrics-target
     spec:
       containers:
       - name: webapp

--- a/config/kubernetes/staging/service.yml
+++ b/config/kubernetes/staging/service.yml
@@ -26,4 +26,4 @@ spec:
     name: metrics
     targetPort: 9394
   selector:
-    app: review-criminal-legal-aid-web-staging
+    metrics-target: laa-review-criminal-legal-aid-staging-metrics-target


### PR DESCRIPTION
## Description of change
This change enables Prometheus to collect metrics from Sidekiq, alongside this change on Cloud Platform: https://github.com/ministryofjustice/cloud-platform-environments/pull/32646

## Link to relevant ticket
[CRIMAPP-1679](https://dsdmoj.atlassian.net/browse/CRIMAPP-1679)

[CRIMAPP-1679]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ