### PR TITLE
[CRIMAPP-1679] Use ActiveStorage S3 to store generated reports (staging)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -2,7 +2,7 @@ require_relative 'boot'
 
 require 'rails'
 require 'active_record/railtie'
-# require "active_storage/engine"
+require "active_storage/engine"
 require 'action_controller/railtie'
 require 'action_view/railtie'
 require 'action_mailer/railtie'
@@ -50,6 +50,7 @@ module LaaReviewCriminalLegalAid
     unless HostEnv.production?
       config.active_job.queue_adapter = :sidekiq
     end
+    config.action_mailer.deliver_later_queue_name = 'mailers'
 
     # Authentication, authorization, and session configuration
 
@@ -91,6 +92,10 @@ module LaaReviewCriminalLegalAid
 
     # Prohibit all HTML tags
     config.action_view.sanitized_allowed_tags = []
+
+    # Disable the default Active Storage routes
+    # https://edgeguides.rubyonrails.org/active_storage_overview.html#authenticated-controllers
+    config.active_storage.draw_routes = false
 
     config.x.maat_api.oauth_url = ENV.fetch('MAAT_API_OAUTH_URL', nil)
     config.x.maat_api.client_id = ENV.fetch('MAAT_API_CLIENT_ID', nil)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,4 +70,6 @@ Rails.application.configure do
 
   # Allow connections from inside a docker container to this host machine
   config.hosts += %w[host.docker.internal]
+
+  config.active_storage.service = :local
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,4 +92,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.active_storage.service = :amazon
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -62,4 +62,6 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  config.active_storage.service = :test
 end

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -17,3 +17,4 @@ data:
   MAAT_API_API_URL: https://laa-crime-applications-adaptor-uat.apps.live.cloud-platform.service.justice.gov.uk
   MAAT_API_OAUTH_URL: https://caa-api-uat.auth.eu-west-2.amazoncognito.com
   MAAT_API_FIRST_SUPPORTED_MAAT_ID: '6039330'
+  AWS_S3_REGION: eu-west-2

--- a/config/kubernetes/staging/deployment-worker.tpl
+++ b/config/kubernetes/staging/deployment-worker.tpl
@@ -84,3 +84,8 @@ spec:
               secretKeyRef:
                 name: ec-cluster-output
                 key: auth_token
+          - name: AWS_S3_BUCKET
+            valueFrom:
+              secretKeyRef:
+                name: s3-bucket
+                key: bucket_name

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -95,3 +95,8 @@ spec:
               secretKeyRef:
                 name: ec-cluster-output
                 key: auth_token
+          - name: AWS_S3_BUCKET
+            valueFrom:
+              secretKeyRef:
+                name: s3-bucket
+                key: bucket_name

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,12 @@
+local:
+  service: Disk
+  root: <%= Rails.root.join('storage') %>
+
+test:
+  service: Disk
+  root: <%= Rails.root.join('tmp/storage') %>
+
+amazon:
+  service: S3
+  region: <%= ENV['AWS_S3_REGION'] %>
+  bucket: <%= ENV['AWS_S3_BUCKET'] %>

--- a/db/migrate/20250506083556_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250506083556_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_03_15_132443) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_06_083556) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -19,6 +19,34 @@ ActiveRecord::Schema[7.2].define(version: 2024_03_15_132443) do
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
   create_enum "user_role", ["caseworker", "supervisor", "data_analyst"]
+
+  create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.uuid "record_id", null: false
+    t.uuid "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "current_assignments", id: false, force: :cascade do |t|
     t.uuid "user_id", null: false
@@ -96,5 +124,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_03_15_132443) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "current_assignments", "users"
 end


### PR DESCRIPTION
## Description of change
This change sets up ActiveStorage with an S3 bucket to be used to store generated reports. S3 bucket created here: https://github.com/ministryofjustice/cloud-platform-environments/pull/32693
This is for staging only. A separate PR will be created to do this for production.

## Link to relevant ticket
[CRIMAPP-1679](https://dsdmoj.atlassian.net/browse/CRIMAPP-1679)

[CRIMAPP-1679]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ