### PR TITLE
[CRIMAPP-1679] Add aws-sdk-s3 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'omniauth-rails_csrf_protection'
 
 gem 'oauth2'
 
+gem 'aws-sdk-s3', require: false
 gem 'aws-sdk-sns', '~> 1.60', require: false
 
 gem 'aggregate_root'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,16 +101,25 @@ GEM
     ast (2.4.2)
     attr_required (1.0.2)
     aws-eventstream (1.3.0)
-    aws-partitions (1.864.0)
-    aws-sdk-core (3.190.0)
+    aws-partitions (1.1098.0)
+    aws-sdk-core (3.223.0)
       aws-eventstream (~> 1, >= 1.3.0)
-      aws-partitions (~> 1, >= 1.651.0)
-      aws-sigv4 (~> 1.8)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
       jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.100.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.185.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
     aws-sdk-sns (1.70.0)
       aws-sdk-core (~> 3, >= 3.188.0)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.8.0)
+    aws-sigv4 (1.11.0)
       aws-eventstream (~> 1, >= 1.0.2)
     axe-core-api (4.8.0)
       dumb_delegator
@@ -616,6 +625,7 @@ PLATFORMS
 
 DEPENDENCIES
   aggregate_root
+  aws-sdk-s3
   aws-sdk-sns (~> 1.60)
   axe-core-rspec
   bootsnap


### PR DESCRIPTION
## Description of change
This adds the missing `aws-sdk-s3` gem that was forgotten in the last PR, causing staging to crash.

## Link to relevant ticket
[CRIMAPP-1679](https://dsdmoj.atlassian.net/browse/CRIMAPP-1679)

[CRIMAPP-1679]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ