### PR TITLE
[CRIMAPP-1769] improve datastore error messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'logstash-event'
 
 gem 'laa-criminal-applications-datastore-api-client',
     github: 'ministryofjustice/laa-criminal-applications-datastore-api-client',
-    tag: 'v1.2.1',
+    tag: 'v1.2.4',
     require: 'datastore_api'
 
 gem 'laa-criminal-legal-aid-schemas',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-applications-datastore-api-client.git
-  revision: d909b89aea359a6a7b991947ec8a3fd46e0677ba
-  tag: v1.2.1
+  revision: 1486d188e9cdc5655477ee674c6df6b5e0dfe8da
+  tag: v1.2.4
   specs:
-    laa-criminal-applications-datastore-api-client (1.1.0)
+    laa-criminal-applications-datastore-api-client (1.2.4)
       faraday (~> 2.7)
       moj-simple-jwt-auth (~> 0.1.0)
 

--- a/app/controllers/casework/base_controller.rb
+++ b/app/controllers/casework/base_controller.rb
@@ -9,9 +9,15 @@ module Casework
     helper_method :assignments_count, :set_crime_application
 
     rescue_from DatastoreApi::Errors::ApiError do |e|
-      Rails.error.report(e, handled: true, severity: :error)
+      Rails.error.report(e, handled: false, severity: :error)
 
-      render status: :internal_server_error, template: 'errors/datastore_error'
+      render status: :internal_server_error, template: 'errors/internal_server_error'
+    end
+
+    rescue_from DatastoreApi::Errors::ConflictError do |e|
+      Rails.error.report(e, handled: false, severity: :error)
+
+      render status: :unprocessable_entity, template: 'errors/unprocessable_entity'
     end
 
     rescue_from DatastoreApi::Errors::NotFoundError do

--- a/app/controllers/casework/crime_applications_controller.rb
+++ b/app/controllers/casework/crime_applications_controller.rb
@@ -40,9 +40,11 @@ module Casework
       ).call
 
       set_flash :marked_as_ready
+
+      redirect_to crime_application_path(@crime_application)
     rescue Reviewing::Error => e
       set_flash(e.message_key, success: false)
-    ensure
+
       redirect_to crime_application_path(@crime_application)
     end
 

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -27,7 +27,7 @@ class ErrorsController < ApplicationController
   def error_page
     return :internal_server_error if status >= 500
     return :forbidden if status == 403
-    return :unprocessable_entity if [422, 400].include? status
+    return :unprocessable_entity if [422, 400, 409].include? status
 
     :not_found
   end

--- a/app/views/errors/datastore_error.html.erb
+++ b/app/views/errors/datastore_error.html.erb
@@ -1,8 +1,0 @@
-<% title t('.page_title') %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-    <p class="govuk-body-l"><%=t '.body_1' %></p>
-  </div>
-</div>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -3,5 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t '.heading' %></h1>
+    <p class="govuk-body-l"><%=t '.body_1' %></p>
+    <p class="govuk-body-l"><%= sanitize t('.body_2', url: mail_to(Rails.configuration.x.admin.onboarding_email)) %></p>
   </div>
 </div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -3,7 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t '.heading' %></h1>
-
     <p class="govuk-body-l"><%=t '.body_1' %></p>
     <p class="govuk-body-l"><%= sanitize t('.body_2', url: mail_to(Rails.configuration.x.admin.onboarding_email)) %></p>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,7 +2,7 @@ require_relative 'boot'
 
 require 'rails'
 require 'active_record/railtie'
-require "active_storage/engine"
+require 'active_storage/engine'
 require 'action_controller/railtie'
 require 'action_view/railtie'
 require 'action_mailer/railtie'
@@ -84,7 +84,8 @@ module LaaReviewCriminalLegalAid
       'Allocating::WorkStreamNotFound' => :not_found,
       'Deciding::DecisionNotFound' => :not_found,
       'Deciding::ApplicationNotAssignedToUser' => :forbidden,
-      'ApplicationController::ForbiddenError' => :forbidden
+      'ApplicationController::ForbiddenError' => :forbidden,
+      'DatastoreApi::Errors::NotFoundError' => :not_found
     )
 
     # Prohibit all HTML tags

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/integer/time"
+require 'active_support/core_ext/integer/time'
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
@@ -14,12 +14,12 @@ Rails.application.configure do
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration
   # system, or in some way before deploying your code.
-  config.eager_load = ENV["CI"].present?
+  config.eager_load = ENV['CI'].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
+    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
   }
 
   # Show full error reports and disable caching.

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -6,11 +6,11 @@ en:
     attributes:
       add_another_decision:
         inclusion: Select yes to add another case
-      assessed_by: 
+      assessed_by:
         blank: Enter the caseworker name
-      assessed_on: 
+      assessed_on:
         blank: Enter the date of the test
-      base: 
+      base:
         incomplete_decisions: Complete decision details first
       details:
         blank: Enter a reason for the result
@@ -23,7 +23,7 @@ en:
         inclusion: Select the funding decision
       reason:
         inclusion: Choose a reason
-      result: 
+      result:
         blank: Select a result for the Interest of justice test
         inclusion: Select a result for the Interest of justice test
       maat_id:
@@ -32,7 +32,7 @@ en:
         not_a_number: *invalid_maat_id
         greater_than: *invalid_maat_id
         record_not_found: *invalid_maat_id
-        reference_mismatch: This MAAT ID is linked to another LAA reference number 
+        reference_mismatch: This MAAT ID is linked to another LAA reference number
         already_linked: This MAAT ID is linked to another application
         decision_already_linked: This MAAT ID is already linked
       next_step:
@@ -58,14 +58,12 @@ en:
       body_3: If the web address is correct or you selected a link or button, contact %{url} for help.
     internal_server_error:
       page_title: Unexpected error
-      heading: Sorry, something went wrong with our service
+      heading: Sorry, there is a problem with the service
+      body_1: Try again later.
+      body_2: If this problem continues, contact %{url} for help.
     forbidden:
       page_title: Not authorised
       heading: Access to this service is restricted
-    datastore_error:
-      page_title: Unexpected error
-      heading: Sorry, something went wrong with our service
-      body_1: We cannot connect to our database. This means you cannot view, search, or review applications.
     unprocessable_entity:
       page_title: Request error
       heading: Sorry, there is a problem with your request


### PR DESCRIPTION
## Description of change

Show better error messages for Datastore API errors

## Link to relevant ticket

[CRIMAPP-1769](https://dsdmoj.atlassian.net/browse/CRIMAPP-1769)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1769]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ