### PR TITLE
[CRIMAPP-1679] Create GeneratedReports table and job

### DIFF
--- a/app/controllers/reporting/generated_reports_controller.rb
+++ b/app/controllers/reporting/generated_reports_controller.rb
@@ -1,0 +1,26 @@
+module Reporting
+  class GeneratedReportsController < Reporting::BaseController
+    before_action :require_download_access!, only: [:download]
+    before_action :generated_report
+    before_action :report_type
+    before_action :require_report_access!
+
+    def download
+      report = generated_report.report
+      send_data report.download,
+                filename: report.filename.to_s,
+                content_type: report.content_type,
+                disposition: 'attachment'
+    end
+
+    private
+
+    def generated_report
+      @generated_report ||= GeneratedReport.find(params.require(:id))
+    end
+
+    def report_type
+      @report_type ||= generated_report.report_type
+    end
+  end
+end

--- a/app/controllers/reporting/user_reports_controller.rb
+++ b/app/controllers/reporting/user_reports_controller.rb
@@ -8,6 +8,7 @@ module Reporting
     def index
       @latest_temporal_reports = latest_temporal_reports
       @snapshot_report_types = snapshot_report_types
+      @downloadable_reports = GeneratedReport.all
     end
 
     def show

--- a/app/jobs/generate_downloadable_temporal_report_job.rb
+++ b/app/jobs/generate_downloadable_temporal_report_job.rb
@@ -1,0 +1,38 @@
+class GenerateDownloadableTemporalReportJob < ApplicationJob
+  queue_as :reports
+
+  def perform(report_type, interval) # rubocop:disable Metrics/MethodLength
+    report = Reporting::TemporalReport.klass_for_interval(interval).new(
+      time_period: previous_time_period(interval:),
+      report_type: report_type
+    )
+
+    io = StringIO.new(report.csv)
+    io.set_encoding('UTF-8')
+
+    GeneratedReport.create!(
+      report_type: report_type,
+      interval: interval,
+      period_start_date: report.time_period.starts_on,
+      period_end_date: report.time_period.ends_on,
+      report: {
+        io: io,
+        filename: "#{report_type}_#{interval}_#{report.period_as_param}.csv",
+        content_type: 'text/csv'
+      }
+    )
+  end
+
+  private
+
+  def previous_time_period(interval:, date: Time.current)
+    previous_date =
+      case interval
+      when 'monthly' then date.last_month
+      when 'weekly' then date.last_week
+      when 'daily' then date.yesterday
+      end
+
+    Reporting::TimePeriod.new(interval: interval, date: previous_date)
+  end
+end

--- a/app/models/generated_report.rb
+++ b/app/models/generated_report.rb
@@ -1,0 +1,10 @@
+class GeneratedReport < ApplicationRecord
+  has_one_attached :report
+
+  default_scope { order(created_at: :desc) }
+
+  def period
+    format = Reporting::TemporalReport.klass_for_interval(interval)::PERIOD_NAME_FORMAT
+    period_start_date.strftime(format)
+  end
+end

--- a/app/models/reporting/caseworker_report.rb
+++ b/app/models/reporting/caseworker_report.rb
@@ -19,6 +19,16 @@ module Reporting
       sorted_rows.reverse
     end
 
+    def csv(*)
+      CSV.generate(headers: true) do |csv|
+        csv << ['caseworker', *CaseworkerReports::Row::COUNTERS]
+
+        rows.each do |row|
+          csv << [row.user_name, *CaseworkerReports::Row::COUNTERS.map { |c| row.send(c) }]
+        end
+      end
+    end
+
     private
 
     attr_reader :dataset

--- a/app/models/reporting/temporal_report.rb
+++ b/app/models/reporting/temporal_report.rb
@@ -15,7 +15,7 @@ module Reporting
       {
         report_type: report_type,
         interval: time_period.interval,
-        period: time_period.starts_on.strftime(self.class::PARAM_FORMAT)
+        period: period_as_param
       }
     end
 
@@ -67,6 +67,10 @@ module Reporting
       raise 'Implement in subclass.'
     end
     # :nocov:
+
+    def period_as_param
+      time_period.starts_on.strftime(self.class::PARAM_FORMAT)
+    end
 
     private
 

--- a/app/views/reporting/user_reports/index.html.erb
+++ b/app/views/reporting/user_reports/index.html.erb
@@ -37,3 +37,24 @@
     </h3>
   </div>
 </div>
+
+<% if current_user.can_download_reports? && @downloadable_reports.present? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-m">
+        <%= t '.downloads' %>
+      </h2>
+
+      <% @downloadable_reports.group_by(&:report_type).each do |report_type, reports| %>
+        <h3 class="govuk-heading-s">
+          <%= label_text(report_type).pluralize %>
+        </h3>
+        <% reports.each do |report| %>
+          <p class="govuk-body">
+            <%= govuk_link_to(label_text('download_generated_report', interval: report.interval, period: report.period), reporting_download_generated_report_path(report), no_visited_state: true) %>
+          </p>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/en/reporting.yml
+++ b/config/locales/en/reporting.yml
@@ -22,6 +22,7 @@ en:
       index:
         page_title: Reporting 
         heading: Reports
+        downloads: Downloads
   labels:
     return_reasons_report: Return reasons report
     workload_report: Workload report
@@ -35,6 +36,7 @@ en:
       monthly: month 
       weekly: week 
       daily: day 
+    download_generated_report: Download %{interval} report for %{period} (CSV)
   table_headings:
     application_type: Application type
     applications_closed: Number of closed applications

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,8 @@ Rails.application.routes.draw do
 
   namespace :reporting do
     root to: 'user_reports#index'
+    get 'generated-reports/:id/download', to: 'generated_reports#download', as: :download_generated_report
+
     get ':report_type', to: 'user_reports#show', as: 'user_report'
 
     get ':report_type/:interval/latest-complete', to: 'temporal_reports#latest_complete', as: :latest_complete_temporal_report

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,3 +3,11 @@
 :queues:
   - default
   - mailers
+  - reports
+:scheduler:
+  :schedule:
+    # for testing purposes only
+    caseworker_report_test:
+      cron: '15 * * * *' # every 15 min
+      class: GenerateDownloadableTemporalReportJob
+      args: ['caseworker_report', 'monthly']

--- a/db/migrate/20250506144826_create_generated_reports.rb
+++ b/db/migrate/20250506144826_create_generated_reports.rb
@@ -1,0 +1,11 @@
+class CreateGeneratedReports < ActiveRecord::Migration[7.2]
+  def change
+    create_table :generated_reports, id: :uuid do |t|
+      t.string :report_type
+      t.string :interval
+      t.datetime :period_start_date
+      t.datetime :period_end_date
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_06_083556) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_06_144826) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -76,6 +76,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_06_083556) do
     t.index ["created_at"], name: "index_event_store_events_in_streams_on_created_at"
     t.index ["stream", "event_id"], name: "index_event_store_events_in_streams_on_stream_and_event_id", unique: true
     t.index ["stream", "position"], name: "index_event_store_events_in_streams_on_stream_and_position", unique: true
+  end
+
+  create_table "generated_reports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "report_type"
+    t.string "interval"
+    t.datetime "period_start_date"
+    t.datetime "period_end_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "received_on_reports", primary_key: "business_day", id: :date, force: :cascade do |t|

--- a/spec/jobs/generate_downloadable_temporal_report_job_spec.rb
+++ b/spec/jobs/generate_downloadable_temporal_report_job_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe GenerateDownloadableTemporalReportJob, type: :job do
+  it 'is in reports queue' do
+    expect(described_class.new.queue_name).to eq('reports')
+  end
+
+  describe 'generating caseworker reports' do
+    subject(:job) { described_class.perform_now(report_type, period) }
+
+    let(:report_type) { 'caseworker_report' }
+
+    before do
+      travel_to Time.zone.local(2025, 5, 8)
+      job
+    end
+
+    describe 'for the previous month' do
+      let(:period) { 'monthly' }
+
+      it 'creates one report record' do
+        expect(GeneratedReport.count).to eq(1)
+      end
+
+      it 'creates a report record with the right attributes' do # rubocop:disable RSpec/MultipleExpectations
+        generated_report = GeneratedReport.first
+        expect(generated_report.report_type).to eq('caseworker_report')
+        expect(generated_report.interval).to eq('monthly')
+        expect(generated_report.period_start_date).to eq(Date.parse('2025-04-01'))
+        expect(generated_report.period_end_date).to eq(Date.parse('2025-04-30'))
+      end
+
+      it 'attaches a report CSV to the record' do # rubocop:disable RSpec/MultipleExpectations
+        report_file = GeneratedReport.first.report
+        expect(report_file).not_to be_nil
+        expect(report_file.filename).to eq('caseworker_report_monthly_2025-April.csv')
+        expect(report_file.content_type).to eq('text/csv')
+      end
+    end
+
+    describe 'for the previous week' do
+      let(:period) { 'weekly' }
+
+      it 'creates one report record' do
+        expect(GeneratedReport.count).to eq(1)
+      end
+
+      it 'creates a report record with the right attributes' do # rubocop:disable RSpec/MultipleExpectations
+        generated_report = GeneratedReport.first
+        expect(generated_report.report_type).to eq('caseworker_report')
+        expect(generated_report.interval).to eq('weekly')
+        expect(generated_report.period_start_date).to eq(Date.parse('2025-04-28'))
+        expect(generated_report.period_end_date).to eq(Date.parse('2025-05-04'))
+      end
+
+      it 'attaches a report CSV to the record' do # rubocop:disable RSpec/MultipleExpectations
+        report_file = GeneratedReport.first.report
+        expect(report_file).not_to be_nil
+        expect(report_file.filename).to eq('caseworker_report_weekly_2025-18.csv')
+        expect(report_file.content_type).to eq('text/csv')
+      end
+    end
+
+    describe 'for the previous day' do
+      let(:period) { 'daily' }
+
+      it 'creates one report record' do
+        expect(GeneratedReport.count).to eq(1)
+      end
+
+      it 'creates a report record with the right attributes' do # rubocop:disable RSpec/MultipleExpectations
+        generated_report = GeneratedReport.first
+        expect(generated_report.report_type).to eq('caseworker_report')
+        expect(generated_report.interval).to eq('daily')
+        expect(generated_report.period_start_date).to eq(Date.parse('2025-05-07'))
+        expect(generated_report.period_end_date).to eq(Date.parse('2025-05-07'))
+      end
+
+      it 'attaches a report CSV to the record' do # rubocop:disable RSpec/MultipleExpectations
+        report_file = GeneratedReport.first.report
+        expect(report_file).not_to be_nil
+        expect(report_file.filename).to eq('caseworker_report_daily_2025-05-07.csv')
+        expect(report_file.content_type).to eq('text/csv')
+      end
+    end
+  end
+end

--- a/spec/models/reporting/caseworker_report_spec.rb
+++ b/spec/models/reporting/caseworker_report_spec.rb
@@ -83,4 +83,30 @@ describe Reporting::CaseworkerReport do
       end
     end
   end
+
+  describe '#csv' do
+    subject(:csv) { report.csv }
+
+    let(:dataset) do
+      {
+        a: instance_double(CaseworkerReports::Row, user_name: 'Al Hart', assigned_to_user: 4, reassigned_to_user: 0,
+reassigned_from_user: 0, unassigned_from_user: 0, completed_by_user: 5, sent_back_by_user: 1),
+        b: instance_double(CaseworkerReports::Row, user_name: 'Bo Brown', assigned_to_user: 7, reassigned_to_user: 1,
+reassigned_from_user: 0, unassigned_from_user: 0, completed_by_user: 7, sent_back_by_user: 3),
+        c: instance_double(CaseworkerReports::Row, user_name: 'An Brown', assigned_to_user: 2, reassigned_to_user: 1,
+reassigned_from_user: 1, unassigned_from_user: 0, completed_by_user: 1, sent_back_by_user: 1)
+      }
+    end
+
+    # rubocop:disable Layout/LineLength
+    it 'has the correct data' do
+      expect(csv).to eq(
+        "caseworker,assigned_to_user,reassigned_to_user,reassigned_from_user,unassigned_from_user,completed_by_user,sent_back_by_user\n" \
+        "Al Hart,4,0,0,0,5,1\n" \
+        "An Brown,2,1,1,0,1,1\n" \
+        "Bo Brown,7,1,0,0,7,3\n"
+      )
+    end
+    # rubocop:enable Layout/LineLength
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require 'laa_crime_schemas'
 require 'spec_helper'
 require 'rspec/rails'
 require 'axe-rspec'
+require 'sidekiq/testing'
 
 ['init/*.rb', 'shared_contexts/*.rb', 'shared_examples/*.rb', 'support/**/*.rb'].each do |path|
   Dir[File.expand_path(path, __dir__)].each { |f| require f }

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe 'Authorisation' do
       application_searches_search
       assigned_applications_next_application
       reporting
+      reporting_download_generated_report
     ]
   end
 
@@ -113,7 +114,7 @@ RSpec.describe 'Authorisation' do
   end
 
   let(:data_analyst_routes) do
-    %w[reporting_download_temporal_report]
+    %w[reporting_download_temporal_report reporting_download_generated_report]
   end
 
   let(:current_user_can_manage_others) { false }

--- a/spec/system/reporting/generated_reports_spec.rb
+++ b/spec/system/reporting/generated_reports_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe 'Generated reports' do
+  let!(:generated_report) do
+    GeneratedReport.create!(
+      report_type: 'caseworker_report',
+      interval: 'monthly',
+      period_start_date: Date.parse('2025-04-01'),
+      period_end_date: Date.parse('2025-04-30'),
+      report: {
+        io: StringIO.new('caseworker report'),
+        filename: 'caserworker_report_monthly_2025-April.csv',
+        content_type: 'text/csv',
+      }
+    )
+  end
+
+  before do
+    visit reporting_root_path
+  end
+
+  context 'when the user is a data analyst' do
+    let(:current_user_role) { UserRole::DATA_ANALYST }
+
+    it 'shows the right headings' do
+      expect(page).to have_selector('h2', text: 'Downloads')
+      expect(page).to have_selector('h3', text: 'Caseworker reports')
+    end
+
+    it 'shows the download link' do
+      expect(page).to have_link('Download monthly report for April 2025 (CSV)')
+    end
+
+    describe 'downloading the report' do
+      before do
+        click_link('Download monthly report for April 2025 (CSV)')
+      end
+
+      it 'has the correct content type' do
+        expect(page.driver.response.content_type).to eq('text/csv')
+      end
+
+      it 'has the correct body' do
+        expect(page.driver.response.body).to eq('caseworker report')
+      end
+
+      it 'has the correct file name' do
+        expect(page.driver.response.headers['Content-Disposition']).to match(
+          'caserworker_report_monthly_2025-April.csv'
+        )
+      end
+
+      it 'can visit the download link to get the report' do
+        visit reporting_download_generated_report_path(generated_report)
+        expect(page.driver.response.headers['Content-Disposition']).to match(
+          'caserworker_report_monthly_2025-April.csv'
+        )
+      end
+    end
+  end
+
+  context 'when user is a supervisor' do
+    let(:current_user_role) { UserRole::SUPERVISOR }
+
+    it 'does not show the headings' do
+      expect(page).not_to have_text('Downloads')
+      expect(page).not_to have_text('Caseworker reports')
+    end
+
+    it 'does not show the download link' do
+      expect(page).not_to have_link('Download monthly report for April 2025 (CSV)')
+    end
+
+    it 'cannot visit the download link to get the report' do
+      visit reporting_download_generated_report_path(generated_report)
+      expect(page).to have_http_status :forbidden
+    end
+  end
+end

--- a/spec/system/reporting/generated_reports_spec.rb
+++ b/spec/system/reporting/generated_reports_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Generated reports' do
       period_end_date: Date.parse('2025-04-30'),
       report: {
         io: StringIO.new('caseworker report'),
-        filename: 'caserworker_report_monthly_2025-April.csv',
+        filename: 'caseworker_report_monthly_2025-April.csv',
         content_type: 'text/csv',
       }
     )
@@ -46,14 +46,14 @@ RSpec.describe 'Generated reports' do
 
       it 'has the correct file name' do
         expect(page.driver.response.headers['Content-Disposition']).to match(
-          'caserworker_report_monthly_2025-April.csv'
+          'caseworker_report_monthly_2025-April.csv'
         )
       end
 
       it 'can visit the download link to get the report' do
         visit reporting_download_generated_report_path(generated_report)
         expect(page.driver.response.headers['Content-Disposition']).to match(
-          'caserworker_report_monthly_2025-April.csv'
+          'caseworker_report_monthly_2025-April.csv'
         )
       end
     end


### PR DESCRIPTION
## Description of change
This change creates the job `GenerateDownloadableTemporalReportJob`, which creates and stores a CSV report for the given report type and interval. For now, the job creates a report for the previous month, week, or day, relative to when the job is executed. Additionally, the job is scheduled to run every 15 minutes for quick testing on staging.

The table `generated_reports` stores the reports generated by the job.

The generated reports are shown as download links in a basic layout on `/reporting` for authorised users only.

## Link to relevant ticket
[CRIMAPP-1679](https://dsdmoj.atlassian.net/browse/CRIMAPP-1679)

[CRIMAPP-1679]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ