### PR TITLE
[CRIMAPP-1679] Basic auth for Sidekiq UI

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -14,3 +14,11 @@ Sidekiq.configure_server do |config|
     FileUtils.rm_f(SIDEKIQ_WILL_PROCESSES_JOBS_FILE)
   end
 end
+
+if Rails.env.production?
+  require "sidekiq/web"
+  Sidekiq::Web.use Rack::Auth::Basic do |username, password|
+    ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_UI_USERNAME"])) &
+      ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_UI_PASSWORD"]))
+  end
+end


### PR DESCRIPTION
## Description of change
This adds HTTP basic auth to the Sidekiq UI, accessible on `/sidekiq`. The username and password will be added as secrets.

## Link to relevant ticket
[CRIMAPP-1679](https://dsdmoj.atlassian.net/browse/CRIMAPP-1679)

[CRIMAPP-1679]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ