### PR TITLE
[CRIMAPP-1679] Add service account name to staging

### DIFF
--- a/config/kubernetes/staging/deployment-worker.tpl
+++ b/config/kubernetes/staging/deployment-worker.tpl
@@ -21,6 +21,7 @@ spec:
         tier: worker
         metrics-target: laa-review-criminal-legal-aid-staging-metrics-target
     spec:
+      serviceAccountName: laa-review-criminal-legal-aid-staging-service
       containers:
       - name: worker
         image: ${ECR_URL}:${IMAGE_TAG}

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -21,6 +21,7 @@ spec:
         tier: frontend
         metrics-target: laa-review-criminal-legal-aid-staging-metrics-target
     spec:
+      serviceAccountName: laa-review-criminal-legal-aid-staging-service
       containers:
       - name: webapp
         image: ${ECR_URL}:${IMAGE_TAG}


### PR DESCRIPTION
## Description of change
This adds the service account name to staging deployments to (hopefully) allow access to S3 using IRSA. Accompanying CloudPlatform PR: https://github.com/ministryofjustice/cloud-platform-environments/pull/32815

## Link to relevant ticket
[CRIMAPP-1679](https://dsdmoj.atlassian.net/browse/CRIMAPP-1679)

[CRIMAPP-1679]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ