### PR TITLE
[CRIMAPP-1679] Enable Sidekiq and update infrastructure in prod

### DIFF
--- a/app/lib/prometheus_metrics/configuration.rb
+++ b/app/lib/prometheus_metrics/configuration.rb
@@ -42,8 +42,6 @@ module PrometheusMetrics
     end
 
     def self.sidekiq?
-      return false if HostEnv.production?
-
       Sidekiq.server?
     end
 

--- a/app/notifiers/access_granted_notifier.rb
+++ b/app/notifiers/access_granted_notifier.rb
@@ -2,7 +2,7 @@ class AccessGrantedNotifier
   def call(event)
     Rails.error.handle do
       email = User.find(event.data.fetch(:user_id)).email
-      NotifyMailer.access_granted_email(email).deliver_now
+      NotifyMailer.access_granted_email(email).deliver_later
     end
   end
 end

--- a/app/notifiers/role_changed_notifier.rb
+++ b/app/notifiers/role_changed_notifier.rb
@@ -4,7 +4,7 @@ class RoleChangedNotifier
       admin_emails = User.admins.map(&:email)
       user = User.find(event.data.fetch(:user_id))
 
-      NotifyMailer.role_changed_email(admin_emails, user).deliver_now
+      NotifyMailer.role_changed_email(admin_emails, user).deliver_later
     end
   end
 end

--- a/app/notifiers/sent_back_notifier.rb
+++ b/app/notifiers/sent_back_notifier.rb
@@ -4,13 +4,7 @@ class SentBackNotifier
       application_id = event.data.fetch(:application_id)
       return_reason = event.data.fetch(:reason)
 
-      if HostEnv.production?
-        # :nocov:
-        NotifyMailer.application_returned_email(application_id, return_reason).deliver_now
-        # :nocov:
-      else
-        NotifyMailer.application_returned_email(application_id, return_reason).deliver_later
-      end
+      NotifyMailer.application_returned_email(application_id, return_reason).deliver_later
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,6 @@ require 'action_cable/engine'
 require 'rails/test_unit/railtie'
 
 require_relative '../app/lib/notify_mailer_interceptor'
-require_relative '../app/lib/host_env'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -47,9 +46,7 @@ module LaaReviewCriminalLegalAid
       g.orm :active_record, primary_key_type: :uuid
     end
 
-    unless HostEnv.production?
-      config.active_job.queue_adapter = :sidekiq
-    end
+    config.active_job.queue_adapter = :sidekiq
     config.action_mailer.deliver_later_queue_name = 'mailers'
 
     # Authentication, authorization, and session configuration

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,3 @@
-require 'host_env'
-
-return if HostEnv.production?
-
 # For k8s readiness probe - taken from https://github.com/sidekiq/sidekiq/wiki/Kubernetes#sidekiq
 SIDEKIQ_WILL_PROCESSES_JOBS_FILE = Rails.root.join('tmp/sidekiq_process_has_started_and_will_begin_processing_jobs').freeze
 

--- a/config/kubernetes/production/service.yml
+++ b/config/kubernetes/production/service.yml
@@ -26,4 +26,4 @@ spec:
     name: metrics
     targetPort: 9394
   selector:
-    app: review-criminal-legal-aid-web-production
+    metrics-target: laa-review-criminal-legal-aid-production-metrics-target

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,6 @@ Rails.application.routes.draw do
   Rails.application.routes.draw { mount RailsEventStore::Browser => "/res" if Rails.env.development? }
   mount DatastoreApi::HealthEngine::Engine => '/datastore'
 
-  # TODO: should this be accessible in prod? By which users?
   unless HostEnv.production?
     require 'sidekiq/web'
     require 'sidekiq-scheduler/web'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,8 +6,7 @@
   - reports
 :scheduler:
   :schedule:
-    # for testing purposes only
-    caseworker_report_test:
-      cron: '15 * * * *' # every 15 min
+    monthly_caseworker_report:
+      cron: '0 0 1 * *' # midnight, 1st of each month
       class: GenerateDownloadableTemporalReportJob
       args: ['caseworker_report', 'monthly']

--- a/spec/shared_contexts/with_a_stubbed_mailer.rb
+++ b/spec/shared_contexts/with_a_stubbed_mailer.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.shared_context 'with a stubbed mailer' do
-  let(:mailer_double) { instance_double(ActionMailer::MessageDelivery, deliver_now: true, deliver_later: true) }
+  let(:mailer_double) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
 
   let(:notify_mailer_method) { :application_returned_email }
 

--- a/spec/system/manage_users/add_user_spec.rb
+++ b/spec/system/manage_users/add_user_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Invites from manage users dashboard' do
     click_button 'Invite'
 
     expect(NotifyMailer).to have_received(:access_granted_email).with(email)
-    expect(mailer_double).to have_received(:deliver_now)
+    expect(mailer_double).to have_received(:deliver_later)
   end
 
   it 'allows a user without management access to be added' do

--- a/spec/system/manage_users/change_user_role_spec.rb
+++ b/spec/system/manage_users/change_user_role_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Change user role' do
       click_on 'Save new role'
 
       expect(NotifyMailer).to have_received(:role_changed_email).with(admin_emails, active_user)
-      expect(mailer_double).to have_received(:deliver_now)
+      expect(mailer_double).to have_received(:deliver_later)
     end
   end
 


### PR DESCRIPTION
## Description of change
This change:
- Makes all mail delivery async
- Removes redundant production checks, enabling Sidekiq in production
- Applies the necessary infrastructure changes to create worker pods in production
- Adds a monthly caseworker report to the scheduler

Accompanying CloudPlatform PR: https://github.com/ministryofjustice/cloud-platform-environments/pull/32848

## Link to relevant ticket
[CRIMAPP-1679](https://dsdmoj.atlassian.net/browse/CRIMAPP-1679)

[CRIMAPP-1679]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ