### PR TITLE
[CRIMAPP-1679] Limit access to Sidekiq Web

### DIFF
--- a/app/models/concerns/user_role.rb
+++ b/app/models/concerns/user_role.rb
@@ -57,6 +57,10 @@ module UserRole
     can_manage_others?
   end
 
+  def admin?
+    can_manage_others?
+  end
+
   def available_roles
     Types::USER_ROLES - [role]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,11 @@ Rails.application.routes.draw do
   mount DatastoreApi::HealthEngine::Engine => '/datastore'
 
   unless HostEnv.production?
-    require 'sidekiq/web'
-    require 'sidekiq-scheduler/web'
-    mount Sidekiq::Web => "/sidekiq"
+    authenticate :user, lambda { |u| u.admin? } do
+      require 'sidekiq/web'
+      require 'sidekiq-scheduler/web'
+      mount Sidekiq::Web => "/sidekiq"
+    end
   end
 
   get :health, to: 'healthcheck#show'

--- a/spec/models/concerns/user_role_spec.rb
+++ b/spec/models/concerns/user_role_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe UserRole do
   end
 
   describe '#admin?' do
-    context 'with can_manager_others attribute set to true' do
+    context 'with can_manage_others attribute set to true' do
       it 'returns true' do
         user.can_manage_others = true
         expect(user.admin?).to be true

--- a/spec/models/concerns/user_role_spec.rb
+++ b/spec/models/concerns/user_role_spec.rb
@@ -269,4 +269,13 @@ RSpec.describe UserRole do
       end
     end
   end
+
+  describe '#admin?' do
+    context 'with can_manager_others attribute set to true' do
+      it 'returns true' do
+        user.can_manage_others = true
+        expect(user.admin?).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
This change limits access to the Sidekiq Web UI to admin/user managers in staging and locally. There will be no way to access it in hosted production.

## Link to relevant ticket
[CRIMAPP-1679](https://dsdmoj.atlassian.net/browse/CRIMAPP-1679)

[CRIMAPP-1679]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ