### PR TITLE
[CRIMAPP-957] Print stylesheet amends

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -14,12 +14,20 @@
     display: none;
   }
 
-  main {
-    padding: 0 !important;
-    margin: 3em !important;
+  // Prevents bleeding edges
+  @page {
+    size: auto;
+    margin: 20mm 10mm 10mm 10mm;
+  }
 
-    .govuk-grid-column-two-thirds {
-      width: 100% !important;
+  main {
+    // Keeps document in colour for legibility
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+
+    // Prevents cards being broken up on multiple pages
+    .govuk-summary-card {
+      break-inside: avoid;
     }
   }
 }


### PR DESCRIPTION
## Description of change
Amends the print stylesheet to add colour to the document and prevent summary cards from breaking up across pages. 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-957

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1358" alt="Screenshot 2025-05-15 at 08 57 45" src="https://github.com/user-attachments/assets/df4bd4ee-8215-4b24-a224-195b16b4072c" />

## How to manually test the feature
