### PR TITLE
[CRIMAPP-1742] alert if ModSecurity blocks likely user

### DIFF
--- a/config/kubernetes/staging/prometheus.yml
+++ b/config/kubernetes/staging/prometheus.yml
@@ -94,7 +94,7 @@ spec:
 
         - alert: CrimeReview-BlockedRequest
           expr: >-
-            sum(rate(nginx_ingress_controller_requests{exported_namespace=~"^laa-review-criminal-legal-aid.*", status=~"423"}[5m]) * 60 > 5)
+            sum(rate(nginx_ingress_controller_requests{exported_namespace=~"^laa-review-criminal-legal-aid.*", status=~"423"}[5m]) > 0)
             by (exported_namespace)
           for: 1m
           labels:


### PR DESCRIPTION
## Description of change

Alert when Crime Review service blocks a users from GP ip range

## Link to relevant ticket

[CRIMAPP-1742](https://dsdmoj.atlassian.net/browse/CRIMAPP-1742)

## Notes for reviewer

This is currently experimental in terms of frequency and sensitivity of alerting.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1742]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ