### PR TITLE
[CRIMAPP-1795] Update Snyk Container workflow

### DIFF
--- a/.github/workflows/snyk-container.yml
+++ b/.github/workflows/snyk-container.yml
@@ -16,6 +16,7 @@ name: Snyk Container
 on:
   schedule:
     - cron: '30 22 * * 1,4' # At 22:30 on Monday and Thursday.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -45,7 +46,13 @@ jobs:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
         image: app
-        args: --file=Dockerfile --severity-threshold=low --sarif-file-output=snyk.sarif
+        args: --file=Dockerfile
+    - name: Replace security-severity "null" for license-related findings 
+      run: |
+        sed -i 's/"security-severity": "null"/"security-severity": "0"/g' snyk.sarif
+    - name: Replace security-severity "undefined" for license-related findings 
+      run: |
+        sed -i 's/"security-severity": "undefined"/"security-severity": "0"/g' snyk.sarif
     - name: Upload result to GitHub Code Scanning
       uses: github/codeql-action/upload-sarif@v3
       with:


### PR DESCRIPTION
## Description of change
This change updates the Snyk Container workflow by adding a couple of `security-severity` fixes that should resolve the errors in the current workflow.

This also adds the ability to run the workflow manually for testing purposes.
As part of this, I have updated the `SNYK_TOKEN` secret to be my PAT while I'm testing this. If we're happy with using Snyk as our main container image scanner, we should create a service account and use a Snyk token linked to it.

## Link to relevant ticket
[CRIMAPP-1795](https://dsdmoj.atlassian.net/browse/CRIMAPP-1795)

## How to manually test the feature
Run the Snyk Container workflow and check the output.


[CRIMAPP-1795]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ