### PR TITLE
[CRIMAPP-1742] production ingress allow list and ModSec

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -1,3 +1,57 @@
+# production public ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-production-public
+  namespace: laa-review-criminal-legal-aid-production
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: ingress-production-public-laa-review-criminal-legal-aid-production-green
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
+    nginx.ingress.kubernetes.io/modsecurity-transaction-id: "$request_id"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
+      SecRule REQUEST_URI "@beginsWith /api/events" "id:5001, phase:1, pass, t:none, nolog, chain" \
+        SecRule REQUEST_METHOD "@streq POST" "chain" \
+          SecRule REQUEST_HEADERS:Content-Type "@rx [\s]*text/plain[\s]*" "ctl:ruleRemoveById=920420"
+spec:
+  ingressClassName: modsec-non-prod
+  rules:
+    - host: review-criminal-legal-aid.service.justice.gov.uk
+      http:
+        paths:
+          - path: /ping
+            pathType: Exact
+            backend:
+              service:
+                name: service-production
+                port:
+                  number: 80
+          - path: /datastore/ping
+            pathType: Exact
+            backend:
+              service:
+                name: service-production
+                port:
+                  number: 80
+          - path: /api/events
+            pathType: Exact
+            backend:
+              service:
+                name: service-production
+                port:
+                  number: 80
+          - path: /health
+            pathType: Exact
+            backend:
+              service:
+                name: service-production
+                port:
+                  number: 80
+---
+# production application ingress
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -22,10 +76,9 @@ metadata:
       SecRuleEngine On
       SecRequestBodyLimit 1048576
       SecRequestBodyNoFilesLimit 1048576
-      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
-      SecRule REQUEST_URI "@beginsWith /api/events" "id:555001, phase:1, pass, t:none, nolog, chain" \
-        SecRule REQUEST_METHOD "@streq POST" "chain" \
-          SecRule REQUEST_HEADERS:Content-Type "@rx [\s]*text/plain[\s]*" "ctl:ruleRemoveById=920420"
+      SecRule REMOTE_ADDR "!@ipMatch 51.149.249.0/29,194.33.249.0/29,51.149.249.32/29,194.33.248.0/29,20.49.214.199/32,20.49.214.228/32,20.26.11.71/32,20.26.11.108/32,128.77.75.64/26,18.169.147.172/32,35.176.93.186/32,18.130.148.126/32,35.176.148.126/32" \
+        "id:1001,deny,status:403,tag:github_team=laa-crime-apply"
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply,status:423"
       SecRule REQUEST_URI "@endsWith /return" \
         "id:1002,phase:2,pass,nolog,\
         ctl:ruleRemoveById=921110,\
@@ -36,13 +89,20 @@ metadata:
         ctl:ruleRemoveById=933160,\
         ctl:ruleRemoveById=942230,\
         ctl:ruleRemoveById=942360"
-      SecRule REQUEST_COOKIES:_laa_review_criminal_legal_aid_session "@rx .+" \
+      SecRule REQUEST_URI "@endsWith /comment" \
         "id:1003,phase:2,pass,nolog,\
-        ctl:ruleRemoveByTag=attack-rce,\
-        ctl:ruleRemoveByTag=attack-injection-php,\
-        ctl:ruleRemoveByTag=attack-xss,\
-        ctl:ruleRemoveByTag=attack-sqli"
-
+        ctl:ruleRemoveById=921110,\
+        ctl:ruleRemoveById=932100,\
+        ctl:ruleRemoveById=932110,\
+        ctl:ruleRemoveById=932115,\
+        ctl:ruleRemoveById=932380,\
+        ctl:ruleRemoveById=933160,\
+        ctl:ruleRemoveById=942230,\
+        ctl:ruleRemoveById=942360"
+      SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
+      SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
+      SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
+      SecRuleUpdateTargetByTag injection-php !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
 spec:
   ingressClassName: modsec
   tls:

--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -17,7 +17,7 @@ metadata:
         SecRule REQUEST_METHOD "@streq POST" "chain" \
           SecRule REQUEST_HEADERS:Content-Type "@rx [\s]*text/plain[\s]*" "ctl:ruleRemoveById=920420"
 spec:
-  ingressClassName: modsec-non-prod
+  ingressClassName: modsec
   rules:
     - host: review-criminal-legal-aid.service.justice.gov.uk
       http:


### PR DESCRIPTION
## Description of change

- introduce public ingress for /health, /ping, api/events etc
- apply an ModSec ip allowlist to application ingress
- use custom error (423) for ModSec errors on requests on IP allow list

## Link to relevant ticket

[CRIMAPP-1742](https://dsdmoj.atlassian.net/browse/CRIMAPP-1742)

## Notes for reviewer

Copies over ingress changes tested on staging

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1742]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ