### PR TITLE
[CRIMAPP-1815] remove api/events from public ingress

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -13,9 +13,10 @@ metadata:
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
-      SecRule REQUEST_URI "@beginsWith /api/events" "id:5001, phase:1, pass, t:none, nolog, chain" \
-        SecRule REQUEST_METHOD "@streq POST" "chain" \
-          SecRule REQUEST_HEADERS:Content-Type "@rx [\s]*text/plain[\s]*" "ctl:ruleRemoveById=920420"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($request_method !~ ^GET$) {
+        return 405;
+      }
 spec:
   ingressClassName: modsec
   rules:
@@ -30,13 +31,6 @@ spec:
                 port:
                   number: 80
           - path: /datastore/ping
-            pathType: Exact
-            backend:
-              service:
-                name: service-production
-                port:
-                  number: 80
-          - path: /api/events
             pathType: Exact
             backend:
               service:


### PR DESCRIPTION
## Description of change

Remove api/events from public ingress
Only allow GET requests to public endpoints

## Link to relevant ticket

[CRIMAPP-1815](https://dsdmoj.atlassian.net/browse/CRIMAPP-1815)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1815]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ