### PR TITLE
[CRIMAPP-1815] remove all public endpoints

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -1,11 +1,11 @@
-# production public ingress
+# production pingdom ingress
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ingress-production-public
+  name: ingress-production-pingdom
   namespace: laa-review-criminal-legal-aid-production
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: ingress-production-public-laa-review-criminal-legal-aid-production-green
+    external-dns.alpha.kubernetes.io/set-identifier: ingress-production-pingdom-laa-review-criminal-legal-aid-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
@@ -13,6 +13,8 @@ metadata:
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
+      SecRule REMOTE_ADDR "!@ipMatch 13.232.220.164,23.22.2.46,23.83.129.219,23.92.127.2,23.106.37.99,23.111.152.74,23.111.159.174,43.225.198.122,43.229.84.12,46.20.45.18,46.246.122.10,50.2.185.66,50.16.153.186,52.0.204.16,52.24.42.103,52.48.244.35,52.52.34.158,52.52.95.213,52.52.118.192,52.57.132.90,52.59.46.112,52.59.147.246,52.62.12.49,52.63.142.2,52.63.164.147,52.63.167.55,52.67.148.55,52.73.209.122,52.89.43.70,52.194.115.181,52.197.31.124,52.197.224.235,52.198.25.184,52.201.3.199,52.209.34.226,52.209.186.226,52.210.232.124,54.68.48.199,54.70.202.58,54.94.206.111,64.237.49.203,64.237.55.3,66.165.229.130,66.165.233.234,72.46.130.18,72.46.131.10,76.164.234.106,76.164.234.130,82.103.136.16,82.103.139.165,82.103.145.126,85.195.116.134,89.163.146.247,89.163.242.206,94.75.211.73,94.75.211.74,94.247.174.83,103.47.211.210,107.182.234.77,108.181.70.3,148.72.170.233,148.72.171.17,151.106.52.134,162.218.67.34,162.253.128.178,168.1.203.46,169.51.2.18,169.54.70.214,172.241.112.86,173.248.147.18,174.34.156.130,175.45.132.20,178.162.206.244,179.50.12.212,184.75.210.90,184.75.210.226,184.75.214.66,184.75.214.98,185.39.146.214,185.39.146.215,185.70.76.23,185.93.3.65,185.136.156.82,185.152.65.167,185.180.12.65,185.246.208.82,190.120.230.7,196.240.207.18,196.244.191.18,196.245.151.42,199.87.228.66,200.58.101.248,201.33.21.5,207.244.80.239,209.58.139.193,209.58.139.194,209.95.50.14,212.78.83.12,212.78.83.16" \
+        "id:5001,deny,status:403,tag:github_team=laa-crime-apply"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($request_method !~ ^GET$) {
         return 405;
@@ -31,13 +33,6 @@ spec:
                 port:
                   number: 80
           - path: /datastore/ping
-            pathType: Exact
-            backend:
-              service:
-                name: service-production
-                port:
-                  number: 80
-          - path: /health
             pathType: Exact
             backend:
               service:

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -1,11 +1,11 @@
-# staging public ingress
+# staging pingdom ingress
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ingress-staging-public
+  name: ingress-staging-pingdom
   namespace: laa-review-criminal-legal-aid-staging
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: ingress-staging-public-laa-review-criminal-legal-aid-staging-green
+    external-dns.alpha.kubernetes.io/set-identifier: ingress-staging-pingdom-laa-review-criminal-legal-aid-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
@@ -13,9 +13,12 @@ metadata:
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
-      SecRule REQUEST_URI "@beginsWith /api/events" "id:5001, phase:1, pass, t:none, nolog, chain" \
-        SecRule REQUEST_METHOD "@streq POST" "chain" \
-          SecRule REQUEST_HEADERS:Content-Type "@rx [\s]*text/plain[\s]*" "ctl:ruleRemoveById=920420"
+      SecRule REMOTE_ADDR "!@ipMatch 13.232.220.164,23.22.2.46,23.83.129.219,23.92.127.2,23.106.37.99,23.111.152.74,23.111.159.174,43.225.198.122,43.229.84.12,46.20.45.18,46.246.122.10,50.2.185.66,50.16.153.186,52.0.204.16,52.24.42.103,52.48.244.35,52.52.34.158,52.52.95.213,52.52.118.192,52.57.132.90,52.59.46.112,52.59.147.246,52.62.12.49,52.63.142.2,52.63.164.147,52.63.167.55,52.67.148.55,52.73.209.122,52.89.43.70,52.194.115.181,52.197.31.124,52.197.224.235,52.198.25.184,52.201.3.199,52.209.34.226,52.209.186.226,52.210.232.124,54.68.48.199,54.70.202.58,54.94.206.111,64.237.49.203,64.237.55.3,66.165.229.130,66.165.233.234,72.46.130.18,72.46.131.10,76.164.234.106,76.164.234.130,82.103.136.16,82.103.139.165,82.103.145.126,85.195.116.134,89.163.146.247,89.163.242.206,94.75.211.73,94.75.211.74,94.247.174.83,103.47.211.210,107.182.234.77,108.181.70.3,148.72.170.233,148.72.171.17,151.106.52.134,162.218.67.34,162.253.128.178,168.1.203.46,169.51.2.18,169.54.70.214,172.241.112.86,173.248.147.18,174.34.156.130,175.45.132.20,178.162.206.244,179.50.12.212,184.75.210.90,184.75.210.226,184.75.214.66,184.75.214.98,185.39.146.214,185.39.146.215,185.70.76.23,185.93.3.65,185.136.156.82,185.152.65.167,185.180.12.65,185.246.208.82,190.120.230.7,196.240.207.18,196.244.191.18,196.245.151.42,199.87.228.66,200.58.101.248,201.33.21.5,207.244.80.239,209.58.139.193,209.58.139.194,209.95.50.14,212.78.83.12,212.78.83.16" \
+        "id:5001,deny,status:403,tag:github_team=laa-crime-apply"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($request_method !~ ^GET$) {
+        return 405;
+      }
 spec:
   ingressClassName: modsec-non-prod
   rules:
@@ -30,20 +33,6 @@ spec:
                 port:
                   number: 80
           - path: /datastore/ping
-            pathType: Exact
-            backend:
-              service:
-                name: service-staging
-                port:
-                  number: 80
-          - path: /api/events
-            pathType: Exact
-            backend:
-              service:
-                name: service-staging
-                port:
-                  number: 80
-          - path: /health
             pathType: Exact
             backend:
               service:


### PR DESCRIPTION
## Description of change

- Remove public ingress
- Creates a dedicated ingress for `ping` and `datastore/ping` which applies the pingdom ip allowlist and restricts to GET requests. https://my.pingdom.com/probes/ipv4
- Remaining endpoints are configured by the application ingress which is restricted to the latest laa allow list https://github.com/ministryofjustice/laa-ip-allowlist/blob/main/cidrs.txt

## Link to relevant ticket

[CRIMAPP-1814](https://dsdmoj.atlassian.net/browse/CRIMAPP-1814)


## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1814]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ