### PR TITLE
[CRIMAPP-1815] update public ingress to be pingdom only

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -1,11 +1,11 @@
-# production pingdom ingress
+# production public (pingdom only) ingress
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ingress-production-pingdom
+  name: ingress-production-public
   namespace: laa-review-criminal-legal-aid-production
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: ingress-production-pingdom-laa-review-criminal-legal-aid-production-green
+    external-dns.alpha.kubernetes.io/set-identifier: ingress-production-public-laa-review-criminal-legal-aid-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -1,11 +1,11 @@
-# staging pingdom ingress
+# staging public (pingdom only) ingress
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ingress-staging-pingdom
+  name: ingress-staging-public
   namespace: laa-review-criminal-legal-aid-staging
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: ingress-staging-pingdom-laa-review-criminal-legal-aid-staging-green
+    external-dns.alpha.kubernetes.io/set-identifier: ingress-staging-public-laa-review-criminal-legal-aid-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"


### PR DESCRIPTION
## Description of change

Update public ingress to include only pingdom

## Link to relevant ticket
[CRIMAPP-1814](https://dsdmoj.atlassian.net/browse/CRIMAPP-1814)

## Notes for reviewer

Application of the pingdom ingress was being blocked because of a collision with previous public ingress. This fixes that by updating the public ingress with the pingdom rules.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRIMAPP-1814]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ