### PR TITLE
Add missing AWS Region to prod configmap

### DIFF
--- a/config/kubernetes/production/config_map.yml
+++ b/config/kubernetes/production/config_map.yml
@@ -18,3 +18,4 @@ data:
   MAAT_API_API_URL: https://laa-crime-applications-adaptor-prod.apps.live.cloud-platform.service.justice.gov.uk
   MAAT_API_OAUTH_URL: https://caa-api-prod.auth.eu-west-2.amazoncognito.com
   MAAT_API_FIRST_SUPPORTED_MAAT_ID: "6000000"
+  AWS_S3_REGION: eu-west-2


### PR DESCRIPTION
## Description of change
This change adds the missing `AWS_S3_REGION` env variable to production. This was preventing Active Storage from connecting to S3 and crashing the application.