### PR TITLE
Fix Sidekiq dependency loading in Prometheus config

### DIFF
--- a/app/lib/prometheus_metrics/configuration.rb
+++ b/app/lib/prometheus_metrics/configuration.rb
@@ -1,3 +1,6 @@
+require 'sidekiq'
+require 'sidekiq/api'
+
 module PrometheusMetrics
   module Configuration
     require 'prometheus_exporter/server'


### PR DESCRIPTION
## Description of change
This changes fixes an issue in production where Prometheus could not load Sidekiq dependencies.

[OpenSearch logs](https://app-logs.cloud-platform.service.justice.gov.uk/_dashboards/app/data-explorer/discover#?_a=(discover:(columns:!(kubernetes.namespace_name),isDirty:!f,sort:!()),metadata:(indexPattern:bb90f230-0d2e-11ef-bf63-53113938c53a,view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-4d,to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:bb90f230-0d2e-11ef-bf63-53113938c53a,key:kubernetes.namespace_name,negate:!f,params:(query:laa-review-criminal-legal-aid-production),type:phrase),query:(match_phrase:(kubernetes.namespace_name:laa-review-criminal-legal-aid-production))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:bb90f230-0d2e-11ef-bf63-53113938c53a,key:log,negate:!f,params:(query:'ERROR%20--%20:%20PrometheusExporter::Instrumentation::SidekiqProcess'),type:phrase),query:(match_phrase:(log:'ERROR%20--%20:%20PrometheusExporter::Instrumentation::SidekiqProcess')))),query:(language:kuery,query:'')))