### PR TITLE
Reduce worker replicas to 2

### DIFF
--- a/config/kubernetes/production/deployment-worker.tpl
+++ b/config/kubernetes/production/deployment-worker.tpl
@@ -4,7 +4,7 @@ metadata:
   name: deployment-worker-production
   namespace: laa-review-criminal-legal-aid-production
 spec:
-  replicas: 4
+  replicas: 2
   revisionHistoryLimit: 5
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
## Description of change
This change reduces the worker (Sidekiq) pod number from 4 to 2 in production.