### PR TITLE
[CRIMAPP-1826] remove attack-injection-php rules from session cookie

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -90,7 +90,7 @@ metadata:
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
-      SecRuleUpdateTargetByTag injection-php !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
+      SecRuleUpdateTargetByTag attack-injection-php !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
 spec:
   ingressClassName: modsec
   tls:

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -90,7 +90,7 @@ metadata:
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
-      SecRuleUpdateTargetByTag injection-php !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
+      SecRuleUpdateTargetByTag attack-injection-php !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
 spec:
   ingressClassName: modsec-non-prod
   tls:


### PR DESCRIPTION
## Description of change

Update ModsecRule applied to the rails session cookie to prevent observed false positive.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-1826

## Notes for reviewer

- fix confirmed on staging
- also confirmed that other modsec rules are still applied

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
