### PR TITLE
[CRIMAPP-1740] Copy link qa fix

### DIFF
--- a/app/views/application/_copy_link.html.erb
+++ b/app/views/application/_copy_link.html.erb
@@ -1,2 +1,2 @@
-<%= link_to link_text, '#', id: link_id, class: 'govuk-link--no-visited-state copy-text-link', 'aria-label': aria_label %>
+<%= link_to link_text, '', id: link_id, class: 'govuk-link--no-visited-state copy-text-link', 'aria-label': aria_label %>
 <p id="copy-alert" class="govuk-visually-hidden" aria-live="assertive"></p>


### PR DESCRIPTION
## Description of change
Copy links not changing to purple visited state when clicked as per designs due to href on link being set to '#' 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1740

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="1035" height="156" alt="Screenshot 2025-07-16 at 11 13 58" src="https://github.com/user-attachments/assets/92424d7a-ebae-4ec1-88c7-cab000d718f4" />


## How to manually test the feature
