### PR TITLE
Fix typo on link maat id screen

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -8,7 +8,7 @@ en:
       decisions_interests_of_justice_form:
         assessed_on: For example, DD/MM/YYY
       decisions_maat_id_form:
-        maat_id: If you have created more that one MAAT ID, link one at a time.
+        maat_id: If you have created more than one MAAT ID, link one at a time.
 
     legend:
       decisions_interests_of_justice_form:


### PR DESCRIPTION
## Description of change
Changes that to than
> If you have created more than one MAAT ID, link one at a time.

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="601" height="313" alt="Screenshot 2025-07-21 at 16 04 55" src="https://github.com/user-attachments/assets/b0879c3a-5ce3-484e-b403-7b045074a56a" />

### After changes:
<img width="1035" height="319" alt="Screenshot 2025-07-21 at 16 16 53" src="https://github.com/user-attachments/assets/66e9f216-d7ad-4c77-b939-ee7fc9146844" />

## How to manually test the feature
