### PR TITLE
[CRIMAPP-1821] Fix message_poller script

### DIFF
--- a/bin/message_poller
+++ b/bin/message_poller
@@ -1,6 +1,3 @@
-#!/usr/bin/env rails runner
+#!/usr/bin/env sh
 
-Rails.logger = Logger.new($stdout)
-Rails.logger.level = Logger::INFO
-
-Aws::MessagePoller.new(queue: ENV.fetch('SQS_QUEUE', nil)).start!
+exec bundle exec rails runner "Aws::MessagePoller.new(queue: ENV.fetch('SQS_QUEUE', nil)).start!"


### PR DESCRIPTION
## Description of change
This change updates `bin/message_poller`. It now runs using `sh` and explicitly calls `rails runner` with the correct bundle context.

## Link to relevant ticket
[CRIMAPP-1821](https://dsdmoj.atlassian.net/browse/CRIMAPP-1821)

[CRIMAPP-1821]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ