### PR TITLE
[CRIMAPP-1821] Add readiness probe to message poller

### DIFF
--- a/app/services/aws/message_poller.rb
+++ b/app/services/aws/message_poller.rb
@@ -1,5 +1,7 @@
 require 'aws-sdk-sqs'
 
+READY_FILE = Rails.root.join('tmp/poller_ready').freeze
+
 module Aws
   class MessagePoller
     def initialize(queue: nil)
@@ -13,6 +15,7 @@ module Aws
 
       Rails.logger.info('Message poller started...')
       trap_signals
+      ready
       loop do
         break if @finish
 
@@ -42,6 +45,10 @@ module Aws
       return ENV.fetch('SQS_QUEUE_URL') if Rails.env.development?
 
       @sqs_client.get_queue_url(queue_name: queue).queue_url
+    end
+
+    def ready
+      FileUtils.touch(READY_FILE)
     end
 
     # Allow the main loop to finish before shutting down

--- a/config/kubernetes/staging/deployment-message-poller.tpl
+++ b/config/kubernetes/staging/deployment-message-poller.tpl
@@ -34,6 +34,13 @@ spec:
           limits:
             cpu: 500m
             memory: 1Gi
+        readinessProbe:
+          exec:
+            command:
+              - cat
+              - tmp/poller_ready
+          periodSeconds: 10
+          failureThreshold: 4
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
## Description of change
This change adds a readiness probe to `message_poller` so Kubernetes knows when the pod is ready and existing replicas can be destroyed.

## Link to relevant ticket
[CRIMAPP-1821](https://dsdmoj.atlassian.net/browse/CRIMAPP-1821)

[CRIMAPP-1821]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ