### PR TITLE
[CRIMAPP-1821] Fix message_poller probes and logger

### DIFF
--- a/app/services/aws/message_poller.rb
+++ b/app/services/aws/message_poller.rb
@@ -8,6 +8,7 @@ module Aws
       @sqs_client = Aws::SQS::Client.new
       @queue_url = get_queue_url(queue)
       @finish = false
+      configure_logger!
     end
 
     def start! # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
@@ -57,5 +58,18 @@ module Aws
         Signal.trap(signal) { @finish = true }
       end
     end
+
+    # :nocov:
+    def configure_logger!
+      return if ENV['RAILS_LOG_TO_STDOUT'].blank?
+
+      $stdout.sync = true
+      logger = ActiveSupport::Logger.new($stdout)
+      logger.formatter = Logger::Formatter.new
+      logger.level = Logger::INFO
+
+      Rails.logger = ActiveSupport::TaggedLogging.new(logger)
+    end
+    # :nocov:
   end
 end

--- a/config/kubernetes/staging/deployment-message-poller.tpl
+++ b/config/kubernetes/staging/deployment-message-poller.tpl
@@ -46,7 +46,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - pgrep -f message_poller
+              - pgrep -f "rails runner"
           failureThreshold: 30
           periodSeconds: 3
         startupProbe:
@@ -54,7 +54,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - pgrep -f message_poller
+              - pgrep -f "rails runner"
           failureThreshold: 60
           periodSeconds: 5
         envFrom:


### PR DESCRIPTION
## Description of change
- Fixes the `message_poller` startup and liveness probes, which were checking for the existence of the wrong process.
- Explicitly sets the Rails logger in the `message_poller` service class as the default logger does not flush to standard output until the application is terminated.

## Link to relevant ticket
[CRIMAPP-1821](https://dsdmoj.atlassian.net/browse/CRIMAPP-1821)