### PR TITLE
[CRIMAPP-1821] Limit message poller logging

### DIFF
--- a/app/jobs/aws_message_processing_job.rb
+++ b/app/jobs/aws_message_processing_job.rb
@@ -1,6 +1,8 @@
 class AwsMessageProcessingJob < ApplicationJob
   queue_as :aws_messages
 
+  self.log_arguments = false
+
   def perform(message_id, message_body)
     message = Aws::SnsMessage.new(id: message_id, raw_body: message_body)
     Aws::MessageProcessor.process!(message)

--- a/app/services/aws/message_processor.rb
+++ b/app/services/aws/message_processor.rb
@@ -12,7 +12,7 @@ module Aws
     end
 
     def process!
-      Rails.logger.info "Processing '#{message.event_name}' event #{message.id}: #{message.data}"
+      Rails.logger.debug { "Processing '#{message.event_name}' event #{message.id}: #{message.data}" }
       @event.new(id: message.id, data: message.data).create!
     end
 


### PR DESCRIPTION
## Description of change
- Disable argument logging for `AwsMessageProcessingJob`. The arguments passed to this job contain potentially sensitive SNS message metadata.
- `Aws::MessageProcessor` logging is now debug-only to prevent message data from being logged in production.

## Link to relevant ticket
[CRIMAPP-1821](https://dsdmoj.atlassian.net/browse/CRIMAPP-1821)

[CRIMAPP-1821]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ