### PR TITLE
Remove attack-lfi rule from session cookie

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -98,6 +98,7 @@ metadata:
         ctl:ruleRemoveById=933160,\
         ctl:ruleRemoveById=942230,\
         ctl:ruleRemoveById=942360"
+      SecRuleUpdateTargetByTag attack-lfi !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -98,6 +98,7 @@ metadata:
         ctl:ruleRemoveById=933160,\
         ctl:ruleRemoveById=942230,\
         ctl:ruleRemoveById=942360"
+      SecRuleUpdateTargetByTag attack-lfi !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session


### PR DESCRIPTION
These rules could not be use to exploit the rails session cookie but they are causing false positives.