### PR TITLE
Remove attach-sqli rule 942100 from authenticity token

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -103,6 +103,7 @@ metadata:
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-injection-php !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
+      SecRuleUpdateTargetById 942100 !ARGS:authenticity_token
 spec:
   ingressClassName: modsec
   tls:

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -103,6 +103,7 @@ metadata:
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-xss !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-injection-php !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
+      SecRuleUpdateTargetById 942100 !ARGS:authenticity_token
 spec:
   ingressClassName: modsec-non-prod
   tls:


### PR DESCRIPTION
Auth token randomness was causing false +ves. Token itself is server-generated and containing sqli not exploitable because of framework controls.