### PR TITLE
[CRIMAPP-1946] add deletion status and history item

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -67,6 +67,17 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication # rubocop:di
     )
   end
 
+  def deleted_history_item
+    return nil unless deleted?
+
+    ApplicationHistoryItem.new(
+      user_name: 'System',
+      event_type: 'Deleting::SoftDeleted',
+      timestamp: soft_deleted_at,
+      event_data: { superseded_by: }
+    )
+  end
+
   def submission_type
     return 'resubmission' if parent_id && application_type == 'initial'
 

--- a/app/views/casework/application_history_items/_deleting_soft_deleted.html.erb
+++ b/app/views/casework/application_history_items/_deleting_soft_deleted.html.erb
@@ -1,0 +1,3 @@
+<strong>
+  <%= t('deleting.soft_deleted', scope: 'event.description') %> <br>
+</strong>

--- a/app/views/casework/crime_applications/_review_overview.html.erb
+++ b/app/views/casework/crime_applications/_review_overview.html.erb
@@ -1,7 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <div class="govuk-!-margin-top-5 govuk-!-margin-bottom-4">
-      <%= govuk_tag(text: t(crime_application.review_status, scope: 'values.review_status'), colour: t(crime_application.review_status, scope: 'values.color')) %>
+      <% status = crime_application.deleted? ? 'deleted' : crime_application.review_status %>
+      <%= govuk_tag(text: t(status, scope: 'values.review_status'), colour: t(status, scope: 'values.color')) %>
     </div>
 
     <div class="govuk-!-margin-bottom-4 app-wrap-button">

--- a/app/views/casework/crime_applications/history.html.erb
+++ b/app/views/casework/crime_applications/history.html.erb
@@ -25,6 +25,9 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
+      <% if @crime_application.deleted? %>
+        <%= render partial: @crime_application.deleted_history_item, as: :item, layout: 'history_item' %>
+      <% end %>
       <% if @crime_application.superseded? %>
         <%= render partial: @crime_application.superseding_history_item, as: :item, layout: 'history_item' %>
       <% end %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -562,6 +562,7 @@ en:
       closed: Closed
       marked_as_ready: Ready for assessment
       all: All applications
+      deleted: Personal data deleted
     assigned_status:
       assigned: All assigned
       unassigned: Unassigned
@@ -582,6 +583,7 @@ en:
       granted: green
       granted_on_ioj: green
       fail_on_ioj: red
+      deleted: grey
     download_file: "Download file (%{file_extension}, %{file_size})"
     no_hearing_yet: There has not been a hearing yet
     manage_without_income:
@@ -728,6 +730,8 @@ en:
           resubmission: Application reassigned from %{from_whom_name} to %{to_whom_name}
           post_submission_evidence: Post submission evidence reassigned from %{from_whom_name} to %{to_whom_name}
           change_in_financial_circumstances: Change in financial circumstances reassigned from %{from_whom_name} to %{to_whom_name}
+      deleting:
+        soft_deleted: Personal data deleted in accordance with data retention policy
       reviewing:
         sent_back: Application sent back to provider
         application_received:

--- a/spec/system/casework/viewing_an_application/that_has_been_deleted_spec.rb
+++ b/spec/system/casework/viewing_an_application/that_has_been_deleted_spec.rb
@@ -7,6 +7,16 @@ RSpec.describe 'Viewing an application that has been deleted' do
     visit crime_application_path(application_id)
   end
 
+  it 'replaces the review status with "Personal data deleted"' do
+    within('.govuk-tag--grey') do
+      expect(page).to have_text('Personal data deleted')
+    end
+  end
+
+  it 'includes the page title' do
+    expect(page).to have_content I18n.t('casework.crime_applications.show.page_title')
+  end
+
   describe 'applications details' do
     it 'shows relevant details' do # rubocop:disable RSpec/MultipleExpectations
       within(summary_card('Overview')) do |card|
@@ -18,7 +28,15 @@ RSpec.describe 'Viewing an application that has been deleted' do
     end
   end
 
-  it 'includes the page title' do
-    expect(page).to have_content I18n.t('casework.crime_applications.show.page_title')
+  describe 'applications history' do
+    before do
+      click_link 'Application history'
+    end
+
+    it 'shows the deletion event at the top of the application history' do
+      expect(page.first('.app-dashboard-table tbody tr').text).to match(
+        'System Personal data deleted in accordance with data retention policy'
+      )
+    end
   end
 end


### PR DESCRIPTION
## Description of change
- display deletion event in application history
- show deletion status on application details and history pages

## Link to relevant ticket

[CRIMAPP-1946](https://dsdmoj.atlassian.net/browse/CRIMAPP-1946)


## Notes for reviewer
This updates the presentation of a deleted record as per the latest content/design. The deletion event may be take from the datastore's event stream at some point, but until that is ready this code creates a pseudo deletion event in the same maner as is done for superseding. Unlike the design which uses [Deleted] the placeholder text [deleted] is kept in lower case to match other parts of the service.

## Screenshots of changes (if applicable)

### Before changes:
<img width="669" height="909" alt="Screenshot 2025-11-04 at 09 09 02" src="https://github.com/user-attachments/assets/9db449f4-54b2-455f-873f-52d8b12f8154" />


### After changes:

<img width="673" height="889" alt="Screenshot 2025-11-04 at 09 08 45" src="https://github.com/user-attachments/assets/bc47f036-db78-4ec4-9682-959848e68b19" />




[CRIMAPP-1946]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ