### PR TITLE
[CRIMAPP-2011] add volume by office report

### DIFF
--- a/app/controllers/reporting/temporal_reports_controller.rb
+++ b/app/controllers/reporting/temporal_reports_controller.rb
@@ -59,8 +59,15 @@ module Reporting
     end
 
     def set_interval
-      @intervals = Types::TemporalInterval
-      @interval = permitted_params.require(:interval).presence_in(*@intervals)
+      @interval = permitted_params.require(:interval).presence_in(intervals)
+    end
+
+    def intervals
+      @intervals = if @report_type == Types::TemporalReportType['volumes_by_office_report']
+                     [Types::TemporalInterval['monthly']]
+                   else
+                     Types::TemporalInterval.values
+                   end
     end
   end
 end

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -73,18 +73,20 @@ module Types
                          workload_report
                          return_reasons_report
                          current_workload_report
+                         volumes_by_office_report
                        ])
 
   SnapshotReportType = String.enum(Report['workload_report'])
   TemporalReportType = String.enum(Report['caseworker_report'],
-                                   Report['return_reasons_report'])
+                                   Report['return_reasons_report'],
+                                   Report['volumes_by_office_report'])
 
   TemporalInterval = String.enum('daily', 'weekly', 'monthly')
 
   USER_ROLE_REPORTS = {
     UserRole[CASEWORKER_ROLE] => [Report['current_workload_report'], Report['processed_report']],
     UserRole[DATA_ANALYST_ROLE] => Report.values,
-    UserRole[SUPERVISOR_ROLE] => Report.values
+    UserRole[SUPERVISOR_ROLE] => Report.values - [Report['volumes_by_office_report']]
   }.freeze
 
   SortDirection = String.enum('descending', 'ascending')

--- a/app/models/reporting/volumes_by_office_report.rb
+++ b/app/models/reporting/volumes_by_office_report.rb
@@ -1,0 +1,44 @@
+module Reporting
+  require 'csv'
+  class VolumesByOfficeReport
+    CSV_LIMIT = 5_000
+    include Downloadable
+
+    attr_reader :time_period, :sorting
+
+    def initialize(time_period:)
+      @time_period = time_period
+    end
+
+    def csv(*)
+      CSV.generate do |csv|
+        csv << %w[office_code submissions]
+
+        dataset.each do |office_code, volume|
+          csv << [office_code, volume]
+        end
+      end
+    end
+
+    def total_count
+      dataset.size
+    end
+
+    private
+
+    include DatastoreApi::Traits::ApiRequest
+
+    def dataset
+      return @dataset if @dataset.present?
+
+      period = time_period.starts_on.strftime(Reporting::MonthlyReport::PARAM_FORMAT)
+      @dataset = http_client.get("/reporting/volumes_by_office/monthly/#{period}").fetch('data')
+    end
+
+    class << self
+      def for_time_period(time_period:, **_options)
+        new(time_period:)
+      end
+    end
+  end
+end

--- a/app/models/reporting/volumes_by_office_report_sorting.rb
+++ b/app/models/reporting/volumes_by_office_report_sorting.rb
@@ -1,0 +1,12 @@
+module Reporting
+  class VolumesByOfficeReportSorting < ApplicationStruct
+    SORTABLE_COLUMNS = %w[
+      office_code
+    ].freeze
+
+    DEFAULT_SORT_BY = 'office_code'.freeze
+    DEFAULT_SORT_DIRECTION = Types::SortDirection['ascending'].freeze
+
+    include SortableStruct
+  end
+end

--- a/app/views/reporting/temporal_reports/_volumes_by_office_report.en.html.erb
+++ b/app/views/reporting/temporal_reports/_volumes_by_office_report.en.html.erb
@@ -1,0 +1,11 @@
+<p>
+  <% if report.current? %>
+    <%= govuk_inset_text(text: "This report isn't available yet. You’ll be able to download it after the end of the month.") %>
+  <% else %>
+    <%= govuk_link_to(
+          'Download report (CSV)',
+          reporting_download_temporal_report_path(**report.to_param),
+          data: { turbo: false }
+        ) %>
+  <% end %>
+</p>

--- a/app/views/reporting/temporal_reports/show.html.erb
+++ b/app/views/reporting/temporal_reports/show.html.erb
@@ -8,7 +8,7 @@
 
     <div class="govuk-tabs">
       <ul class="govuk-tabs__list" role="tablist">
-        <% @intervals.values.each_with_index do |interval, index| %>
+        <% @intervals.each_with_index do |interval, index| %>
           <% css_class = %w[govuk-tabs__list-item govuk-tabs__list-item--selected] %>
           <%= content_tag(:li, class: @interval == interval ? css_class : css_class.first) do %>
             <%= link_to(

--- a/app/views/reporting/user_reports/index.html.erb
+++ b/app/views/reporting/user_reports/index.html.erb
@@ -29,7 +29,6 @@
               no_visited_state: true
             ) %>
       </h3>
-
     <% end %>
 
     <h3 class='govuk-heading-s'>

--- a/config/locales/en/reporting.yml
+++ b/config/locales/en/reporting.yml
@@ -5,6 +5,8 @@ en:
         title: "Caseworker monthly: %{period_name}"
       return_reasons_report:
         title: "Return reasons monthly: %{period_name}"
+      volumes_by_office_report:
+        title: "Submissions by office monthly: %{period_name}"
     weekly_report:
       caseworker_report:
         title: "Caseworker weekly: %{period_name}"
@@ -16,11 +18,11 @@ en:
       return_reasons_report:
         title: "Return reasons daily: %{period_name}"
     snapshot:
-      workload_report: 
+      workload_report:
         title: "Workload report: %{observed_at}"
     user_reports:
       index:
-        page_title: Reporting 
+        page_title: Reporting
         heading: Reports
         downloads: Downloads
   labels:
@@ -29,13 +31,14 @@ en:
     current_workload_report: Workload report
     processed_report: Processed report
     caseworker_report: Caseworker report
-    monthly: Monthly 
-    weekly: Weekly 
-    daily: Daily 
+    volumes_by_office_report: Submissions by office report
+    monthly: Monthly
+    weekly: Weekly
+    daily: Daily
     period:
-      monthly: month 
-      weekly: week 
-      daily: day 
+      monthly: month
+      weekly: week
+      daily: day
     download_csv: Download source data (CSV)
   table_headings:
     application_type: Application type
@@ -49,13 +52,13 @@ en:
     colspan_unassigned_from_user: Unassigned
     completed_by_user: completed
     days_passed: Business days since applications were received
-    office_code: Office code 
+    office_code: Office code
     open_applications_by_age: "Applications still\xA0open"
     percentage_closed_by_user: "assigned closed"
     percentage_unassigned_from_user: "assigned un-assigned"
     percentage_closed_sent_back: "closed sent back"
     processed_on: When applications were closed
-    provider_name: Legal representative 
+    provider_name: Legal representative
     reassigned_from_user: "by<br>another"
     reassigned_to_user: "from<br>another"
     received: Received
@@ -72,6 +75,6 @@ en:
     today: Today
     yesterday: Yesterday
   caseworker_report:
-    caption:  Number of times applications were assigned to, unassigned from, and closed by a given caseworker
+    caption: Number of times applications were assigned to, unassigned from, and closed by a given caseworker
   warnings:
     experimental_data: This report is experimental and under active development. It may contain inaccurate information.

--- a/spec/models/concerns/user_role_spec.rb
+++ b/spec/models/concerns/user_role_spec.rb
@@ -225,17 +225,17 @@ RSpec.describe UserRole do
   describe '#reports' do
     subject(:reports) { user.reports }
 
-    let(:expected_user_reports) do
-      %w[
-        caseworker_report
-        processed_report
-        workload_report
-        return_reasons_report
-        current_workload_report
-      ]
-    end
-
     context 'when user is supervisor' do
+      let(:expected_user_reports) do
+        %w[
+          caseworker_report
+          processed_report
+          workload_report
+          return_reasons_report
+          current_workload_report
+        ]
+      end
+
       before { user.role = Types::SUPERVISOR_ROLE }
 
       it { is_expected.to eq expected_user_reports }
@@ -250,7 +250,7 @@ RSpec.describe UserRole do
     context 'when user is data_analyst' do
       before { user.role = Types::DATA_ANALYST_ROLE }
 
-      it { is_expected.to eq expected_user_reports }
+      it { is_expected.to eq Types::Report.values }
     end
 
     context 'when user is user manager' do
@@ -265,7 +265,7 @@ RSpec.describe UserRole do
           }
         end
 
-        it { is_expected.to eq expected_user_reports }
+        it { is_expected.to eq Types::Report.values }
       end
     end
   end

--- a/spec/system/reporting/volumes_by_office_report_spec.rb
+++ b/spec/system/reporting/volumes_by_office_report_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.describe 'Volumes by office report' do
+  let(:report_type) { Types::TemporalReportType['submissions_by_office'] }
+  let(:report_title) { 'Submissions by office report' }
+  let(:download_link) { 'Download report (CSV)' }
+  let(:complete_report_path) { 'reporting/volumes_by_office_report/monthly/2025-October' }
+
+  before do
+    visit '/reporting'
+  end
+
+  context 'when a Data Analyts' do
+    let(:current_user_role) { UserRole::DATA_ANALYST }
+
+    it 'shows a link on the user reports page' do
+      expect(page).to have_link report_title
+    end
+
+    it 'does not show the download link on incomplete reports' do
+      click_link(report_title)
+      click_link('Next')
+      expect(page).not_to have_link(download_link)
+      expect(page).to have_text(
+        "This report isn't available yet. You’ll be able to download it after the end of the month."
+      )
+    end
+
+    describe 'attempts to directly view the report' do
+      before { visit complete_report_path }
+
+      it 'returns the reports page' do
+        expect(page).to have_http_status(:success)
+        expect(page).to have_link('Monthly')
+      end
+
+      it 'does now show the Weekly or Daily tabs' do
+        expect(page).not_to have_link('Daily')
+        expect(page).not_to have_link('Weekly')
+      end
+
+      describe 'downloading the report' do
+        before do
+          stub_request(
+            :get,
+            'https://datastore-api-stub.test/api/v1/reporting/volumes_by_office/monthly/2025-October'
+          ).to_return_json(
+            body: { 'data' => { '1A2B3C' => 1, '2B3C4D' => 5 } }
+          )
+
+          click_link download_link
+        end
+
+        it 'has the correct content type' do
+          expect(page.driver.response.content_type).to eq('text/csv; charset=utf-8')
+        end
+
+        it 'has the correct report details' do
+          expect(page.driver.response.body).to eq(
+            "office_code,submissions\n1A2B3C,1\n2B3C4D,5\n"
+          )
+        end
+
+        it 'has the correct file name' do
+          expect(page.driver.response.headers['Content-Disposition']).to match(
+            'volumes_by_office_report_monthly_2025-October_1_of_1.csv'
+          )
+        end
+      end
+    end
+  end
+
+  context 'when a supervisor' do
+    let(:current_user_role) { UserRole::SUPERVISOR }
+
+    describe 'user reports page' do
+      it 'does not show a link on the user reports page' do
+        expect(page).not_to have_link report_title
+      end
+    end
+
+    describe 'attempts to directly view the report' do
+      before { visit complete_report_path }
+
+      it 'returns a forbidden error' do
+        expect(page).to have_http_status(:forbidden)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
- Data Analysts can download monthly Submissions by office report

## Link to relevant ticket

[CRIMAPP-2011](https://dsdmoj.atlassian.net/browse/CRIMAPP-2011)

## Notes for reviewer

- download only--no report table shown on page
- data analyst only--other users cannot download the report
- monthly only--daily and weekly reports are not available
- complete month reports only--only available for download once the month is over

## Screenshots of changes (if applicable)

### Before changes:


### After changes:
<img width="835" height="693" alt="Screenshot 2025-11-10 at 15 00 01" src="https://github.com/user-attachments/assets/962b8a5f-6d95-489d-a56b-baeabeea94ac" />

<img width="852" height="818" alt="Screenshot 2025-11-10 at 14 59 47" src="https://github.com/user-attachments/assets/23bbc300-2681-4e1a-8c89-5a491b28963b" />

<img width="887" height="817" alt="Screenshot 2025-11-10 at 14 59 55" src="https://github.com/user-attachments/assets/def49bb4-fddf-4013-8ce5-a5166bf2bb12" />


## How to manually test the feature


[CRIMAPP-2011]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ