### PR TITLE
Update ModSec rule exceptions

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -84,12 +84,16 @@ metadata:
         ctl:ruleRemoveById=932100,\
         ctl:ruleRemoveById=932110,\
         ctl:ruleRemoveById=932115,\
+        ctl:ruleRemoveById=932125,\
         ctl:ruleRemoveById=932235,\
         ctl:ruleRemoveById=932380,\
         ctl:ruleRemoveById=933160,\
         ctl:ruleRemoveById=942230,\
         ctl:ruleRemoveById=942360,\
         ctl:ruleRemoveById=932370"
+      SecRule REQUEST_URI "@beginsWith /users/auth/azure_ad/callback" \
+        "id:1003,phase:1,pass,nolog,\
+        ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:code"
       SecRuleUpdateTargetByTag attack-lfi !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -84,12 +84,16 @@ metadata:
         ctl:ruleRemoveById=932100,\
         ctl:ruleRemoveById=932110,\
         ctl:ruleRemoveById=932115,\
+        ctl:ruleRemoveById=932125,\
         ctl:ruleRemoveById=932235,\
         ctl:ruleRemoveById=932380,\
         ctl:ruleRemoveById=933160,\
         ctl:ruleRemoveById=942230,\
         ctl:ruleRemoveById=942360,\
         ctl:ruleRemoveById=932370"
+      SecRule REQUEST_URI "@beginsWith /users/auth/azure_ad/callback" \
+        "id:1003,phase:1,pass,nolog,\
+        ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:code"
       SecRuleUpdateTargetByTag attack-lfi !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-rce !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session
       SecRuleUpdateTargetByTag attack-sqli !REQUEST_COOKIES:_laa_review_criminal_legal_aid_session


### PR DESCRIPTION
## Description of change
- updates ModSec rules to reduce false positives

The changes address the following false positive alerts:
https://mojdt.slack.com/archives/C056U956ESH/p1762276887406169
https://mojdt.slack.com/archives/C056U956ESH/p1762452447418459

All of the above have been tested in staging, **except** the exception on `/users/auth/azure_ad/callback` as the values given in the `code` parameter are impossible to predict.