### PR TITLE
[CRIMAPP-1921] Only same-origin resources are allowed.

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,21 +6,19 @@
 
 Rails.application.configure do
   config.content_security_policy do |policy|
-    policy.default_src :self, :https
-    policy.font_src    :self, :https, :data
-    policy.img_src     :self, :https, :data
+    policy.default_src :self
+    policy.font_src    :self
+    policy.img_src     :self
     policy.object_src  :none
-    policy.script_src  :self, :https
-    policy.style_src   :self, :https
+    policy.script_src  :self
+    policy.style_src   :self
     # Specify URI for violation reports
     # policy.report_uri "/csp-violation-report-endpoint"
   end
 
   # Generate session nonces for permitted importmap and inline scripts
   config.content_security_policy_nonce_generator = ->(request) { SecureRandom.base64(16) }
-
-  # config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-  config.content_security_policy_nonce_directives = %w(script-src style-src)
+  config.content_security_policy_nonce_directives = %w[script-src style-src]
 
   # Report violations without enforcing the policy.
   # config.content_security_policy_report_only = true


### PR DESCRIPTION
## Description of change

Updated Content Security Policy to prevent external scripts/styles

## Link to relevant ticket

[CRIMAPP-1921](https://dsdmoj.atlassian.net/browse/CRIMAPP-1921)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
```
default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src 'self' https: 'nonce-OJNw2TjRXMkRIzxyLhA11A=='; style-src 'self' https: 'nonce-OJNw2TjRXMkRIzxyLhA11A=='
```

### After changes:
```
default-src 'self'; font-src 'self'; img-src 'self'; object-src 'none'; script-src 'self' 'nonce-a7X5f4laFsOU4sWC+T6UGQ=='; style-src 'self' 'nonce-a7X5f4laFsOU4sWC+T6UGQ=='
```

## How to manually test the feature


[CRIMAPP-1921]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ