### PR TITLE
[CRIMAPP-1785] Bump schema to v1.7.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.7.6'
+    tag: 'v1.7.7'
 
 gem 'jsbundling-rails'
 gem 'propshaft'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: d2efbe6d7e31969fced3301fd824b72d26f7e232
-  tag: v1.7.6
+  revision: db6411b3cf722f0320953fb09da714ac0840894e
+  tag: v1.7.7
   specs:
-    laa-criminal-legal-aid-schemas (1.7.6)
+    laa-criminal-legal-aid-schemas (1.7.7)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)


### PR DESCRIPTION
## Description of change
Bumps schema version to v1.7.7 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1785

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
