### PR TITLE
[CRIMAPP-2032] Update timestamp format to include year

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,7 +24,7 @@ en:
     formats:
       <<: *DATE_FORMATS
       datetime: "%-d %b %Y %-l:%M%P" # 3 Jan 2019 2:45pm
-      timestamp: "%A %-d %b %-l:%M%P" # Thursday 3 Jan 2:45pm
+      timestamp: "%A %-d %b %Y %-l:%M%P" # Thursday 3 Jan 2019 2:45pm
       snapshot: "%A %-d %B %-l:%M%P"
       now: "%A %-d %B"
       datestamp: "%d/%m/%Y %-l:%M%P" # 03/01/2019 3:29pm

--- a/spec/system/casework/viewing_an_application/history_spec.rb
+++ b/spec/system/casework/viewing_an_application/history_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Viewing application history' do
 
     it 'includes the submission event' do
       first_row = page.first('.app-dashboard-table tbody tr').text
-      expect(first_row).to match('Monday 24 Oct 10:50am John Doe Application submitted')
+      expect(first_row).to match('Monday 24 Oct 2022 10:50am John Doe Application submitted')
     end
   end
 

--- a/spec/system/casework/viewing_an_application/post_submission_evidence_application_spec.rb
+++ b/spec/system/casework/viewing_an_application/post_submission_evidence_application_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'Viewing an application unassigned, open, post submission evidenc
 
     it 'includes the submission event' do
       first_row = page.first('.app-dashboard-table tbody tr').text
-      expect(first_row).to match('Monday 24 Oct 10:50am John Doe Post submission evidence submitted')
+      expect(first_row).to match('Monday 24 Oct 2022 10:50am John Doe Post submission evidence submitted')
     end
 
     it 'includes the assigned event' do


### PR DESCRIPTION
## Description of change
Updates application history dates to include the year

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2032

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1015" height="457" alt="Screenshot 2025-12-15 at 10 19 21" src="https://github.com/user-attachments/assets/69d1dbc3-9857-4e5b-9d6a-49d881e243ef" />

### After changes:

<img width="1015" height="457" alt="Screenshot 2025-12-15 at 10 10 07" src="https://github.com/user-attachments/assets/421fe4f5-3e96-4e55-8f3f-5c088a6d9d93" />


## How to manually test the feature
