### PR TITLE
[CRIMAPP-2057] offline December and January bank holidays

### DIFF
--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -5,7 +5,7 @@
     </h1>
 
     <p class="govuk-body">
-      The service is available from 7am until 10pm.
+      The service is available from 7am until 10pm. It is not available on bank holidays.
     </p>
     <p class="govuk-body">
       Use this service to review criminal legal aid applications.

--- a/config/kubernetes/production/custom-error-page.yml
+++ b/config/kubernetes/production/custom-error-page.yml
@@ -58,7 +58,7 @@ data:
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
                     <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
-                    <p class="govuk-body">You can use the service from 7am until 10pm.</p>
+                    <p class="govuk-body">You can use the service from 7am until 10pm. It is not available on bank holidays.</p>
                 </div>
             </div>
             </main>
@@ -194,4 +194,4 @@ data:
             </div>
         </footer>
     </body>
-    </html> 
+    </html>

--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -73,6 +73,10 @@ metadata:
       SecRuleEngine On
       SecRequestBodyLimit 1048576
       SecRequestBodyNoFilesLimit 1048576
+      SecRule TIME_MON "@eq 0" "id:995,phase:1,deny,status:503,chain"
+        SecRule TIME_DAY "@eq 1" "tag:github_team=laa-crime-apply"
+      SecRule TIME_MON "@eq 11" "id:996,phase:1,deny,status:503,chain"
+        SecRule TIME_DAY "@pm 25 26" "tag:github_team=laa-crime-apply"
       SecRule TIME_HOUR "!@pm 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21" \
         "id:998,phase:1,deny,status:503,tag:github_team=laa-crime-apply"
       SecRule REMOTE_ADDR "!@ipMatch 51.149.249.0/29,194.33.249.0/29,51.149.249.32/29,194.33.248.0/29,20.49.214.199/32,20.49.214.228/32,20.26.11.71/32,20.26.11.108/32,128.77.75.64/26,18.169.147.172/32,35.176.93.186/32,18.130.148.126/32,35.176.148.126/32" \

--- a/config/kubernetes/staging/custom-error-page.yml
+++ b/config/kubernetes/staging/custom-error-page.yml
@@ -58,7 +58,7 @@ data:
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
                     <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
-                    <p class="govuk-body">You can use the service from 7am until 10pm.</p>
+                    <p class="govuk-body">You can use the service from 7am until 10pm. It is not available on bank holidays.</p>
                 </div>
             </div>
             </main>
@@ -102,7 +102,7 @@ data:
         </footer>
         </body>
     </html>
-  403.html: |    
+  403.html: |
     <!DOCTYPE html>    
     <html lang="en" class="govuk-template ">
         <head>
@@ -194,4 +194,4 @@ data:
             </div>
         </footer>
         </body>
-    </html> 
+    </html>

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -73,6 +73,10 @@ metadata:
       SecRuleEngine On
       SecRequestBodyLimit 1048576
       SecRequestBodyNoFilesLimit 1048576
+      SecRule TIME_MON "@eq 0" "id:995,phase:1,deny,status:503,chain"
+        SecRule TIME_DAY "@eq 1" "tag:github_team=laa-crime-apply"
+      SecRule TIME_MON "@eq 11" "id:996,phase:1,deny,status:503,chain"
+        SecRule TIME_DAY "@pm 25 26" "tag:github_team=laa-crime-apply"
       SecRule TIME_HOUR "!@pm 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21" \
         "id:998,phase:1,deny,status:503,tag:github_team=laa-crime-apply"
       SecRule REMOTE_ADDR "!@ipMatch 51.149.249.0/29,194.33.249.0/29,51.149.249.32/29,194.33.248.0/29,20.49.214.199/32,20.49.214.228/32,20.26.11.71/32,20.26.11.108/32,128.77.75.64/26,18.169.147.172/32,35.176.93.186/32,18.130.148.126/32,35.176.148.126/32" \


### PR DESCRIPTION
## Description of change

1. Add ModSecurity ingress rules to keep the service offline (return 503) on UK bank holidays for:
    - Christmas Day (25 December)
    - Boxing Day (26 December)
    - New Year’s Day (1 January)
2. Update service availability content

These changes are applied consistently across staging and production ingress configurations.

## Notes for reviewer
- TIME_MON uses 0 for January and 11 for December, so these match 1 January and 25/26 December respectively.
- This only covers Christmas and NYD bank holidays, as separate ticket to review in the New Year is here: [CRIMAPP-2058](https://dsdmoj.atlassian.net/browse/CRIMAPP-2058)

##Link to relevant ticket
[CRIMAPP-2057](https://dsdmoj.atlassian.net/browse/CRIMAPP-2057)

[CRIMAPP-2058]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-2057]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ