### PR TITLE
[CRIMAPP-1477] Fix action button alignment

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -151,3 +151,7 @@ body.js-enabled {
   display: flex;
   align-items: center;
 }
+
+.govuk-button-group form {
+  display: flex;
+}


### PR DESCRIPTION
## Description of change
- fix the alignment provided by `.govuk-button-group` when one of the child elements is a `form`

## Link to relevant ticket
[CRIMAPP-1477](https://dsdmoj.atlassian.net/browse/CRIMAPP-1477)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="481" height="97" alt="image" src="https://github.com/user-attachments/assets/0a9beede-4391-44c5-8691-88710aba57bb" />

### After changes:
<img width="886" height="118" alt="image" src="https://github.com/user-attachments/assets/248a7da0-aaea-4a27-899e-6f3579774e03" />

[CRIMAPP-1477]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ