### PR TITLE
[CRIMAPP-2029] Update notification content

### DIFF
--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -64,9 +64,8 @@ en:
         - "%{continue_adding_decision_link}"
       continue_adding_decision: Continue adding funding decision
       unexpected_assignee:
-        - You cannot review this application
-        - It has been reassigned to another team member.
-        - Contact your supervisor if you need to work on this application.
+        - This application is assigned to someone else
+        - Ask your supervisor if you need to work on it.
 
   primary_navigation:
     your_list: "Your list (%{count})"

--- a/spec/requests/casework/returns_spec.rb
+++ b/spec/requests/casework/returns_spec.rb
@@ -23,9 +23,8 @@ RSpec.describe 'Returning applications' do
       end
 
       it 'sets the correct flash message and redirects' do
-        expect(flash[:important]).to eq(['You cannot review this application',
-                                         'It has been reassigned to another team member.',
-                                         'Contact your supervisor if you need to work on this application.'])
+        expect(flash[:important]).to eq(['This application is assigned to someone else',
+                                         'Ask your supervisor if you need to work on it.'])
         expect(response).to redirect_to("/applications/#{application_id}")
       end
     end
@@ -70,9 +69,8 @@ RSpec.describe 'Returning applications' do
         end
 
         it 'sets the correct flash message and redirects' do
-          expect(flash[:important]).to eq(['You cannot review this application',
-                                           'It has been reassigned to another team member.',
-                                           'Contact your supervisor if you need to work on this application.'])
+          expect(flash[:important]).to eq(['This application is assigned to someone else',
+                                           'Ask your supervisor if you need to work on it.'])
           expect(response).to redirect_to("/applications/#{application_id}")
         end
       end

--- a/spec/requests/casework/send_decisions_spec.rb
+++ b/spec/requests/casework/send_decisions_spec.rb
@@ -36,9 +36,8 @@ RSpec.describe 'Sending application decisions' do
         end
 
         it 'sets the correct flash message and redirects' do
-          expect(flash[:important]).to eq(['You cannot review this application',
-                                           'It has been reassigned to another team member.',
-                                           'Contact your supervisor if you need to work on this application.'])
+          expect(flash[:important]).to eq(['This application is assigned to someone else',
+                                           'Ask your supervisor if you need to work on it.'])
           expect(response).to redirect_to("/applications/#{application_id}")
         end
       end

--- a/spec/system/casework/deciding/adding_a_maat_decision_by_reference_spec.rb
+++ b/spec/system/casework/deciding/adding_a_maat_decision_by_reference_spec.rb
@@ -94,10 +94,8 @@ RSpec.describe 'Adding a decision by MAAT reference' do
     end
 
     it 'does not allow to add a decision' do
-      expect(page).to have_notification_banner(text: 'You cannot review this application',
-                                               details: ['It has been reassigned to another team member.',
-                                                         'Contact your supervisor if you need to work on ' \
-                                                         'this application.'],
+      expect(page).to have_notification_banner(text: 'This application is assigned to someone else',
+                                               details: 'Ask your supervisor if you need to work on it.',
                                                success: false)
     end
   end

--- a/spec/system/casework/reviewing/a_pse_application_spec.rb
+++ b/spec/system/casework/reviewing/a_pse_application_spec.rb
@@ -100,10 +100,8 @@ RSpec.describe 'Reviewing a PSE application' do
     end
 
     it 'cannot be marked as completed' do
-      expect(page).to have_notification_banner(text: 'You cannot review this application',
-                                               details: ['It has been reassigned to another team member.',
-                                                         'Contact your supervisor if you need to work on ' \
-                                                         'this application.'],
+      expect(page).to have_notification_banner(text: 'This application is assigned to someone else',
+                                               details: 'Ask your supervisor if you need to work on it.',
                                                success: false)
     end
   end

--- a/spec/system/casework/reviewing/mark_application_as_ready_spec.rb
+++ b/spec/system/casework/reviewing/mark_application_as_ready_spec.rb
@@ -135,10 +135,8 @@ RSpec.describe 'Marking an application as ready for assessment' do
     end
 
     it 'cannot be marked as ready' do
-      expect(page).to have_notification_banner(text: 'You cannot review this application',
-                                               details: ['It has been reassigned to another team member.',
-                                                         'Contact your supervisor if you need to work on ' \
-                                                         'this application.'],
+      expect(page).to have_notification_banner(text: 'This application is assigned to someone else',
+                                               details: 'Ask your supervisor if you need to work on it.',
                                                success: false)
     end
   end


### PR DESCRIPTION
## Description of change
- update the content for the notification banner shown when the wrong assignee attempts to perform a reviewing action

## Link to relevant ticket
[CRIMAPP-2029](https://dsdmoj.atlassian.net/browse/CRIMAPP-2029)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="2000" height="460" alt="image" src="https://github.com/user-attachments/assets/9f58febf-d71b-4472-ba0b-fd8d01c0fc3b" />

### After changes:
<img width="1976" height="352" alt="image" src="https://github.com/user-attachments/assets/752de327-d88b-428b-924a-5f3b98c65e71" />


[CRIMAPP-2029]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ