### PR TITLE
[CRIMAPP-2074] Fix application received event content

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -231,4 +231,9 @@ class CrimeApplication < LaaCrimeSchemas::Structs::CrimeApplication # rubocop:di
   def decisions_pending?
     decisions.present? && !status?(::Types::ReviewState[:completed])
   end
+
+  def resubmission?
+    parent_id && [Types::ApplicationType['initial'],
+                  Types::ApplicationType['change_in_financial_circumstances']].include?(application_type)
+  end
 end

--- a/app/views/casework/application_history_items/_reviewing_application_received.html.erb
+++ b/app/views/casework/application_history_items/_reviewing_application_received.html.erb
@@ -1,9 +1,9 @@
 <strong>
-  <% if application.superseded_at.nil? %>
-    <%= t('event.description.reviewing.application_received.original_submission',
+  <% if application.resubmission? %>
+    <%= t('event.description.reviewing.application_received.resubmission',
           application_type: t(application.application_type, scope: 'labels.application_type')) %> <br>
   <% else %>
-    <%= t('event.description.reviewing.application_received.resubmission',
+    <%= t('event.description.reviewing.application_received.original_submission',
           application_type: t(application.application_type, scope: 'labels.application_type')) %> <br>
   <% end %>
 </strong>


### PR DESCRIPTION
## Description of change
Fixes a bug caused by my previous pr (https://github.com/ministryofjustice/laa-review-criminal-legal-aid/pull/974) in the content of application received events where original submissions had the text 'application resubmitted' and resubmissions showed 'application submitted'. I reverted the logic back to what it was previously.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2074

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1062" height="873" alt="Screenshot 2026-01-29 at 08 15 31" src="https://github.com/user-attachments/assets/0a3a66d5-ffaa-46be-af34-3b8170fcb9d2" />

### After changes:
<img width="1062" height="873" alt="Screenshot 2026-01-29 at 08 14 28" src="https://github.com/user-attachments/assets/539c88e4-d160-4bf5-a777-0ce83d4db1c5" />



## How to manually test the feature
