### PR TITLE
[CRIMAPP-2105] Create View link in Review along side existing Download link

### DIFF
--- a/app/components/supporting_evidence_component.html.erb
+++ b/app/components/supporting_evidence_component.html.erb
@@ -1,23 +1,22 @@
 <%= govuk_summary_card(title: label_text(:file_name)) do
-  govuk_summary_list(actions: false) do |list|
-    if crime_application.supporting_evidence.present?
-      crime_application.supporting_evidence.each do |evidence|
-        list.with_row do |row|
-          row.with_key { evidence.filename }
-          row.with_value do
-            govuk_link_to(
-              link_text(evidence),
-              download_path(evidence),
-              class: 'app-no-print',
-              target: target
-            )
+      govuk_summary_list(actions: false) do |list|
+        if crime_application.supporting_evidence.present?
+          crime_application.supporting_evidence.each do |evidence|
+            list.with_row do |row|
+              row.with_key { evidence.filename }
+              row.with_value do
+                if FeatureFlags.view_evidence.enabled?
+                  view_link(evidence)
+                else
+                  download_link(evidence)
+                end
+              end
+            end
+          end
+        else
+          list.with_row do |row|
+            row.with_key { label_text(:no_files_uploaded) }
           end
         end
       end
-    else
-      list.with_row do |row|
-        row.with_key { label_text(:no_files_uploaded) }
-      end
-    end
-  end
-end %>
+    end %>

--- a/app/components/supporting_evidence_component.rb
+++ b/app/components/supporting_evidence_component.rb
@@ -11,27 +11,42 @@ class SupportingEvidenceComponent < ViewComponent::Base
 
   attr_reader :crime_application
 
-  def target
-    FeatureFlags.view_evidence.enabled? ? '_blank' : ''
+  def view_link(evidence)
+    govuk_link_to(
+      view_link_text(evidence),
+      documents_path(
+        crime_application_id: crime_application.id,
+        id: evidence.s3_object_key
+      ),
+      class: 'app-no-print',
+      target: '_blank'
+    )
   end
 
-  def link_text(evidence)
-    if FeatureFlags.view_evidence.enabled?
-      'View'
-    else
-      sanitize(
-        t(:download_file,
-          scope: 'values',
-          file_extension: evidence.file_extension,
-          file_size: number_to_human_size(evidence.file_size))
-      )
-    end
+  def view_link_text(evidence)
+    safe_join [
+      t(:view_file, scope: 'values'),
+      tag.span(sanitize(evidence.filename), class: 'govuk-visually-hidden')
+    ], ' '
   end
 
-  def download_path(evidence)
-    download_documents_path(
-      crime_application_id: crime_application.id,
-      id: evidence.s3_object_key
+  def download_link(evidence)
+    govuk_link_to(
+      download_text(evidence),
+      download_documents_path(
+        crime_application_id: crime_application.id,
+        id: evidence.s3_object_key
+      ),
+      class: 'app-no-print'
+    )
+  end
+
+  def download_text(evidence)
+    sanitize(
+      t(:download_file,
+        scope: 'values',
+        file_extension: evidence.file_extension,
+        file_size: number_to_human_size(evidence.file_size))
     )
   end
 end

--- a/app/controllers/casework/documents_controller.rb
+++ b/app/controllers/casework/documents_controller.rb
@@ -1,25 +1,34 @@
 module Casework
   class DocumentsController < Casework::BaseController
     before_action :set_crime_application, :set_document
-    before_action :require_doc_part_of_app
 
-    class CannotDownloadUnlessAssigned < StandardError; end
-    class CannotDownloadDocNotPartOfApp < StandardError; end
+    rescue_from 'Datastore::Documents::DownloadError' do
+      set_flash(:cannot_download_try_again, file_name: @document.filename, success: false)
 
-    def show; end
+      redirect_to crime_application_path(params[:crime_application_id])
+    end
+
+    def show
+      redirect_to(view_url, allow_other_host: true)
+    end
 
     def download
-      presign_download = Datastore::Documents::Download.new(document: @document, log_context: log_context).call
-
-      if presign_download.respond_to?(:url)
-        redirect_to(presign_download.url, allow_other_host: true)
-      else
-        set_flash(:cannot_download_try_again, file_name: @document.filename, success: false)
-        redirect_to crime_application_path(params[:crime_application_id])
-      end
+      redirect_to(download_url, allow_other_host: true)
     end
 
     private
+
+    def download_url
+      Datastore::Documents::Download.new(
+        document: @document, log_context: log_context, inline: false
+      ).call.url
+    end
+
+    def view_url
+      Datastore::Documents::Download.new(
+        document: @document, log_context: log_context, inline: true
+      ).call.url
+    end
 
     def log_context
       { caseworker_id: current_user_id, caseworker_ip: request.remote_ip, file_type: @document.content_type,
@@ -28,12 +37,9 @@ module Casework
 
     def set_document
       @document = @crime_application.supporting_evidence.find { |evidence| evidence.s3_object_key == params[:id] }
-    end
 
-    def require_doc_part_of_app
-      # To ensure users can only download documents that are part of the current application
-      raise CannotDownloadDocNotPartOfApp if @document.blank?
-    rescue CannotDownloadDocNotPartOfApp
+      return @document if @document.present?
+
       set_flash(:cannot_download_doc_uploaded_to_another_app, success: false)
       redirect_to crime_application_path(params[:crime_application_id])
     end

--- a/app/views/casework/crime_applications/_supporting_evidence.html.erb
+++ b/app/views/casework/crime_applications/_supporting_evidence.html.erb
@@ -32,4 +32,4 @@
       title: label_text(:evidence_other)
     } %>
 
-<%= render SupportingEvidenceComponent.new(crime_application: crime_application) %>
+<%= render SupportingEvidenceComponent.new(crime_application:) %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -594,6 +594,7 @@ en:
       fail_on_ioj: red
       deleted: grey
     download_file: "Download file (%{file_extension}, %{file_size})"
+    view_file: "View"
     no_hearing_yet: There has not been a hearing yet
     manage_without_income:
       friends_sofa: They sleep on a friend's sofa for free

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,12 @@
 Rails.application.routes.draw do
-  Rails.application.routes.draw { mount RailsEventStore::Browser => "/res" if Rails.env.development? }
+  Rails.application.routes.draw { mount RailsEventStore::Browser => '/res' if Rails.env.development? }
   mount DatastoreApi::HealthEngine::Engine => '/datastore'
 
   unless HostEnv.production?
-    authenticate :user, lambda { |u| u.admin? } do
+    authenticate :user, ->(u) { u.admin? } do
       require 'sidekiq/web'
       require 'sidekiq-scheduler/web'
-      mount Sidekiq::Web => "/sidekiq"
+      mount Sidekiq::Web => '/sidekiq'
     end
   end
 
@@ -20,15 +20,13 @@ Rails.application.routes.draw do
     }
   )
 
-  get "users/auth/failure", to: "errors#forbidden"
+  get 'users/auth/failure', to: 'errors#forbidden'
 
   devise_scope :user do
     unauthenticated :user do
       root 'users/sessions#new', as: :unauthenticated_root
 
-      if FeatureFlags.dev_auth.enabled?
-        get 'dev_auth', to: 'users/dev_auth#new'
-      end
+      get 'dev_auth', to: 'users/dev_auth#new' if FeatureFlags.dev_auth.enabled?
     end
 
     authenticated :user do
@@ -48,7 +46,7 @@ Rails.application.routes.draw do
       get 'what-do-you-want-to-do-next', to: 'send_decisions#new', as: :send_decisions
       post 'what-do-you-want-to-do-next', to: 'send_decisions#create'
 
-      resources :decisions, only: [:create] do 
+      resources :decisions, only: [:create] do
         scope module: :decisions do
           get 'interests-of-justice', to: 'interests_of_justices#edit'
           put 'interests-of-justice', to: 'interests_of_justices#update'
@@ -60,7 +58,7 @@ Rails.application.routes.draw do
           put 'comment', to: 'comments#update'
         end
       end
-      
+
       get 'link-maat-id', to: 'maat_decisions#new', as: :maat_decisions
       post 'link-maat-id', to: 'maat_decisions#create'
 
@@ -91,7 +89,8 @@ Rails.application.routes.draw do
 
     get ':report_type', to: 'user_reports#show', as: 'user_report'
 
-    get ':report_type/:interval/latest-complete', to: 'temporal_reports#latest_complete', as: :latest_complete_temporal_report
+    get ':report_type/:interval/latest-complete', to: 'temporal_reports#latest_complete',
+as: :latest_complete_temporal_report
     get ':report_type/:interval/:period', to: 'temporal_reports#show', as: :temporal_report
     get ':report_type/:interval/:period/download', to: 'temporal_reports#download', as: :download_temporal_report
     get ':report_type/:date/at/:time', to: 'snapshots#show', as: :snapshot

--- a/spec/components/supporting_evidence_component_spec.rb
+++ b/spec/components/supporting_evidence_component_spec.rb
@@ -1,12 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe SupportingEvidenceComponent, type: :component do
-  let(:crime_application) { double }
+  let(:crime_application) { instance_double(CrimeApplication) }
   let(:supporting_evidence) { [] }
 
   before do
-    allow(crime_application).to receive(:id).and_return('12345')
-    allow(crime_application).to receive(:supporting_evidence).and_return(supporting_evidence)
+    allow(crime_application).to receive_messages(id: '12345', supporting_evidence: supporting_evidence)
   end
 
   describe '.new' do
@@ -31,27 +30,31 @@ RSpec.describe SupportingEvidenceComponent, type: :component do
     end
 
     context 'when there are files uploaded' do
-      let(:evidence1) do
-        double(
+      let(:pdf_evidence) do
+        Document.new(
           filename: 'document1.pdf',
+          content_type: 'application/pdf',
           file_extension: 'pdf',
           file_size: 1024,
           s3_object_key: 'key1'
         )
       end
-      let(:evidence2) do
-        double(
+      let(:jpeg_evidence) do
+        Document.new(
           filename: 'document2.jpg',
+          content_type: 'image/jpeg',
           file_extension: 'jpg',
           file_size: 2048,
           s3_object_key: 'key2'
         )
       end
-      let(:supporting_evidence) { [evidence1, evidence2] }
+      let(:supporting_evidence) { [pdf_evidence, jpeg_evidence] }
 
       context 'when view_evidence feature flag is disabled' do
         before do
-          allow(FeatureFlags).to receive(:view_evidence).and_return(double(enabled?: false))
+          allow(FeatureFlags).to receive(:view_evidence) {
+            instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+          }
           render_inline(described_class.new(crime_application:))
         end
 
@@ -61,24 +64,22 @@ RSpec.describe SupportingEvidenceComponent, type: :component do
         end
 
         it 'displays download links with file extension and size' do
-          expect(page).to have_link('Download file (pdf, 1 KB)')
-          expect(page).to have_link('Download file (jpg, 2 KB)')
-        end
-
-        it 'links have correct paths' do
-          expect(page).to have_link(href: /crime_application_id=12345/)
-          expect(page).to have_link(href: /id=key1/)
-          expect(page).to have_link(href: /id=key2/)
-        end
-
-        it 'links do not have target attribute' do
-          expect(page.all('a').first[:target]).to eq('')
+          expect(page).to have_link(
+            'Download file (pdf, 1 KB)', target: nil,
+            href: %r{/documents/download\?.*crime_application_id=12345.*id=key1}
+          )
+          expect(page).to have_link(
+            'Download file (jpg, 2 KB)', target: nil,
+            href: %r{/documents/download\?.*crime_application_id=12345.*id=key2}
+          )
         end
       end
 
       context 'when view_evidence feature flag is enabled' do
         before do
-          allow(FeatureFlags).to receive(:view_evidence).and_return(double(enabled?: true))
+          allow(FeatureFlags).to receive(:view_evidence) {
+            instance_double(FeatureFlags::EnabledFeature, enabled?: true)
+          }
           render_inline(described_class.new(crime_application:))
         end
 
@@ -87,12 +88,15 @@ RSpec.describe SupportingEvidenceComponent, type: :component do
           expect(page).to have_text('document2.jpg')
         end
 
-        it 'displays view links' do
-          expect(page).to have_link('View', count: 2)
-        end
-
-        it 'links have target=_blank' do
-          expect(page.all('a').first[:target]).to eq('_blank')
+        it 'displays view links with visually hidden filename' do
+          expect(page).to have_link(
+            'View document1.pdf', target: '_blank',
+            href: %r{/documents\?.*crime_application_id=12345.*id=key1}
+          )
+          expect(page).to have_link(
+            'View document2.jpg', target: '_blank',
+            href: %r{/documents\?.*crime_application_id=12345.*id=key2}
+          )
         end
       end
     end

--- a/spec/services/datastore/documents/download_spec.rb
+++ b/spec/services/datastore/documents/download_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe Datastore::Documents::Download do
           .to_return(status: 500)
       end
 
-      it 'returns false' do
-        expect(download_service.call).to be(false)
+      it 'raises an DownloadError' do
+        expect { download_service.call }.to raise_error Datastore::Documents::DownloadError
       end
     end
 

--- a/spec/shared_contexts/when_downloading_a_document.rb
+++ b/spec/shared_contexts/when_downloading_a_document.rb
@@ -1,13 +1,14 @@
 RSpec.shared_context 'when downloading a document' do
   let(:filename) { 'test.pdf' }
   let(:s3_object_key) { '123/abcdef1234' }
+  let(:content_dispostion) { 'attachment' }
 
   let(:expected_query) do
     {
       object_key: %r{123/.*},
       s3_opts: {
         expires_in: Datastore::Documents::Download::PRESIGNED_URL_EXPIRES_IN,
-        response_content_disposition: "attachment; filename=#{filename}; filename*= UTF-8''#{filename};"
+        response_content_disposition: "#{content_dispostion}; filename=#{filename}; filename*= UTF-8''#{filename};"
       }
     }
   end

--- a/spec/system/casework/viewing_an_application/application_details/supporting_evidence_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/supporting_evidence_spec.rb
@@ -3,10 +3,11 @@ require 'rails_helper'
 RSpec.describe 'Viewing supporting evidence' do
   include_context 'with stubbed application'
   include_context 'when downloading a document'
+  let(:viewing_enabled) { false }
 
   before do
     allow(FeatureFlags).to receive(:view_evidence) {
-      instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+      instance_double(FeatureFlags::EnabledFeature, enabled?: viewing_enabled)
     }
 
     visit crime_application_path(application_id)
@@ -26,6 +27,21 @@ RSpec.describe 'Viewing supporting evidence' do
           expect(card).to have_summary_row 'test.pdf', link_text
 
           click_link(link_text)
+        end
+      end
+
+      context 'when viewing evidence is enabled' do
+        let(:viewing_enabled) { true }
+        let(:content_dispostion) { 'inline' }
+
+        it 'shows a link to download the supporting evidence' do
+          link_text = 'View test.pdf'
+
+          within(files_card) do |card|
+            expect(card).to have_summary_row 'test.pdf', link_text
+
+            click_link(link_text)
+          end
         end
       end
     end


### PR DESCRIPTION
## Description of change

Lays the groundwork for supporting both view and download links for evidence files, while maintaining current behavior (view OR download based on feature flag).

Currently, the feature flag switches between view OR download. This PR prepares the component to support a future state where both view AND download links will be available simultaneously for each file. Also moves "View" to I18n and adds  accessible description to the "View" link

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2105

## Notes for reviewer

This change does not introduce any change in behaviour.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
