### PR TITLE
[CRIMAPP-2105] Enable evidence viewing in staging

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,8 +10,7 @@ feature_flags:
   view_evidence:
     local: true
     test: false
-    staging: false
-    preprod: false
+    staging: true
     production: false
 
 # For settings that vary by HostEnv name


### PR DESCRIPTION
Production configuration has been successfully tested in Staging and is ready for deployment to Production. This enables the feature flag to allow testing of the feature in the Staging environment.