### PR TITLE
[CRIMAPP-2108] log download metadata

### DIFF
--- a/app/services/evidence_access_logger.rb
+++ b/app/services/evidence_access_logger.rb
@@ -1,0 +1,50 @@
+class EvidenceAccessLogger
+  EVIDENCE_VIEWED = 'evidence_viewed'.freeze
+  EVIDENCE_DOWNLOADED = 'evidence_downloaded'.freeze
+
+  def self.log_view(crime_application:, document:, current_user:)
+    new(
+      action: EVIDENCE_VIEWED,
+      crime_application: crime_application,
+      document: document,
+      current_user: current_user
+    ).log
+  end
+
+  def self.log_download(crime_application:, document:, current_user:)
+    new(
+      action: EVIDENCE_DOWNLOADED,
+      crime_application: crime_application,
+      document: document,
+      current_user: current_user
+    ).log
+  end
+
+  def initialize(action:, crime_application:, document:, current_user:)
+    @action = action
+    @crime_application = crime_application
+    @document = document
+    @current_user = current_user
+  end
+
+  def log
+    Rails.logger.info(log_message)
+  end
+
+  private
+
+  def log_message
+    "#{@action} #{evidence_accessed.to_json}"
+  end
+
+  def evidence_accessed
+    {
+      application_id: @crime_application.id,
+      caseworker_id: @current_user.id,
+      caseworker_role: @current_user.role,
+      assigned: @crime_application.assigned_to?(@current_user.id) ? 'assigned' : 'not_assigned',
+      file_type: @document.content_type,
+      timestamp: Time.current.iso8601
+    }
+  end
+end

--- a/docs/evidence_access_logging.md
+++ b/docs/evidence_access_logging.md
@@ -1,0 +1,152 @@
+# Evidence Access Logging
+
+## Overview
+
+This logging system captures caseworker evidence viewing and downloading events in a structured format optimized for OpenSearch queries.
+
+## Log Events
+
+Two event types are logged:
+
+- `evidence_viewed` - When a caseworker views a file inline
+- `evidence_downloaded` - When a caseworker downloads a file
+
+## Log Format
+
+Each event is logged with a searchable event name followed by a JSON object:
+
+```
+evidence_viewed {"application_id":"12345","caseworker_id":"user_456","caseworker_role":"caseworker","assigned":"assigned","file_type":"application/pdf","timestamp":"2024-01-15T10:30:00Z"}
+```
+
+## Logged Fields
+
+| Field             | Description                                   | Example Values                                                |
+| ----------------- | --------------------------------------------- | ------------------------------------------------------------- |
+| `application_id`  | Crime application ID                          | `"12345"`                                                     |
+| `caseworker_id`   | User ID of the caseworker                     | `"user_456"`                                                  |
+| `caseworker_role` | Role of the caseworker                        | `"caseworker"`, `"supervisor"`, `"data_analyst"`, `"auditor"` |
+| `assigned`        | Whether caseworker is assigned to application | `"assigned"`, `"not_assigned"`                                |
+| `file_type`       | MIME type of the file                         | `"application/pdf"`, `"image/jpeg"`                           |
+| `timestamp`       | ISO 8601 timestamp                            | `"2024-01-15T10:30:00Z"`                                      |
+
+## OpenSearch Query Examples
+
+### Basic Stats: View vs Download Ratio
+
+```json
+{
+  "query": {
+    "bool": {
+      "should": [
+        { "match": { "message": "evidence_viewed" } },
+        { "match": { "message": "evidence_downloaded" } }
+      ]
+    }
+  },
+  "aggs": {
+    "by_action": {
+      "terms": {
+        "field": "message.keyword",
+        "include": ["evidence_viewed", "evidence_downloaded"]
+      }
+    }
+  }
+}
+```
+
+### Filter by Role
+
+```json
+{
+  "query": {
+    "bool": {
+      "must": [
+        { "match": { "message": "evidence_viewed" } },
+        { "match": { "message": "caseworker_role\":\"supervisor" } }
+      ]
+    }
+  }
+}
+```
+
+### Filter by Assignment Status
+
+```json
+{
+  "query": {
+    "bool": {
+      "must": [
+        { "match": { "message": "evidence_downloaded" } },
+        { "match": { "message": "assigned\":\"not_assigned" } }
+      ]
+    }
+  }
+}
+```
+
+### Count Downloads by File Type
+
+```json
+{
+  "query": {
+    "match": { "message": "evidence_downloaded" }
+  },
+  "aggs": {
+    "by_file_type": {
+      "terms": {
+        "script": {
+          "source": "def m = /file_type\":\"([^\"]+)/.matcher(doc['message.keyword'].value); m.find() ? m.group(1) : 'unknown'"
+        }
+      }
+    }
+  }
+}
+```
+
+### Activity by Caseworker
+
+```json
+{
+  "query": {
+    "bool": {
+      "should": [
+        { "match": { "message": "evidence_viewed" } },
+        { "match": { "message": "evidence_downloaded" } }
+      ]
+    }
+  },
+  "aggs": {
+    "by_caseworker": {
+      "terms": {
+        "script": {
+          "source": "def m = /caseworker_id\":\"([^\"]+)/.matcher(doc['message.keyword'].value); m.find() ? m.group(1) : 'unknown'"
+        }
+      }
+    }
+  }
+}
+```
+
+### Time-based Analysis
+
+```json
+{
+  "query": {
+    "bool": {
+      "must": [
+        { "match": { "message": "evidence_viewed" } },
+        { "range": { "@timestamp": { "gte": "now-7d" } } }
+      ]
+    }
+  },
+  "aggs": {
+    "views_over_time": {
+      "date_histogram": {
+        "field": "@timestamp",
+        "calendar_interval": "day"
+      }
+    }
+  }
+}
+```

--- a/spec/services/evidence_access_logger_spec.rb
+++ b/spec/services/evidence_access_logger_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe EvidenceAccessLogger do
+  let(:crime_application) { instance_double(CrimeApplication, id: '12345', assigned_to?: assigned) }
+  let(:document) do
+    instance_double(
+      Document,
+      content_type: 'application/pdf',
+      filename: 'test.pdf',
+      s3_object_key: 's3_key_123'
+    )
+  end
+  let(:current_user) { instance_double(User, id: 'user_456', role: 'caseworker') }
+  let(:assigned) { true }
+  let(:timestamp) { Time.zone.parse('2024-01-15 10:30:00') }
+  let(:logger_spy) { instance_spy(ActiveSupport::Logger) }
+
+  before do
+    allow(Time).to receive(:current).and_return(timestamp)
+    allow(Rails).to receive(:logger).and_return(logger_spy)
+  end
+
+  describe '.log_view' do
+    it 'logs evidence_viewed event with structured data' do
+      described_class.log_view(crime_application:, document:, current_user:)
+
+      expected_log = %r{evidence_viewed.*{"application_id":"12345","caseworker_id":"user_456",
+                      "caseworker_role":"caseworker","assigned":"assigned",
+                      "file_type":"application/pdf","timestamp":"2024-01-15T10:30:00Z"}}x
+
+      expect(logger_spy).to have_received(:info).with(expected_log)
+    end
+  end
+
+  describe '.log_download' do
+    it 'logs evidence_downloaded event with structured data' do
+      described_class.log_download(crime_application:, document:, current_user:)
+
+      expected_log = %r{evidence_downloaded.*{"application_id":"12345","caseworker_id":"user_456",
+                      "caseworker_role":"caseworker","assigned":"assigned",
+                      "file_type":"application/pdf","timestamp":"2024-01-15T10:30:00Z"}}x
+
+      expect(logger_spy).to have_received(:info).with(expected_log)
+    end
+  end
+
+  describe 'assignment status' do
+    context 'when user is assigned to application' do
+      let(:assigned) { true }
+
+      it 'logs assigned status' do
+        described_class.log_view(
+          crime_application:,
+          document:,
+          current_user:
+        )
+
+        expect(logger_spy).to have_received(:info).with(/assigned":"assigned"/)
+      end
+    end
+
+    context 'when user is not assigned to application' do
+      let(:assigned) { false }
+
+      it 'logs not_assigned status' do
+        described_class.log_view(
+          crime_application:,
+          document:,
+          current_user:
+        )
+
+        expect(logger_spy).to have_received(:info).with(/assigned":"not_assigned"/)
+      end
+    end
+  end
+
+  describe 'caseworker roles' do
+    %w[caseworker supervisor data_analyst].each do |role|
+      context "when caseworker has #{role} role" do
+        let(:current_user) { instance_double(User, id: 'user_456', role: role) }
+
+        it "logs #{role} in caseworker_role" do
+          described_class.log_view(
+            crime_application:,
+            document:,
+            current_user:
+          )
+
+          expect(logger_spy).to have_received(:info).with(/caseworker_role":"#{role}"/)
+        end
+      end
+    end
+  end
+end

--- a/spec/system/casework/viewing_an_application/application_details/supporting_evidence_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/supporting_evidence_spec.rb
@@ -31,6 +31,18 @@ RSpec.describe 'Viewing supporting evidence' do
         end
       end
 
+      it 'logs evidence download event' do
+        link_text = 'Download file (pdf, 12 Bytes)'
+
+        allow(EvidenceAccessLogger).to receive(:log_download)
+
+        within(files_card) do
+          click_link(link_text)
+        end
+
+        expect(EvidenceAccessLogger).to have_received(:log_download)
+      end
+
       context 'when viewing evidence is enabled' do
         let(:viewing_enabled) { true }
 
@@ -42,6 +54,18 @@ RSpec.describe 'Viewing supporting evidence' do
               click_link(link_text)
               expect(current_path).to eq('/crime-apply-documents-dev/42/WtpJTOwsQ2')
             end
+          end
+
+          it 'logs evidence view event' do
+            link_text = 'View'
+
+            allow(EvidenceAccessLogger).to receive(:log_view)
+
+            within(files_card) do
+              click_link(link_text)
+            end
+
+            expect(EvidenceAccessLogger).to have_received(:log_view)
           end
         end
 


### PR DESCRIPTION
## Description of change

- Add evidence access logging for caseworkers
- Implements structured logging to capture when caseworkers view or download evidence files, enabling analytics on access patterns and supporting future role-based access controls.
  
## Link to relevant ticket

[CRIMAPP-2108](https://dsdmoj.atlassian.net/browse/CRIMAPP-2108)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
