### PR TITLE
[CRIMAPP-2061] Remove erb_lint from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,3 @@ repos:
         name: rubocop
         entry: bundle exec rubocop --force-exclusion
         language: system
-      - id: erblint
-        name: erblint
-        entry: bundle exec erb_lint --lint-all
-        language: system

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ We use the Ministry of Justice [DevSecOps Hooks](https://github.com/ministryofju
 With pre-commit hooks enabled, the following tools are run on each commit:
 - GitLeaks (via [devsecops-hooks](https://github.com/ministryofjustice/devsecops-hooks))
 - Rubocop
-- ERB Lint
 
 To bypass the hooks, use the `-n` or `--no-verify` option, e.g.
 ```shell


### PR DESCRIPTION
## Description of change
- remove `erb_lint` from the pre-commit hooks

## Link to relevant ticket
[CRIMAPP-2061](https://dsdmoj.atlassian.net/browse/CRIMAPP-2061)