### PR TITLE
[CRIMAPP-2101] snyk open sources uses yarn not npm

### DIFF
--- a/.github/workflows/snyk-open-source.yml
+++ b/.github/workflows/snyk-open-source.yml
@@ -3,8 +3,6 @@ name: Snyk Open Source
 on:
   pull_request:
   workflow_dispatch:
-  schedule:
-    - cron: "0 21 * * 1" # Mondays at 21:00
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description of change

- snyk-open-source.yml to uses yarn install instead of npm install, so the scan respects the lockfile and yarn resolutions
- remove the Monday schedule from snyk-open-source.yml--the container scan (which runs Mon/Thu) already covers the same Node/Ruby dependencies on a schedule. The open source scan now only runs on PRs, to add faster feedback and possibly to allow blocking CI on vuln discovery as per security guardrail discussions.

## Link to relevant ticket
[CRIMAPP-2101](https://dsdmoj.atlassian.net/browse/CRIMAPP-2101)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
