### PR TITLE
[CRIMAPP-2168] Enforce reviewing actions

### DIFF
--- a/app/aggregates/reviewing.rb
+++ b/app/aggregates/reviewing.rb
@@ -13,6 +13,7 @@ module Reviewing
   class DecisionNotLinked < Error; end
   class IncompleteDecisions < Error; end
   class UnexpectedAssignee < Error; end
+  class NotAuthorisedToReview < Error; end
 
   class DecisionAdded < Event; end
   class DecisionRemoved < Event; end

--- a/app/aggregates/reviewing/command.rb
+++ b/app/aggregates/reviewing/command.rb
@@ -4,6 +4,7 @@ module Reviewing
 
     def with_review(user_id: nil, &block)
       raise UnexpectedAssignee if user_id.present? && unexpected_assignee?(user_id)
+      raise NotAuthorisedToReview if user_id.present? && not_authorised_to_review?(user_id)
 
       repository.with_aggregate(
         Review.new(application_id), stream_name, &block
@@ -24,6 +25,13 @@ module Reviewing
 
     def unexpected_assignee?(user_id)
       !Assigning::LoadAssignment.call(assignment_id: application_id).assigned_to?(user_id)
+    end
+
+    def not_authorised_to_review?(user_id)
+      review = Reviewing::LoadReview.call(application_id:)
+      user = User.find(user_id)
+
+      !ReviewerEligibility.new(user:, review:).allowed?
     end
 
     class << self

--- a/app/aggregates/reviewing/reviewer_eligibility.rb
+++ b/app/aggregates/reviewing/reviewer_eligibility.rb
@@ -8,7 +8,7 @@ module Reviewing
     end
 
     def allowed?
-      user.caseworker?
+      user.caseworker? || user.supervisor?
     end
   end
 end

--- a/app/aggregates/reviewing/reviewer_eligibility.rb
+++ b/app/aggregates/reviewing/reviewer_eligibility.rb
@@ -1,0 +1,14 @@
+module Reviewing
+  class ReviewerEligibility
+    attr_reader :user, :review
+
+    def initialize(user:, review:)
+      @user = user
+      @review = review
+    end
+
+    def allowed?
+      user.caseworker?
+    end
+  end
+end

--- a/app/controllers/casework/base_controller.rb
+++ b/app/controllers/casework/base_controller.rb
@@ -6,7 +6,7 @@ module Casework
     before_action :require_service_user!
     before_action :set_security_headers
 
-    helper_method :assignments_count, :set_crime_application
+    helper_method :assignments_count, :can_review_application?, :set_crime_application
 
     rescue_from DatastoreApi::Errors::ApiError do |e|
       Rails.error.report(e, handled: false, severity: :error)
@@ -22,6 +22,12 @@ module Casework
 
     rescue_from DatastoreApi::Errors::NotFoundError do
       render status: :not_found, template: 'errors/application_not_found'
+    end
+
+    rescue_from Reviewing::NotAuthorisedToReview do
+      set_flash(:not_authorised_to_review, success: false)
+
+      redirect_to reviewing_authorisation_redirect_path
     end
 
     private
@@ -43,9 +49,27 @@ module Casework
       ).count
     end
 
+    def can_review_application?(crime_application)
+      current_user.caseworker? && crime_application.reviewable_by?(current_user_id)
+    end
+
+    def require_reviewing_caseworker!
+      return if current_user.caseworker?
+
+      set_flash(:not_authorised_to_review, success: false)
+
+      redirect_to reviewing_authorisation_redirect_path
+    end
+
     def set_crime_application
       app_id_param = params.key?(:crime_application_id) ? params[:crime_application_id] : params[:id]
       @crime_application = CrimeApplication.find(app_id_param)
+    end
+
+    def reviewing_authorisation_redirect_path
+      return crime_application_path(current_crime_application) if current_crime_application
+
+      assigned_applications_path
     end
 
     def current_crime_application

--- a/app/controllers/casework/base_controller.rb
+++ b/app/controllers/casework/base_controller.rb
@@ -50,11 +50,11 @@ module Casework
     end
 
     def can_review_application?(crime_application)
-      current_user.caseworker? && crime_application.reviewable_by?(current_user_id)
+      (current_user.caseworker? || current_user.supervisor?) && crime_application.reviewable_by?(current_user_id)
     end
 
     def require_reviewing_caseworker!
-      return if current_user.caseworker?
+      return if current_user.caseworker? || current_user.supervisor?
 
       set_flash(:not_authorised_to_review, success: false)
 

--- a/app/controllers/casework/base_controller.rb
+++ b/app/controllers/casework/base_controller.rb
@@ -53,7 +53,7 @@ module Casework
       (current_user.caseworker? || current_user.supervisor?) && crime_application.reviewable_by?(current_user_id)
     end
 
-    def require_reviewing_caseworker!
+    def require_reviewer!
       return if current_user.caseworker? || current_user.supervisor?
 
       set_flash(:not_authorised_to_review, success: false)

--- a/app/controllers/casework/completes_controller.rb
+++ b/app/controllers/casework/completes_controller.rb
@@ -1,6 +1,7 @@
 module Casework
   class CompletesController < Casework::BaseController
     before_action :set_crime_application
+    before_action :require_reviewing_caseworker!
 
     def create
       Reviewing::Complete.new(

--- a/app/controllers/casework/completes_controller.rb
+++ b/app/controllers/casework/completes_controller.rb
@@ -1,7 +1,7 @@
 module Casework
   class CompletesController < Casework::BaseController
     before_action :set_crime_application
-    before_action :require_reviewing_caseworker!
+    before_action :require_reviewer!
 
     def create
       Reviewing::Complete.new(

--- a/app/controllers/casework/crime_applications_controller.rb
+++ b/app/controllers/casework/crime_applications_controller.rb
@@ -6,6 +6,7 @@ module Casework
     before_action :require_a_user_work_stream, only: %i[open closed]
     before_action :set_current_work_stream, only: %i[open closed]
     before_action :set_crime_application, only: %i[show history ready]
+    before_action :require_reviewing_caseworker!, only: [:ready]
 
     def open
       set_search(

--- a/app/controllers/casework/crime_applications_controller.rb
+++ b/app/controllers/casework/crime_applications_controller.rb
@@ -6,7 +6,7 @@ module Casework
     before_action :require_a_user_work_stream, only: %i[open closed]
     before_action :set_current_work_stream, only: %i[open closed]
     before_action :set_crime_application, only: %i[show history ready]
-    before_action :require_reviewing_caseworker!, only: [:ready]
+    before_action :require_reviewer!, only: [:ready]
 
     def open
       set_search(

--- a/app/controllers/casework/decisions_controller.rb
+++ b/app/controllers/casework/decisions_controller.rb
@@ -2,7 +2,7 @@ module Casework
   class DecisionsController < Casework::BaseController
     include SetDecisionAndAuthorise
 
-    before_action :require_reviewing_caseworker!, only: [:create]
+    before_action :require_reviewer!, only: [:create]
     before_action :set_decision, except: [:create]
 
     def create

--- a/app/controllers/casework/decisions_controller.rb
+++ b/app/controllers/casework/decisions_controller.rb
@@ -2,6 +2,7 @@ module Casework
   class DecisionsController < Casework::BaseController
     include SetDecisionAndAuthorise
 
+    before_action :require_reviewing_caseworker!, only: [:create]
     before_action :set_decision, except: [:create]
 
     def create

--- a/app/controllers/casework/maat_decisions_controller.rb
+++ b/app/controllers/casework/maat_decisions_controller.rb
@@ -2,7 +2,7 @@ module Casework
   class MaatDecisionsController < Casework::BaseController
     include SetDecisionAndAuthorise
 
-    before_action :require_reviewing_caseworker!, only: %i[new create create_by_reference]
+    before_action :require_reviewer!, only: %i[new create create_by_reference]
     before_action :set_decision, :require_maat_decision!, except: [:create, :new, :create_by_reference]
 
     def new

--- a/app/controllers/casework/maat_decisions_controller.rb
+++ b/app/controllers/casework/maat_decisions_controller.rb
@@ -2,6 +2,7 @@ module Casework
   class MaatDecisionsController < Casework::BaseController
     include SetDecisionAndAuthorise
 
+    before_action :require_reviewing_caseworker!, only: %i[new create create_by_reference]
     before_action :set_decision, :require_maat_decision!, except: [:create, :new, :create_by_reference]
 
     def new

--- a/app/controllers/casework/returns_controller.rb
+++ b/app/controllers/casework/returns_controller.rb
@@ -1,6 +1,7 @@
 module Casework
   class ReturnsController < Casework::BaseController
     before_action :set_crime_application
+    before_action :require_reviewing_caseworker!
     before_action :set_return_details
 
     def new

--- a/app/controllers/casework/returns_controller.rb
+++ b/app/controllers/casework/returns_controller.rb
@@ -1,7 +1,7 @@
 module Casework
   class ReturnsController < Casework::BaseController
     before_action :set_crime_application
-    before_action :require_reviewing_caseworker!
+    before_action :require_reviewer!
     before_action :set_return_details
 
     def new

--- a/app/controllers/casework/send_decisions_controller.rb
+++ b/app/controllers/casework/send_decisions_controller.rb
@@ -1,6 +1,6 @@
 module Casework
   class SendDecisionsController < Casework::BaseController
-    before_action :set_crime_application, :require_reviewing_caseworker!, :set_decisions, :set_form
+    before_action :set_crime_application, :require_reviewer!, :set_decisions, :set_form
     before_action :redirect_if_add_another, only: [:create]
 
     def new; end

--- a/app/controllers/casework/send_decisions_controller.rb
+++ b/app/controllers/casework/send_decisions_controller.rb
@@ -1,6 +1,6 @@
 module Casework
   class SendDecisionsController < Casework::BaseController
-    before_action :set_crime_application, :set_decisions, :set_form
+    before_action :set_crime_application, :require_reviewing_caseworker!, :set_decisions, :set_form
     before_action :redirect_if_add_another, only: [:create]
 
     def new; end

--- a/app/views/casework/crime_applications/_funding_decision.html.erb
+++ b/app/views/casework/crime_applications/_funding_decision.html.erb
@@ -1,15 +1,15 @@
 <% if crime_application.decisions.present? %>
   <h2 class="govuk-heading-l"><%= label_text(:funding_decision) %></h2>
 
-  <% if crime_application.decisions_pending? && crime_application.reviewable_by?(current_user_id) %>
+  <% if crime_application.decisions_pending? && can_review_application?(crime_application) %>
     <%= govuk_warning_text(text: t('.finish_adding_decisions')) %>
   <% end %>
 
   <%= render(DecisionComponent.with_collection(
                crime_application.decisions,
-               show_actions: crime_application.reviewable_by?(current_user_id)
+               show_actions: can_review_application?(crime_application)
              )) %>
-<% elsif crime_application.reviewable_by?(current_user_id) %>
+<% elsif can_review_application?(crime_application) %>
   <% if crime_application.cifc? %>
     <h2 class="govuk-heading-l"><%= label_text(:funding_decision) %></h2>
 

--- a/app/views/casework/crime_applications/show.html.erb
+++ b/app/views/casework/crime_applications/show.html.erb
@@ -4,7 +4,7 @@
   <%= stylesheet_link_tag 'print', media: 'print' %>
 <% end %>
 
-<% if @crime_application.decisions_pending? && @crime_application.reviewable_by?(current_user_id) %>
+<% if @crime_application.decisions_pending? && can_review_application?(@crime_application) %>
   <% message = t(:finish_adding_decisions, scope: 'flash.important', continue_adding_decision_link: govuk_link_to(t(:continue_adding_decision, scope: 'flash.important'), crime_application_send_decisions_path(@crime_application))) %>
   <%= render FlashNotice.new(:important, message) %>
 <% end %>
@@ -42,7 +42,7 @@
 
 <div class="govuk-grid-row app-no-print">
   <div class="govuk-grid-column-full">
-    <% if @crime_application.reviewable_by?(current_user_id) %>
+    <% if can_review_application?(@crime_application) %>
       <div class="govuk-button-group govuk-!-margin-bottom-6">
         <%= reviewing_actions(@crime_application) %>
       </div>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -66,6 +66,8 @@ en:
       unexpected_assignee:
         - This application is assigned to someone else
         - Ask your supervisor if you need to work on it.
+      not_authorised_to_review:
+        - You must be a caseworker to review
 
   primary_navigation:
     your_list: "Your list (%{count})"

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -67,7 +67,7 @@ en:
         - This application is assigned to someone else
         - Ask your supervisor if you need to work on it.
       not_authorised_to_review:
-        - You must be a caseworker to review
+        - You must be a caseworker to review an application
 
   primary_navigation:
     your_list: "Your list (%{count})"

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -67,7 +67,7 @@ en:
         - This application is assigned to someone else
         - Ask your supervisor if you need to work on it.
       not_authorised_to_review:
-        - You must be a caseworker to review an application
+        - You must be a caseworker or supervisor to review an application
 
   primary_navigation:
     your_list: "Your list (%{count})"

--- a/spec/aggregates/reviewing/complete_spec.rb
+++ b/spec/aggregates/reviewing/complete_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Reviewing::Complete do
     described_class.new(application_id:, user_id:)
   end
 
+  include_context 'with an existing caseworker'
   include_context 'with review'
   include_context 'with stubbed assignment'
 
@@ -15,7 +16,7 @@ RSpec.describe Reviewing::Complete do
     )
   end
 
-  let(:user_id) { SecureRandom.uuid }
+  let(:user_id) { caseworker_user.id }
   let(:reference) { rand(100_000..1_000_000) }
   let(:decision_id) { SecureRandom.uuid }
   let(:decisions) { [] }

--- a/spec/aggregates/reviewing/complete_spec.rb
+++ b/spec/aggregates/reviewing/complete_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Reviewing::Complete do
   end
 
   include_context 'with an existing caseworker user'
-  include_context 'with an existing supervisor user'
   include_context 'with review'
   include_context 'with stubbed assignment'
 
@@ -85,7 +84,16 @@ RSpec.describe Reviewing::Complete do
   end
 
   context 'when assigned but not authorised to review' do
-    let(:user_id) { supervisor_user.id }
+    let(:user_id) do
+      User.create!(
+        first_name: 'Data',
+        last_name: 'Analyst',
+        email: "data-analyst-#{SecureRandom.hex(4)}@example.com",
+        auth_subject_id: SecureRandom.uuid,
+        can_manage_others: false,
+        role: UserRole::DATA_ANALYST
+      ).id
+    end
 
     it 'raises a not authorised to review error' do
       expect { command.call }.to raise_error(Reviewing::NotAuthorisedToReview)

--- a/spec/aggregates/reviewing/complete_spec.rb
+++ b/spec/aggregates/reviewing/complete_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Reviewing::Complete do
     described_class.new(application_id:, user_id:)
   end
 
-  include_context 'with an existing caseworker'
+  include_context 'with an existing caseworker user'
+  include_context 'with an existing supervisor user'
   include_context 'with review'
   include_context 'with stubbed assignment'
 
@@ -80,6 +81,14 @@ RSpec.describe Reviewing::Complete do
       expect do
         command.call
       end.to raise_error(Reviewing::IncompleteDecisions)
+    end
+  end
+
+  context 'when assigned but not authorised to review' do
+    let(:user_id) { supervisor_user.id }
+
+    it 'raises a not authorised to review error' do
+      expect { command.call }.to raise_error(Reviewing::NotAuthorisedToReview)
     end
   end
 

--- a/spec/aggregates/reviewing/handlers/complete_review_spec.rb
+++ b/spec/aggregates/reviewing/handlers/complete_review_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Reviewing::Handlers::CompleteReview do
   subject(:handler) { described_class.new }
 
-  include_context 'with an existing caseworker'
+  include_context 'with an existing caseworker user'
   include_context 'with review'
   include_context 'with stubbed assignment'
 

--- a/spec/aggregates/reviewing/handlers/complete_review_spec.rb
+++ b/spec/aggregates/reviewing/handlers/complete_review_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Reviewing::Handlers::CompleteReview do
   subject(:handler) { described_class.new }
 
+  include_context 'with an existing caseworker'
   include_context 'with review'
   include_context 'with stubbed assignment'
 
@@ -47,7 +48,7 @@ RSpec.describe Reviewing::Handlers::CompleteReview do
 
     context 'when there is a draft decision' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       let(:decision_id) { SecureRandom.uuid }
-      let(:user_id) { SecureRandom.uuid }
+      let(:user_id) { caseworker_user.id }
       let(:reference) { 123_456 }
       let(:decisions) do
         [

--- a/spec/aggregates/reviewing/mark_as_ready_spec.rb
+++ b/spec/aggregates/reviewing/mark_as_ready_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Reviewing::MarkAsReady do
     described_class.new(application_id:, user_id:)
   end
 
-  include_context 'with an existing caseworker'
+  include_context 'with an existing caseworker user'
   include_context 'with review'
   include_context 'with stubbed assignment'
 

--- a/spec/aggregates/reviewing/mark_as_ready_spec.rb
+++ b/spec/aggregates/reviewing/mark_as_ready_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Reviewing::MarkAsReady do
     described_class.new(application_id:, user_id:)
   end
 
+  include_context 'with an existing caseworker'
   include_context 'with review'
   include_context 'with stubbed assignment'
 
@@ -32,7 +33,7 @@ RSpec.describe Reviewing::MarkAsReady do
     )
   end
 
-  let(:user_id) { SecureRandom.uuid }
+  let(:user_id) { caseworker_user.id }
 
   it 'changes the state from :received to :marked_as_ready' do
     expect { command.call }.to change { review.state }

--- a/spec/aggregates/reviewing/reviewer_eligibility_spec.rb
+++ b/spec/aggregates/reviewing/reviewer_eligibility_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Reviewing::ReviewerEligibility do
+  subject(:eligibility) { described_class.new(user:, review:) }
+
+  include_context 'with an existing caseworker user'
+  include_context 'with an existing supervisor user'
+
+  let(:review) { instance_double(Reviewing::Review) }
+
+  context 'when the user is a caseworker' do
+    let(:user) { caseworker_user }
+
+    it 'allows the user to review' do
+      expect(eligibility.allowed?).to be(true)
+    end
+  end
+
+  context 'when the user is not a caseworker' do
+    let(:user) { supervisor_user }
+
+    it 'does not allow the user to review' do
+      expect(eligibility.allowed?).to be(false)
+    end
+  end
+end

--- a/spec/aggregates/reviewing/reviewer_eligibility_spec.rb
+++ b/spec/aggregates/reviewing/reviewer_eligibility_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Reviewing::ReviewerEligibility do
   context 'when the user is a supervisor' do
     let(:user) { supervisor_user }
 
-    it 'does not allow the user to review' do
-      expect(eligibility.allowed?).to be(false)
+    it 'allows the user to review' do
+      expect(eligibility.allowed?).to be(true)
     end
   end
 

--- a/spec/aggregates/reviewing/reviewer_eligibility_spec.rb
+++ b/spec/aggregates/reviewing/reviewer_eligibility_spec.rb
@@ -7,6 +7,26 @@ RSpec.describe Reviewing::ReviewerEligibility do
   include_context 'with an existing supervisor user'
 
   let(:review) { instance_double(Reviewing::Review) }
+  let(:data_analyst_user) do
+    User.create!(
+      first_name: 'Data',
+      last_name: 'Analyst',
+      email: "data-analyst-#{SecureRandom.hex(4)}@example.com",
+      auth_subject_id: SecureRandom.uuid,
+      can_manage_others: false,
+      role: UserRole::DATA_ANALYST
+    )
+  end
+  let(:auditor_user) do
+    User.create!(
+      first_name: 'Audit',
+      last_name: 'User',
+      email: "auditor-#{SecureRandom.hex(4)}@example.com",
+      auth_subject_id: SecureRandom.uuid,
+      can_manage_others: false,
+      role: UserRole::AUDITOR
+    )
+  end
 
   context 'when the user is a caseworker' do
     let(:user) { caseworker_user }
@@ -16,8 +36,24 @@ RSpec.describe Reviewing::ReviewerEligibility do
     end
   end
 
-  context 'when the user is not a caseworker' do
+  context 'when the user is a supervisor' do
     let(:user) { supervisor_user }
+
+    it 'does not allow the user to review' do
+      expect(eligibility.allowed?).to be(false)
+    end
+  end
+
+  context 'when the user is a data analyst' do
+    let(:user) { data_analyst_user }
+
+    it 'does not allow the user to review' do
+      expect(eligibility.allowed?).to be(false)
+    end
+  end
+
+  context 'when the user is an auditor' do
+    let(:user) { auditor_user }
 
     it 'does not allow the user to review' do
       expect(eligibility.allowed?).to be(false)

--- a/spec/aggregates/reviewing/send_back_spec.rb
+++ b/spec/aggregates/reviewing/send_back_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Reviewing::SendBack do
     described_class.new(application_id:, user_id:, return_details:)
   end
 
+  include_context 'with an existing caseworker'
   include_context 'with stubbed assignment'
 
   before do
@@ -31,7 +32,7 @@ RSpec.describe Reviewing::SendBack do
     )
   end
 
-  let(:user_id) { SecureRandom.uuid }
+  let(:user_id) { caseworker_user.id }
 
   let(:return_details) do
     { reason: 'evidence_issue', details: 'Detailed reason for return' }

--- a/spec/aggregates/reviewing/send_back_spec.rb
+++ b/spec/aggregates/reviewing/send_back_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Reviewing::SendBack do
     described_class.new(application_id:, user_id:, return_details:)
   end
 
-  include_context 'with an existing caseworker'
+  include_context 'with an existing caseworker user'
   include_context 'with stubbed assignment'
 
   before do

--- a/spec/controllers/casework/base_controller_spec.rb
+++ b/spec/controllers/casework/base_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Casework::BaseController, type: :controller do
+  controller(described_class) do
+    def index
+      raise Reviewing::NotAuthorisedToReview
+    end
+  end
+
+  include_context 'with an existing supervisor user'
+
+  before do
+    allow(controller).to receive_messages(authenticate_user!: true, current_user: supervisor_user,
+                                          current_user_id: supervisor_user.id)
+  end
+
+  describe 'GET #index' do
+    it 'sets the flash message and redirects to assigned applications when no crime application is loaded' do
+      get :index
+
+      expect(flash[:important]).to eq(['You must be a caseworker to review'])
+      expect(response).to redirect_to(assigned_applications_path)
+    end
+  end
+end

--- a/spec/controllers/casework/base_controller_spec.rb
+++ b/spec/controllers/casework/base_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Casework::BaseController, type: :controller do
     it 'sets the flash message and redirects to assigned applications when no crime application is loaded' do
       get :index
 
-      expect(flash[:important]).to eq(['You must be a caseworker to review'])
+      expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
       expect(response).to redirect_to(assigned_applications_path)
     end
   end

--- a/spec/controllers/casework/base_controller_spec.rb
+++ b/spec/controllers/casework/base_controller_spec.rb
@@ -7,18 +7,27 @@ RSpec.describe Casework::BaseController, type: :controller do
     end
   end
 
-  include_context 'with an existing supervisor user'
+  let(:data_analyst_user) do
+    User.create!(
+      first_name: 'Data',
+      last_name: 'Analyst',
+      email: "data-analyst-#{SecureRandom.hex(4)}@example.com",
+      auth_subject_id: SecureRandom.uuid,
+      can_manage_others: false,
+      role: UserRole::DATA_ANALYST
+    )
+  end
 
   before do
-    allow(controller).to receive_messages(authenticate_user!: true, current_user: supervisor_user,
-                                          current_user_id: supervisor_user.id)
+    allow(controller).to receive_messages(authenticate_user!: true, current_user: data_analyst_user,
+                                          current_user_id: data_analyst_user.id)
   end
 
   describe 'GET #index' do
     it 'sets the flash message and redirects to assigned applications when no crime application is loaded' do
       get :index
 
-      expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
+      expect(flash[:important]).to eq(['You must be a caseworker or supervisor to review an application'])
       expect(response).to redirect_to(assigned_applications_path)
     end
   end

--- a/spec/read_models/received_on_reports/configuration_spec.rb
+++ b/spec/read_models/received_on_reports/configuration_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ReceivedOnReports::Configuration do
-  include_context 'with an existing caseworker'
+  include_context 'with an existing caseworker user'
   include_context 'with stubbed assignment'
 
   let(:application_id) { SecureRandom.uuid }

--- a/spec/read_models/received_on_reports/configuration_spec.rb
+++ b/spec/read_models/received_on_reports/configuration_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe ReceivedOnReports::Configuration do
+  include_context 'with an existing caseworker'
   include_context 'with stubbed assignment'
 
   let(:application_id) { SecureRandom.uuid }
   let(:event_store) { Rails.configuration.event_store }
   let(:submitted_at) { Time.zone.local(2023, 7, 30) }
-  let(:user_id) { SecureRandom.uuid }
+  let(:user_id) { caseworker_user.id }
 
   describe '#configuration' do
     before do

--- a/spec/requests/casework/completes_spec.rb
+++ b/spec/requests/casework/completes_spec.rb
@@ -1,25 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe 'Completing applications' do
+  include Devise::Test::IntegrationHelpers
   include_context 'with stubbed application'
-  include_context 'with an existing supervisor user'
+
+  let(:data_analyst_user) do
+    User.create!(
+      first_name: 'Data',
+      last_name: 'Analyst',
+      email: "data-analyst-#{SecureRandom.hex(4)}@example.com",
+      auth_subject_id: SecureRandom.uuid,
+      can_manage_others: false,
+      role: UserRole::DATA_ANALYST
+    )
+  end
 
   before do
-    sign_in supervisor_user
+    sign_in data_analyst_user
   end
 
   describe 'create' do
     before do
       Assigning::AssignToUser.new(
-        assignment_id: application_id, user_id: supervisor_user.id,
-        to_whom_id: supervisor_user.id, reference: 100_123
+        assignment_id: application_id, user_id: data_analyst_user.id,
+        to_whom_id: data_analyst_user.id, reference: 100_123
       ).call
 
       post "/applications/#{application_id}/complete"
     end
 
     it 'sets the correct flash message and redirects' do
-      expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
+      expect(flash[:important]).to eq(['You must be a caseworker or supervisor to review an application'])
       expect(response).to redirect_to("/applications/#{application_id}")
     end
   end

--- a/spec/requests/casework/completes_spec.rb
+++ b/spec/requests/casework/completes_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Completing applications' do
   include_context 'with stubbed application'
-  include_context 'with a supervisor user'
+  include_context 'with an existing supervisor user'
 
   before do
     sign_in supervisor_user

--- a/spec/requests/casework/completes_spec.rb
+++ b/spec/requests/casework/completes_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Completing applications' do
     end
 
     it 'sets the correct flash message and redirects' do
-      expect(flash[:important]).to eq(['You must be a caseworker to review'])
+      expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
       expect(response).to redirect_to("/applications/#{application_id}")
     end
   end

--- a/spec/requests/casework/completes_spec.rb
+++ b/spec/requests/casework/completes_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'Completing applications' do
+  include_context 'with stubbed application'
+  include_context 'with a supervisor user'
+
+  before do
+    sign_in supervisor_user
+  end
+
+  describe 'create' do
+    before do
+      Assigning::AssignToUser.new(
+        assignment_id: application_id, user_id: supervisor_user.id,
+        to_whom_id: supervisor_user.id, reference: 100_123
+      ).call
+
+      post "/applications/#{application_id}/complete"
+    end
+
+    it 'sets the correct flash message and redirects' do
+      expect(flash[:important]).to eq(['You must be a caseworker to review'])
+      expect(response).to redirect_to("/applications/#{application_id}")
+    end
+  end
+end

--- a/spec/requests/casework/crime_applications_spec.rb
+++ b/spec/requests/casework/crime_applications_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'Crime applications' do
+  include_context 'with stubbed application'
+  include_context 'with a supervisor user'
+
+  before do
+    sign_in supervisor_user
+  end
+
+  describe 'ready' do
+    before do
+      Assigning::AssignToUser.new(
+        assignment_id: application_id, user_id: supervisor_user.id,
+        to_whom_id: supervisor_user.id, reference: 100_123
+      ).call
+
+      put "/applications/#{application_id}/ready"
+    end
+
+    it 'sets the correct flash message and redirects' do
+      expect(flash[:important]).to eq(['You must be a caseworker to review'])
+      expect(response).to redirect_to("/applications/#{application_id}")
+    end
+  end
+end

--- a/spec/requests/casework/crime_applications_spec.rb
+++ b/spec/requests/casework/crime_applications_spec.rb
@@ -1,25 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe 'Crime applications' do
+  include Devise::Test::IntegrationHelpers
   include_context 'with stubbed application'
-  include_context 'with an existing supervisor user'
+
+  let(:data_analyst_user) do
+    User.create!(
+      first_name: 'Data',
+      last_name: 'Analyst',
+      email: "data-analyst-#{SecureRandom.hex(4)}@example.com",
+      auth_subject_id: SecureRandom.uuid,
+      can_manage_others: false,
+      role: UserRole::DATA_ANALYST
+    )
+  end
 
   before do
-    sign_in supervisor_user
+    sign_in data_analyst_user
   end
 
   describe 'ready' do
     before do
       Assigning::AssignToUser.new(
-        assignment_id: application_id, user_id: supervisor_user.id,
-        to_whom_id: supervisor_user.id, reference: 100_123
+        assignment_id: application_id, user_id: data_analyst_user.id,
+        to_whom_id: data_analyst_user.id, reference: 100_123
       ).call
 
       put "/applications/#{application_id}/ready"
     end
 
     it 'sets the correct flash message and redirects' do
-      expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
+      expect(flash[:important]).to eq(['You must be a caseworker or supervisor to review an application'])
       expect(response).to redirect_to("/applications/#{application_id}")
     end
   end

--- a/spec/requests/casework/crime_applications_spec.rb
+++ b/spec/requests/casework/crime_applications_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Crime applications' do
   include_context 'with stubbed application'
-  include_context 'with a supervisor user'
+  include_context 'with an existing supervisor user'
 
   before do
     sign_in supervisor_user

--- a/spec/requests/casework/crime_applications_spec.rb
+++ b/spec/requests/casework/crime_applications_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Crime applications' do
     end
 
     it 'sets the correct flash message and redirects' do
-      expect(flash[:important]).to eq(['You must be a caseworker to review'])
+      expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
       expect(response).to redirect_to("/applications/#{application_id}")
     end
   end

--- a/spec/requests/casework/decisions_spec.rb
+++ b/spec/requests/casework/decisions_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Creating decisions' do
     end
 
     it 'sets the correct flash message and redirects' do
-      expect(flash[:important]).to eq(['You must be a caseworker to review'])
+      expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
       expect(response).to redirect_to("/applications/#{application_id}")
     end
   end

--- a/spec/requests/casework/decisions_spec.rb
+++ b/spec/requests/casework/decisions_spec.rb
@@ -1,25 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe 'Creating decisions' do
+  include Devise::Test::IntegrationHelpers
   include_context 'with stubbed application'
-  include_context 'with an existing supervisor user'
+
+  let(:data_analyst_user) do
+    User.create!(
+      first_name: 'Data',
+      last_name: 'Analyst',
+      email: "data-analyst-#{SecureRandom.hex(4)}@example.com",
+      auth_subject_id: SecureRandom.uuid,
+      can_manage_others: false,
+      role: UserRole::DATA_ANALYST
+    )
+  end
 
   before do
-    sign_in supervisor_user
+    sign_in data_analyst_user
   end
 
   describe 'create' do
     before do
       Assigning::AssignToUser.new(
-        assignment_id: application_id, user_id: supervisor_user.id,
-        to_whom_id: supervisor_user.id, reference: 100_123
+        assignment_id: application_id, user_id: data_analyst_user.id,
+        to_whom_id: data_analyst_user.id, reference: 100_123
       ).call
 
       post "/applications/#{application_id}/decisions"
     end
 
     it 'sets the correct flash message and redirects' do
-      expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
+      expect(flash[:important]).to eq(['You must be a caseworker or supervisor to review an application'])
       expect(response).to redirect_to("/applications/#{application_id}")
     end
   end

--- a/spec/requests/casework/decisions_spec.rb
+++ b/spec/requests/casework/decisions_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Creating decisions' do
   include_context 'with stubbed application'
-  include_context 'with a supervisor user'
+  include_context 'with an existing supervisor user'
 
   before do
     sign_in supervisor_user

--- a/spec/requests/casework/decisions_spec.rb
+++ b/spec/requests/casework/decisions_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'Creating decisions' do
+  include_context 'with stubbed application'
+  include_context 'with a supervisor user'
+
+  before do
+    sign_in supervisor_user
+  end
+
+  describe 'create' do
+    before do
+      Assigning::AssignToUser.new(
+        assignment_id: application_id, user_id: supervisor_user.id,
+        to_whom_id: supervisor_user.id, reference: 100_123
+      ).call
+
+      post "/applications/#{application_id}/decisions"
+    end
+
+    it 'sets the correct flash message and redirects' do
+      expect(flash[:important]).to eq(['You must be a caseworker to review'])
+      expect(response).to redirect_to("/applications/#{application_id}")
+    end
+  end
+end

--- a/spec/requests/casework/maat_decisions_spec.rb
+++ b/spec/requests/casework/maat_decisions_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'MAAT decisions' do
     end
 
     it 'sets the correct flash message and redirects' do
-      expect(flash[:important]).to eq(['You must be a caseworker to review'])
+      expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
       expect(response).to redirect_to("/applications/#{application_id}")
     end
   end
@@ -35,7 +35,7 @@ RSpec.describe 'MAAT decisions' do
     end
 
     it 'sets the correct flash message and redirects' do
-      expect(flash[:important]).to eq(['You must be a caseworker to review'])
+      expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
       expect(response).to redirect_to("/applications/#{application_id}")
     end
   end
@@ -51,7 +51,7 @@ RSpec.describe 'MAAT decisions' do
     end
 
     it 'sets the correct flash message and redirects' do
-      expect(flash[:important]).to eq(['You must be a caseworker to review'])
+      expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
       expect(response).to redirect_to("/applications/#{application_id}")
     end
   end

--- a/spec/requests/casework/maat_decisions_spec.rb
+++ b/spec/requests/casework/maat_decisions_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe 'MAAT decisions' do
+  include_context 'with stubbed application'
+  include_context 'with a supervisor user'
+
+  before do
+    sign_in supervisor_user
+  end
+
+  describe 'new' do
+    before do
+      Assigning::AssignToUser.new(
+        assignment_id: application_id, user_id: supervisor_user.id,
+        to_whom_id: supervisor_user.id, reference: 100_123
+      ).call
+
+      get "/applications/#{application_id}/link-maat-id"
+    end
+
+    it 'sets the correct flash message and redirects' do
+      expect(flash[:important]).to eq(['You must be a caseworker to review'])
+      expect(response).to redirect_to("/applications/#{application_id}")
+    end
+  end
+
+  describe 'create' do
+    before do
+      Assigning::AssignToUser.new(
+        assignment_id: application_id, user_id: supervisor_user.id,
+        to_whom_id: supervisor_user.id, reference: 100_123
+      ).call
+
+      post "/applications/#{application_id}/link-maat-id", params: { maat_id_form: { maat_id: '123456' } }
+    end
+
+    it 'sets the correct flash message and redirects' do
+      expect(flash[:important]).to eq(['You must be a caseworker to review'])
+      expect(response).to redirect_to("/applications/#{application_id}")
+    end
+  end
+
+  describe 'create_by_reference' do
+    before do
+      Assigning::AssignToUser.new(
+        assignment_id: application_id, user_id: supervisor_user.id,
+        to_whom_id: supervisor_user.id, reference: 100_123
+      ).call
+
+      post "/applications/#{application_id}/maat_decisions/create_by_reference"
+    end
+
+    it 'sets the correct flash message and redirects' do
+      expect(flash[:important]).to eq(['You must be a caseworker to review'])
+      expect(response).to redirect_to("/applications/#{application_id}")
+    end
+  end
+end

--- a/spec/requests/casework/maat_decisions_spec.rb
+++ b/spec/requests/casework/maat_decisions_spec.rb
@@ -1,25 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe 'MAAT decisions' do
+  include Devise::Test::IntegrationHelpers
   include_context 'with stubbed application'
-  include_context 'with an existing supervisor user'
+
+  let(:data_analyst_user) do
+    User.create!(
+      first_name: 'Data',
+      last_name: 'Analyst',
+      email: "data-analyst-#{SecureRandom.hex(4)}@example.com",
+      auth_subject_id: SecureRandom.uuid,
+      can_manage_others: false,
+      role: UserRole::DATA_ANALYST
+    )
+  end
 
   before do
-    sign_in supervisor_user
+    sign_in data_analyst_user
   end
 
   describe 'new' do
     before do
       Assigning::AssignToUser.new(
-        assignment_id: application_id, user_id: supervisor_user.id,
-        to_whom_id: supervisor_user.id, reference: 100_123
+        assignment_id: application_id, user_id: data_analyst_user.id,
+        to_whom_id: data_analyst_user.id, reference: 100_123
       ).call
 
       get "/applications/#{application_id}/link-maat-id"
     end
 
     it 'sets the correct flash message and redirects' do
-      expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
+      expect(flash[:important]).to eq(['You must be a caseworker or supervisor to review an application'])
       expect(response).to redirect_to("/applications/#{application_id}")
     end
   end
@@ -27,15 +38,15 @@ RSpec.describe 'MAAT decisions' do
   describe 'create' do
     before do
       Assigning::AssignToUser.new(
-        assignment_id: application_id, user_id: supervisor_user.id,
-        to_whom_id: supervisor_user.id, reference: 100_123
+        assignment_id: application_id, user_id: data_analyst_user.id,
+        to_whom_id: data_analyst_user.id, reference: 100_123
       ).call
 
       post "/applications/#{application_id}/link-maat-id", params: { maat_id_form: { maat_id: '123456' } }
     end
 
     it 'sets the correct flash message and redirects' do
-      expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
+      expect(flash[:important]).to eq(['You must be a caseworker or supervisor to review an application'])
       expect(response).to redirect_to("/applications/#{application_id}")
     end
   end
@@ -43,15 +54,15 @@ RSpec.describe 'MAAT decisions' do
   describe 'create_by_reference' do
     before do
       Assigning::AssignToUser.new(
-        assignment_id: application_id, user_id: supervisor_user.id,
-        to_whom_id: supervisor_user.id, reference: 100_123
+        assignment_id: application_id, user_id: data_analyst_user.id,
+        to_whom_id: data_analyst_user.id, reference: 100_123
       ).call
 
       post "/applications/#{application_id}/maat_decisions/create_by_reference"
     end
 
     it 'sets the correct flash message and redirects' do
-      expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
+      expect(flash[:important]).to eq(['You must be a caseworker or supervisor to review an application'])
       expect(response).to redirect_to("/applications/#{application_id}")
     end
   end

--- a/spec/requests/casework/maat_decisions_spec.rb
+++ b/spec/requests/casework/maat_decisions_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'MAAT decisions' do
   include_context 'with stubbed application'
-  include_context 'with a supervisor user'
+  include_context 'with an existing supervisor user'
 
   before do
     sign_in supervisor_user

--- a/spec/requests/casework/returns_spec.rb
+++ b/spec/requests/casework/returns_spec.rb
@@ -12,9 +12,10 @@ RSpec.describe 'Returning applications' do
       email: 'Zoe.Blogs@example.com',
       auth_subject_id: SecureRandom.uuid,
       can_manage_others: false,
-      role: UserRole::CASEWORKER
+      role: current_user_role
     )
   end
+  let(:current_user_role) { UserRole::CASEWORKER }
 
   before do
     sign_in user

--- a/spec/requests/casework/returns_spec.rb
+++ b/spec/requests/casework/returns_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Returning applications' do
       end
 
       context 'when assigned but not authorised to review' do
-        let(:current_user_role) { UserRole::SUPERVISOR }
+        let(:current_user_role) { UserRole::DATA_ANALYST }
 
         before do
           Assigning::AssignToUser.new(
@@ -54,7 +54,7 @@ RSpec.describe 'Returning applications' do
         end
 
         it 'sets the correct flash message and redirects' do
-          expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
+          expect(flash[:important]).to eq(['You must be a caseworker or supervisor to review an application'])
           expect(response).to redirect_to("/applications/#{application_id}")
         end
       end
@@ -107,7 +107,7 @@ RSpec.describe 'Returning applications' do
       end
 
       describe 'NotAuthorisedToReview' do
-        let(:current_user_role) { UserRole::SUPERVISOR }
+        let(:current_user_role) { UserRole::DATA_ANALYST }
 
         before do
           Assigning::AssignToUser.new(
@@ -119,7 +119,7 @@ RSpec.describe 'Returning applications' do
         end
 
         it 'sets the correct flash message and redirects' do
-          expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
+          expect(flash[:important]).to eq(['You must be a caseworker or supervisor to review an application'])
           expect(response).to redirect_to("/applications/#{application_id}")
         end
       end

--- a/spec/requests/casework/returns_spec.rb
+++ b/spec/requests/casework/returns_spec.rb
@@ -3,8 +3,18 @@ require 'rails_helper'
 RSpec.describe 'Returning applications' do
   include Devise::Test::IntegrationHelpers
 
-  include_context 'with an existing user'
   include_context 'with stubbed application'
+
+  let(:user) do
+    User.create!(
+      first_name: 'Zoe',
+      last_name: 'Blogs',
+      email: 'Zoe.Blogs@example.com',
+      auth_subject_id: SecureRandom.uuid,
+      can_manage_others: false,
+      role: UserRole::CASEWORKER
+    )
+  end
 
   before do
     sign_in user
@@ -14,18 +24,38 @@ RSpec.describe 'Returning applications' do
     describe 'new' do
       let(:new) { get "/applications/#{application_id}/return/new" }
 
-      before do
-        another_user_id = SecureRandom.uuid
-        Assigning::AssignToUser.new(assignment_id: application_id, user_id: another_user_id,
-                                    to_whom_id: another_user_id, reference: 100_123).call
+      context 'when application is assigned to someone else' do
+        before do
+          another_user_id = SecureRandom.uuid
+          Assigning::AssignToUser.new(assignment_id: application_id, user_id: another_user_id,
+                                      to_whom_id: another_user_id, reference: 100_123).call
 
-        new
+          new
+        end
+
+        it 'sets the correct flash message and redirects' do
+          expect(flash[:important]).to eq(['This application is assigned to someone else',
+                                           'Ask your supervisor if you need to work on it.'])
+          expect(response).to redirect_to("/applications/#{application_id}")
+        end
       end
 
-      it 'sets the correct flash message and redirects' do
-        expect(flash[:important]).to eq(['This application is assigned to someone else',
-                                         'Ask your supervisor if you need to work on it.'])
-        expect(response).to redirect_to("/applications/#{application_id}")
+      context 'when assigned but not authorised to review' do
+        let(:current_user_role) { UserRole::SUPERVISOR }
+
+        before do
+          Assigning::AssignToUser.new(
+            assignment_id: application_id, user_id: user.id,
+            to_whom_id: user.id, reference: 100_123
+          ).call
+
+          new
+        end
+
+        it 'sets the correct flash message and redirects' do
+          expect(flash[:important]).to eq(['You must be a caseworker to review'])
+          expect(response).to redirect_to("/applications/#{application_id}")
+        end
       end
     end
 
@@ -71,6 +101,24 @@ RSpec.describe 'Returning applications' do
         it 'sets the correct flash message and redirects' do
           expect(flash[:important]).to eq(['This application is assigned to someone else',
                                            'Ask your supervisor if you need to work on it.'])
+          expect(response).to redirect_to("/applications/#{application_id}")
+        end
+      end
+
+      describe 'NotAuthorisedToReview' do
+        let(:current_user_role) { UserRole::SUPERVISOR }
+
+        before do
+          Assigning::AssignToUser.new(
+            assignment_id: application_id, user_id: user.id,
+            to_whom_id: user.id, reference: 100_123
+          ).call
+
+          create
+        end
+
+        it 'sets the correct flash message and redirects' do
+          expect(flash[:important]).to eq(['You must be a caseworker to review'])
           expect(response).to redirect_to("/applications/#{application_id}")
         end
       end

--- a/spec/requests/casework/returns_spec.rb
+++ b/spec/requests/casework/returns_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Returning applications' do
         end
 
         it 'sets the correct flash message and redirects' do
-          expect(flash[:important]).to eq(['You must be a caseworker to review'])
+          expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
           expect(response).to redirect_to("/applications/#{application_id}")
         end
       end
@@ -119,7 +119,7 @@ RSpec.describe 'Returning applications' do
         end
 
         it 'sets the correct flash message and redirects' do
-          expect(flash[:important]).to eq(['You must be a caseworker to review'])
+          expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
           expect(response).to redirect_to("/applications/#{application_id}")
         end
       end

--- a/spec/requests/casework/send_decisions_spec.rb
+++ b/spec/requests/casework/send_decisions_spec.rb
@@ -12,9 +12,10 @@ RSpec.describe 'Sending application decisions' do
       email: 'Zoe.Blogs@example.com',
       auth_subject_id: SecureRandom.uuid,
       can_manage_others: false,
-      role: UserRole::CASEWORKER
+      role: current_user_role
     )
   end
+  let(:current_user_role) { UserRole::CASEWORKER }
 
   before do
     sign_in user

--- a/spec/requests/casework/send_decisions_spec.rb
+++ b/spec/requests/casework/send_decisions_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Sending application decisions' do
         end
 
         it 'sets the correct flash message and redirects' do
-          expect(flash[:important]).to eq(['You must be a caseworker to review'])
+          expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
           expect(response).to redirect_to("/applications/#{application_id}")
         end
       end

--- a/spec/requests/casework/send_decisions_spec.rb
+++ b/spec/requests/casework/send_decisions_spec.rb
@@ -3,8 +3,18 @@ require 'rails_helper'
 RSpec.describe 'Sending application decisions' do
   include Devise::Test::IntegrationHelpers
 
-  include_context 'with an existing user'
   include_context 'with stubbed application'
+
+  let(:user) do
+    User.create!(
+      first_name: 'Zoe',
+      last_name: 'Blogs',
+      email: 'Zoe.Blogs@example.com',
+      auth_subject_id: SecureRandom.uuid,
+      can_manage_others: false,
+      role: UserRole::CASEWORKER
+    )
+  end
 
   before do
     sign_in user
@@ -38,6 +48,24 @@ RSpec.describe 'Sending application decisions' do
         it 'sets the correct flash message and redirects' do
           expect(flash[:important]).to eq(['This application is assigned to someone else',
                                            'Ask your supervisor if you need to work on it.'])
+          expect(response).to redirect_to("/applications/#{application_id}")
+        end
+      end
+
+      describe 'NotAuthorisedToReview' do
+        let(:current_user_role) { UserRole::SUPERVISOR }
+
+        before do
+          Assigning::AssignToUser.new(
+            assignment_id: application_id, user_id: user.id,
+            to_whom_id: user.id, reference: 1_234_567
+          ).call
+
+          create
+        end
+
+        it 'sets the correct flash message and redirects' do
+          expect(flash[:important]).to eq(['You must be a caseworker to review'])
           expect(response).to redirect_to("/applications/#{application_id}")
         end
       end

--- a/spec/requests/casework/send_decisions_spec.rb
+++ b/spec/requests/casework/send_decisions_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Sending application decisions' do
       end
 
       describe 'NotAuthorisedToReview' do
-        let(:current_user_role) { UserRole::SUPERVISOR }
+        let(:current_user_role) { UserRole::DATA_ANALYST }
 
         before do
           Assigning::AssignToUser.new(
@@ -66,7 +66,7 @@ RSpec.describe 'Sending application decisions' do
         end
 
         it 'sets the correct flash message and redirects' do
-          expect(flash[:important]).to eq(['You must be a caseworker to review an application'])
+          expect(flash[:important]).to eq(['You must be a caseworker or supervisor to review an application'])
           expect(response).to redirect_to("/applications/#{application_id}")
         end
       end

--- a/spec/shared_contexts/with_a_signed_in_supervisor_user.rb
+++ b/spec/shared_contexts/with_a_signed_in_supervisor_user.rb
@@ -1,0 +1,14 @@
+RSpec.shared_context 'with a supervisor user', shared_context: :metadata do
+  include Devise::Test::IntegrationHelpers
+
+  let(:supervisor_user) do
+    User.create!(
+      first_name: 'Zoe',
+      last_name: 'Blogs',
+      email: "supervisor-#{SecureRandom.hex(4)}@example.com",
+      auth_subject_id: SecureRandom.uuid,
+      can_manage_others: false,
+      role: UserRole::SUPERVISOR
+    )
+  end
+end

--- a/spec/shared_contexts/with_an_existing_caseworker.rb
+++ b/spec/shared_contexts/with_an_existing_caseworker.rb
@@ -1,0 +1,14 @@
+RSpec.shared_context 'with an existing caseworker', shared_context: :metadata do
+  let(:caseworker_user) do
+    User.create!(
+      first_name: 'Case',
+      last_name: 'Worker',
+      email: "caseworker-#{SecureRandom.hex(4)}@example.com",
+      auth_subject_id: SecureRandom.uuid,
+      can_manage_others: false,
+      first_auth_at: 4.days.ago,
+      last_auth_at: 4.days.ago,
+      role: UserRole::CASEWORKER
+    )
+  end
+end

--- a/spec/shared_contexts/with_an_existing_caseworker_user.rb
+++ b/spec/shared_contexts/with_an_existing_caseworker_user.rb
@@ -1,4 +1,4 @@
-RSpec.shared_context 'with an existing caseworker', shared_context: :metadata do
+RSpec.shared_context 'with an existing caseworker user', shared_context: :metadata do
   let(:caseworker_user) do
     User.create!(
       first_name: 'Case',

--- a/spec/shared_contexts/with_an_existing_supervisor_user.rb
+++ b/spec/shared_contexts/with_an_existing_supervisor_user.rb
@@ -1,4 +1,4 @@
-RSpec.shared_context 'with a supervisor user', shared_context: :metadata do
+RSpec.shared_context 'with an existing supervisor user', shared_context: :metadata do
   include Devise::Test::IntegrationHelpers
 
   let(:supervisor_user) do

--- a/spec/system/casework/deciding/adding_a_cifc_decision_spec.rb
+++ b/spec/system/casework/deciding/adding_a_cifc_decision_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Adding a CIFC decision by MAAT ID' do
     end
 
     context 'when the MAAT ID is linked to a different application on review' do # rubocop:disable RSpec/MultipleMemoizedHelpers
-      include_context 'with an existing caseworker'
+      include_context 'with an existing caseworker user'
       let(:user_id) { caseworker_user.id }
 
       before do

--- a/spec/system/casework/deciding/adding_a_cifc_decision_spec.rb
+++ b/spec/system/casework/deciding/adding_a_cifc_decision_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe 'Adding a CIFC decision by MAAT ID' do
     end
 
     context 'when the MAAT ID is linked to a different application on review' do # rubocop:disable RSpec/MultipleMemoizedHelpers
-      let(:user_id) { SecureRandom.uuid }
+      include_context 'with an existing caseworker'
+      let(:user_id) { caseworker_user.id }
 
       before do
         with_assignment(user_id: user_id, assignment_id: original_application.id) do

--- a/spec/system/casework/deciding/adding_a_nafi_decision_spec.rb
+++ b/spec/system/casework/deciding/adding_a_nafi_decision_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Adding a NAFI decision' do
   include AssignmentHelpers
 
-  include_context 'with an existing caseworker'
+  include_context 'with an existing caseworker user'
   include_context 'with stubbed application'
   include_context 'when adding a decision by MAAT ID'
 

--- a/spec/system/casework/deciding/adding_a_nafi_decision_spec.rb
+++ b/spec/system/casework/deciding/adding_a_nafi_decision_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Adding a NAFI decision' do
   include AssignmentHelpers
 
+  include_context 'with an existing caseworker'
   include_context 'with stubbed application'
   include_context 'when adding a decision by MAAT ID'
 
@@ -56,7 +57,7 @@ RSpec.describe 'Adding a NAFI decision' do
   end
 
   context 'when the MAAT ID is linked to a different draft application on review' do
-    let(:user_id) { SecureRandom.uuid }
+    let(:user_id) { caseworker_user.id }
     let(:application_id) { original_application.id }
 
     before do
@@ -78,7 +79,7 @@ RSpec.describe 'Adding a NAFI decision' do
   end
 
   context 'when the MAAT ID is linked to a different sent application on review' do
-    let(:user_id) { SecureRandom.uuid }
+    let(:user_id) { caseworker_user.id }
     let(:application_id) { original_application.id }
 
     before do

--- a/spec/system/casework/deciding/adding_a_non_means_decision_spec.rb
+++ b/spec/system/casework/deciding/adding_a_non_means_decision_spec.rb
@@ -2,8 +2,14 @@ require 'rails_helper'
 
 RSpec.describe 'Adding a Non-means application' do
   include DecisionFormHelpers
+  let(:current_user_role) { UserRole::CASEWORKER }
 
   # rubocop:disable RSpec/ExampleLength
+  shared_examples 'hides "Start" button' do
+    it 'does not show the "Start" button' do
+      expect(page).to have_no_button('Start')
+    end
+  end
 
   include_context 'with stubbed application' do
     let(:application_data) do
@@ -21,6 +27,10 @@ RSpec.describe 'Adding a Non-means application' do
     it 'informs that a manual decision is required' do
       expect(page).to have_selector 'h2', text: 'Funding decision'
       expect(page).to have_selector 'p', text: 'You need to manually enter a decision for this application.'
+    end
+
+    it 'shows the "Start" button' do
+      expect(page).to have_button('Start')
     end
 
     it 'validates the interests of justice form' do
@@ -57,6 +67,31 @@ RSpec.describe 'Adding a Non-means application' do
         'Overall result', 'Granted',
         'Comments', 'Caseworker comment'
       )
+    end
+
+  end
+
+  context 'when viewing the application as a non-caseworker' do
+    before do
+      visit crime_application_path(application_id)
+    end
+
+    context 'as a supervisor' do
+      let(:current_user_role) { UserRole::SUPERVISOR }
+
+      include_examples 'hides "Start" button'
+    end
+
+    context 'as a data analyst' do
+      let(:current_user_role) { UserRole::DATA_ANALYST }
+
+      include_examples 'hides "Start" button'
+    end
+
+    context 'as an auditor' do
+      let(:current_user_role) { UserRole::AUDITOR }
+
+      include_examples 'hides "Start" button'
     end
   end
 

--- a/spec/system/casework/deciding/adding_a_non_means_decision_spec.rb
+++ b/spec/system/casework/deciding/adding_a_non_means_decision_spec.rb
@@ -71,15 +71,9 @@ RSpec.describe 'Adding a Non-means application' do
     end
   end
 
-  context 'when viewing the application as a non-caseworker' do
+  context 'when viewing the application as a non-reviewer' do
     before do
       visit crime_application_path(application_id)
-    end
-
-    context 'when a supervisor' do
-      let(:current_user_role) { UserRole::SUPERVISOR }
-
-      include_examples 'hides "Start" button'
     end
 
     context 'when a data analyst' do

--- a/spec/system/casework/deciding/adding_a_non_means_decision_spec.rb
+++ b/spec/system/casework/deciding/adding_a_non_means_decision_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Adding a Non-means application' do
   include DecisionFormHelpers
+
   let(:current_user_role) { UserRole::CASEWORKER }
 
   # rubocop:disable RSpec/ExampleLength
@@ -68,7 +69,6 @@ RSpec.describe 'Adding a Non-means application' do
         'Comments', 'Caseworker comment'
       )
     end
-
   end
 
   context 'when viewing the application as a non-caseworker' do
@@ -76,19 +76,19 @@ RSpec.describe 'Adding a Non-means application' do
       visit crime_application_path(application_id)
     end
 
-    context 'as a supervisor' do
+    context 'when a supervisor' do
       let(:current_user_role) { UserRole::SUPERVISOR }
 
       include_examples 'hides "Start" button'
     end
 
-    context 'as a data analyst' do
+    context 'when a data analyst' do
       let(:current_user_role) { UserRole::DATA_ANALYST }
 
       include_examples 'hides "Start" button'
     end
 
-    context 'as an auditor' do
+    context 'when an auditor' do
       let(:current_user_role) { UserRole::AUDITOR }
 
       include_examples 'hides "Start" button'

--- a/spec/system/casework/reviewing/a_pse_application_spec.rb
+++ b/spec/system/casework/reviewing/a_pse_application_spec.rb
@@ -7,7 +7,15 @@ RSpec.describe 'Reviewing a PSE application' do
   let(:application_data) { JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'post_submission_evidence').read) }
   let(:complete_cta) { 'Mark as completed' }
 
+  shared_examples 'hides "Mark as completed" button' do
+    it 'the "Mark as completed" button is not visible' do
+      expect(page).to have_no_button(complete_cta)
+    end
+  end
+
   context 'when assigned to the application' do
+    let(:current_user_role) { UserRole::CASEWORKER }
+
     before do
       allow(DatastoreApi::Requests::UpdateApplication).to receive(:new).and_return(
         instance_double(DatastoreApi::Requests::UpdateApplication, call: {})
@@ -21,6 +29,10 @@ RSpec.describe 'Reviewing a PSE application' do
       expect(page).not_to have_button('Send back to provider')
       click_button 'Mark as completed'
       expect(page).to have_content('You marked the application as complete')
+    end
+
+    it 'shows the "Mark as completed" button' do
+      expect(page).to have_button(complete_cta)
     end
 
     it 'removes the application from "Your list"' do
@@ -62,14 +74,42 @@ RSpec.describe 'Reviewing a PSE application' do
     end
   end
 
+  context 'when viewing the application as a supervisor' do
+    let(:current_user_role) { UserRole::SUPERVISOR }
+
+    before do
+      visit crime_application_path(application_id)
+    end
+
+    include_examples 'hides "Mark as completed" button'
+  end
+
+  context 'when viewing the application as a data analyst' do
+    let(:current_user_role) { UserRole::DATA_ANALYST }
+
+    before do
+      visit crime_application_path(application_id)
+    end
+
+    include_examples 'hides "Mark as completed" button'
+  end
+
+  context 'when viewing the application as an auditor' do
+    let(:current_user_role) { UserRole::AUDITOR }
+
+    before do
+      visit crime_application_path(application_id)
+    end
+
+    include_examples 'hides "Mark as completed" button'
+  end
+
   context 'when not assigned to the application' do
     before do
       visit crime_application_path(application_id)
     end
 
-    it 'the "Mark as completed" button is not visible' do
-      expect(page).to have_no_button(complete_cta)
-    end
+    include_examples 'hides "Mark as completed" button'
   end
 
   context 'when reassigned while the page is already loaded' do

--- a/spec/system/casework/reviewing/a_pse_application_spec.rb
+++ b/spec/system/casework/reviewing/a_pse_application_spec.rb
@@ -74,15 +74,9 @@ RSpec.describe 'Reviewing a PSE application' do
     end
   end
 
-  context 'when viewing the application as a non-caseworker' do
+  context 'when viewing the application as a non-reviewer' do
     before do
       visit crime_application_path(application_id)
-    end
-
-    context 'when a supervisor' do
-      let(:current_user_role) { UserRole::SUPERVISOR }
-
-      include_examples 'hides "Mark as completed" button'
     end
 
     context 'when a data analyst' do
@@ -95,6 +89,32 @@ RSpec.describe 'Reviewing a PSE application' do
       let(:current_user_role) { UserRole::AUDITOR }
 
       include_examples 'hides "Mark as completed" button'
+    end
+  end
+
+  context 'when a supervisor is assigned to the application' do
+    let(:current_user_role) { UserRole::SUPERVISOR }
+
+    before do
+      allow(DatastoreApi::Requests::UpdateApplication).to receive(:new).and_return(
+        instance_double(DatastoreApi::Requests::UpdateApplication, call: {})
+      )
+
+      Assigning::AssignToUser.new(
+        assignment_id: application_id, user_id: current_user_id,
+        to_whom_id: current_user_id, reference: 100_123
+      ).call
+
+      visit crime_application_path(application_id)
+    end
+
+    it 'shows the "Mark as completed" button' do
+      expect(page).to have_button(complete_cta)
+    end
+
+    it 'can be completed by the supervisor' do
+      click_button 'Mark as completed'
+      expect(page).to have_content('You marked the application as complete')
     end
   end
 

--- a/spec/system/casework/reviewing/a_pse_application_spec.rb
+++ b/spec/system/casework/reviewing/a_pse_application_spec.rb
@@ -92,32 +92,6 @@ RSpec.describe 'Reviewing a PSE application' do
     end
   end
 
-  context 'when a supervisor is assigned to the application' do
-    let(:current_user_role) { UserRole::SUPERVISOR }
-
-    before do
-      allow(DatastoreApi::Requests::UpdateApplication).to receive(:new).and_return(
-        instance_double(DatastoreApi::Requests::UpdateApplication, call: {})
-      )
-
-      Assigning::AssignToUser.new(
-        assignment_id: application_id, user_id: current_user_id,
-        to_whom_id: current_user_id, reference: 100_123
-      ).call
-
-      visit crime_application_path(application_id)
-    end
-
-    it 'shows the "Mark as completed" button' do
-      expect(page).to have_button(complete_cta)
-    end
-
-    it 'can be completed by the supervisor' do
-      click_button 'Mark as completed'
-      expect(page).to have_content('You marked the application as complete')
-    end
-  end
-
   context 'when not assigned to the application' do
     before do
       visit crime_application_path(application_id)

--- a/spec/system/casework/reviewing/a_pse_application_spec.rb
+++ b/spec/system/casework/reviewing/a_pse_application_spec.rb
@@ -74,34 +74,28 @@ RSpec.describe 'Reviewing a PSE application' do
     end
   end
 
-  context 'when viewing the application as a supervisor' do
-    let(:current_user_role) { UserRole::SUPERVISOR }
-
+  context 'when viewing the application as a non-caseworker' do
     before do
       visit crime_application_path(application_id)
     end
 
-    include_examples 'hides "Mark as completed" button'
-  end
+    context 'as a supervisor' do
+      let(:current_user_role) { UserRole::SUPERVISOR }
 
-  context 'when viewing the application as a data analyst' do
-    let(:current_user_role) { UserRole::DATA_ANALYST }
-
-    before do
-      visit crime_application_path(application_id)
+      include_examples 'hides "Mark as completed" button'
     end
 
-    include_examples 'hides "Mark as completed" button'
-  end
+    context 'as a data analyst' do
+      let(:current_user_role) { UserRole::DATA_ANALYST }
 
-  context 'when viewing the application as an auditor' do
-    let(:current_user_role) { UserRole::AUDITOR }
-
-    before do
-      visit crime_application_path(application_id)
+      include_examples 'hides "Mark as completed" button'
     end
 
-    include_examples 'hides "Mark as completed" button'
+    context 'as an auditor' do
+      let(:current_user_role) { UserRole::AUDITOR }
+
+      include_examples 'hides "Mark as completed" button'
+    end
   end
 
   context 'when not assigned to the application' do

--- a/spec/system/casework/reviewing/a_pse_application_spec.rb
+++ b/spec/system/casework/reviewing/a_pse_application_spec.rb
@@ -79,19 +79,19 @@ RSpec.describe 'Reviewing a PSE application' do
       visit crime_application_path(application_id)
     end
 
-    context 'as a supervisor' do
+    context 'when a supervisor' do
       let(:current_user_role) { UserRole::SUPERVISOR }
 
       include_examples 'hides "Mark as completed" button'
     end
 
-    context 'as a data analyst' do
+    context 'when a data analyst' do
       let(:current_user_role) { UserRole::DATA_ANALYST }
 
       include_examples 'hides "Mark as completed" button'
     end
 
-    context 'as an auditor' do
+    context 'when an auditor' do
       let(:current_user_role) { UserRole::AUDITOR }
 
       include_examples 'hides "Mark as completed" button'

--- a/spec/system/casework/reviewing/mark_application_as_ready_spec.rb
+++ b/spec/system/casework/reviewing/mark_application_as_ready_spec.rb
@@ -3,7 +3,14 @@ require 'rails_helper'
 RSpec.describe 'Marking an application as ready for assessment' do
   include_context 'with an existing application'
 
+  let(:current_user_role) { UserRole::CASEWORKER }
   let(:ready_for_assessment_cta) { 'Mark as ready for MAAT' }
+
+  shared_examples 'hides "Mark as ready for MAAT" button' do
+    it 'the "Mark as ready for MAAT" button is not visible' do
+      expect(page).to have_no_button(ready_for_assessment_cta)
+    end
+  end
 
   context 'when assigned to the application' do
     before do
@@ -58,6 +65,36 @@ RSpec.describe 'Marking an application as ready for assessment' do
     end
   end
 
+  context 'when viewing the application as a supervisor' do
+    let(:current_user_role) { UserRole::SUPERVISOR }
+
+    before do
+      visit crime_application_path(crime_application_id)
+    end
+
+    include_examples 'hides "Mark as ready for MAAT" button'
+  end
+
+  context 'when viewing the application as a data analyst' do
+    let(:current_user_role) { UserRole::DATA_ANALYST }
+
+    before do
+      visit crime_application_path(crime_application_id)
+    end
+
+    include_examples 'hides "Mark as ready for MAAT" button'
+  end
+
+  context 'when viewing the application as an auditor' do
+    let(:current_user_role) { UserRole::AUDITOR }
+
+    before do
+      visit crime_application_path(crime_application_id)
+    end
+
+    include_examples 'hides "Mark as ready for MAAT" button'
+  end
+
   context 'when marked as ready in the datastore but not on Review' do
     before do
       click_on 'Kit Pound'
@@ -102,9 +139,7 @@ RSpec.describe 'Marking an application as ready for assessment' do
       click_on('Kit Pound')
     end
 
-    it 'the "Ready for assessment" button is not visible' do
-      expect(page).to have_no_button(ready_for_assessment_cta)
-    end
+    include_examples 'hides "Mark as ready for MAAT" button'
   end
 
   context 'when reassigned while the page is already loaded' do

--- a/spec/system/casework/reviewing/mark_application_as_ready_spec.rb
+++ b/spec/system/casework/reviewing/mark_application_as_ready_spec.rb
@@ -65,34 +65,28 @@ RSpec.describe 'Marking an application as ready for assessment' do
     end
   end
 
-  context 'when viewing the application as a supervisor' do
-    let(:current_user_role) { UserRole::SUPERVISOR }
-
+  context 'when viewing the application as a non-caseworker' do
     before do
       visit crime_application_path(crime_application_id)
     end
 
-    include_examples 'hides "Mark as ready for MAAT" button'
-  end
+    context 'as a supervisor' do
+      let(:current_user_role) { UserRole::SUPERVISOR }
 
-  context 'when viewing the application as a data analyst' do
-    let(:current_user_role) { UserRole::DATA_ANALYST }
-
-    before do
-      visit crime_application_path(crime_application_id)
+      include_examples 'hides "Mark as ready for MAAT" button'
     end
 
-    include_examples 'hides "Mark as ready for MAAT" button'
-  end
+    context 'as a data analyst' do
+      let(:current_user_role) { UserRole::DATA_ANALYST }
 
-  context 'when viewing the application as an auditor' do
-    let(:current_user_role) { UserRole::AUDITOR }
-
-    before do
-      visit crime_application_path(crime_application_id)
+      include_examples 'hides "Mark as ready for MAAT" button'
     end
 
-    include_examples 'hides "Mark as ready for MAAT" button'
+    context 'as an auditor' do
+      let(:current_user_role) { UserRole::AUDITOR }
+
+      include_examples 'hides "Mark as ready for MAAT" button'
+    end
   end
 
   context 'when marked as ready in the datastore but not on Review' do

--- a/spec/system/casework/reviewing/mark_application_as_ready_spec.rb
+++ b/spec/system/casework/reviewing/mark_application_as_ready_spec.rb
@@ -70,19 +70,19 @@ RSpec.describe 'Marking an application as ready for assessment' do
       visit crime_application_path(crime_application_id)
     end
 
-    context 'as a supervisor' do
+    context 'when a supervisor' do
       let(:current_user_role) { UserRole::SUPERVISOR }
 
       include_examples 'hides "Mark as ready for MAAT" button'
     end
 
-    context 'as a data analyst' do
+    context 'when a data analyst' do
       let(:current_user_role) { UserRole::DATA_ANALYST }
 
       include_examples 'hides "Mark as ready for MAAT" button'
     end
 
-    context 'as an auditor' do
+    context 'when an auditor' do
       let(:current_user_role) { UserRole::AUDITOR }
 
       include_examples 'hides "Mark as ready for MAAT" button'

--- a/spec/system/casework/reviewing/mark_application_as_ready_spec.rb
+++ b/spec/system/casework/reviewing/mark_application_as_ready_spec.rb
@@ -65,15 +65,9 @@ RSpec.describe 'Marking an application as ready for assessment' do
     end
   end
 
-  context 'when viewing the application as a non-caseworker' do
+  context 'when viewing the application as a non-reviewer' do
     before do
       visit crime_application_path(crime_application_id)
-    end
-
-    context 'when a supervisor' do
-      let(:current_user_role) { UserRole::SUPERVISOR }
-
-      include_examples 'hides "Mark as ready for MAAT" button'
     end
 
     context 'when a data analyst' do
@@ -134,6 +128,31 @@ RSpec.describe 'Marking an application as ready for assessment' do
     end
 
     include_examples 'hides "Mark as ready for MAAT" button'
+  end
+
+  context 'when a supervisor is assigned to the application' do
+    let(:current_user_role) { UserRole::SUPERVISOR }
+
+    before do
+      allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
+        .and_return(instance_double(DatastoreApi::Requests::UpdateApplication, call: {}))
+
+      Assigning::AssignToUser.new(
+        assignment_id: crime_application_id, user_id: current_user_id,
+        to_whom_id: current_user_id, reference: 100_123
+      ).call
+
+      visit crime_application_path(crime_application_id)
+    end
+
+    it 'shows the "Mark as ready for MAAT" button' do
+      expect(page).to have_button(ready_for_assessment_cta)
+    end
+
+    it 'can mark the application as ready' do
+      click_button(ready_for_assessment_cta)
+      expect(page).to have_content('Application ready for assessment in MAAT.')
+    end
   end
 
   context 'when reassigned while the page is already loaded' do

--- a/spec/system/casework/reviewing/mark_application_as_ready_spec.rb
+++ b/spec/system/casework/reviewing/mark_application_as_ready_spec.rb
@@ -130,31 +130,6 @@ RSpec.describe 'Marking an application as ready for assessment' do
     include_examples 'hides "Mark as ready for MAAT" button'
   end
 
-  context 'when a supervisor is assigned to the application' do
-    let(:current_user_role) { UserRole::SUPERVISOR }
-
-    before do
-      allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
-        .and_return(instance_double(DatastoreApi::Requests::UpdateApplication, call: {}))
-
-      Assigning::AssignToUser.new(
-        assignment_id: crime_application_id, user_id: current_user_id,
-        to_whom_id: current_user_id, reference: 100_123
-      ).call
-
-      visit crime_application_path(crime_application_id)
-    end
-
-    it 'shows the "Mark as ready for MAAT" button' do
-      expect(page).to have_button(ready_for_assessment_cta)
-    end
-
-    it 'can mark the application as ready' do
-      click_button(ready_for_assessment_cta)
-      expect(page).to have_content('Application ready for assessment in MAAT.')
-    end
-  end
-
   context 'when reassigned while the page is already loaded' do
     before do
       allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)

--- a/spec/system/casework/reviewing/send_back_to_provider_spec.rb
+++ b/spec/system/casework/reviewing/send_back_to_provider_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe 'Send an application back to the provider' do
 
   let(:send_back_cta) { 'Send back to provider' }
 
+  shared_examples 'hides "Send back to provider" button' do
+    it 'the "Send back to provider" button is not visible' do
+      expect(page).to have_no_button(send_back_cta)
+    end
+  end
+
   context 'when assigned to the application' do
     before do
       click_on 'Kit Pound'
@@ -155,6 +161,36 @@ RSpec.describe 'Send an application back to the provider' do
     end
   end
 
+  context 'when viewing the application as a supervisor' do
+    let(:current_user_role) { UserRole::SUPERVISOR }
+
+    before do
+      visit crime_application_path(crime_application_id)
+    end
+
+    include_examples 'hides "Send back to provider" button'
+  end
+
+  context 'when viewing the application as a data analyst' do
+    let(:current_user_role) { UserRole::DATA_ANALYST }
+
+    before do
+      visit crime_application_path(crime_application_id)
+    end
+
+    include_examples 'hides "Send back to provider" button'
+  end
+
+  context 'when viewing the application as an auditor' do
+    let(:current_user_role) { UserRole::AUDITOR }
+
+    before do
+      visit crime_application_path(crime_application_id)
+    end
+
+    include_examples 'hides "Send back to provider" button'
+  end
+
   context 'when not assigned to the application' do
     let(:assignee_id) do
       User.create(first_name: 'A', last_name: 'Caseworder').id
@@ -165,8 +201,6 @@ RSpec.describe 'Send an application back to the provider' do
       click_on('Kit Pound')
     end
 
-    it 'the "Send back to provider" button is not visible' do
-      expect(page).to have_no_button(send_back_cta)
-    end
+    include_examples 'hides "Send back to provider" button'
   end
 end

--- a/spec/system/casework/reviewing/send_back_to_provider_spec.rb
+++ b/spec/system/casework/reviewing/send_back_to_provider_spec.rb
@@ -166,19 +166,19 @@ RSpec.describe 'Send an application back to the provider' do
       visit crime_application_path(crime_application_id)
     end
 
-    context 'as a supervisor' do
+    context 'when a supervisor' do
       let(:current_user_role) { UserRole::SUPERVISOR }
 
       include_examples 'hides "Send back to provider" button'
     end
 
-    context 'as a data analyst' do
+    context 'when a data analyst' do
       let(:current_user_role) { UserRole::DATA_ANALYST }
 
       include_examples 'hides "Send back to provider" button'
     end
 
-    context 'as an auditor' do
+    context 'when an auditor' do
       let(:current_user_role) { UserRole::AUDITOR }
 
       include_examples 'hides "Send back to provider" button'

--- a/spec/system/casework/reviewing/send_back_to_provider_spec.rb
+++ b/spec/system/casework/reviewing/send_back_to_provider_spec.rb
@@ -161,39 +161,33 @@ RSpec.describe 'Send an application back to the provider' do
     end
   end
 
-  context 'when viewing the application as a supervisor' do
-    let(:current_user_role) { UserRole::SUPERVISOR }
-
+  context 'when viewing the application as a non-caseworker' do
     before do
       visit crime_application_path(crime_application_id)
     end
 
-    include_examples 'hides "Send back to provider" button'
-  end
+    context 'as a supervisor' do
+      let(:current_user_role) { UserRole::SUPERVISOR }
 
-  context 'when viewing the application as a data analyst' do
-    let(:current_user_role) { UserRole::DATA_ANALYST }
-
-    before do
-      visit crime_application_path(crime_application_id)
+      include_examples 'hides "Send back to provider" button'
     end
 
-    include_examples 'hides "Send back to provider" button'
-  end
+    context 'as a data analyst' do
+      let(:current_user_role) { UserRole::DATA_ANALYST }
 
-  context 'when viewing the application as an auditor' do
-    let(:current_user_role) { UserRole::AUDITOR }
-
-    before do
-      visit crime_application_path(crime_application_id)
+      include_examples 'hides "Send back to provider" button'
     end
 
-    include_examples 'hides "Send back to provider" button'
+    context 'as an auditor' do
+      let(:current_user_role) { UserRole::AUDITOR }
+
+      include_examples 'hides "Send back to provider" button'
+    end
   end
 
   context 'when not assigned to the application' do
     let(:assignee_id) do
-      User.create(first_name: 'A', last_name: 'Caseworder').id
+      User.create(first_name: 'A', last_name: 'Caseworker').id
     end
 
     before do

--- a/spec/system/casework/reviewing/send_back_to_provider_spec.rb
+++ b/spec/system/casework/reviewing/send_back_to_provider_spec.rb
@@ -179,26 +179,6 @@ RSpec.describe 'Send an application back to the provider' do
     end
   end
 
-  context 'when a supervisor is assigned to the application' do
-    let(:current_user_role) { UserRole::SUPERVISOR }
-
-    before do
-      allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
-        .and_return(instance_double(DatastoreApi::Requests::UpdateApplication, call: {}))
-
-      Assigning::AssignToUser.new(
-        assignment_id: crime_application_id, user_id: current_user_id,
-        to_whom_id: current_user_id, reference: 100_123
-      ).call
-
-      visit crime_application_path(crime_application_id)
-    end
-
-    it 'the "Send back to provider" button is visible' do
-      expect(page).to have_link(send_back_cta)
-    end
-  end
-
   context 'when not assigned to the application' do
     let(:assignee_id) do
       User.create(first_name: 'A', last_name: 'Caseworker').id

--- a/spec/system/casework/reviewing/send_back_to_provider_spec.rb
+++ b/spec/system/casework/reviewing/send_back_to_provider_spec.rb
@@ -161,15 +161,9 @@ RSpec.describe 'Send an application back to the provider' do
     end
   end
 
-  context 'when viewing the application as a non-caseworker' do
+  context 'when viewing the application as a non-reviewer' do
     before do
       visit crime_application_path(crime_application_id)
-    end
-
-    context 'when a supervisor' do
-      let(:current_user_role) { UserRole::SUPERVISOR }
-
-      include_examples 'hides "Send back to provider" button'
     end
 
     context 'when a data analyst' do
@@ -182,6 +176,26 @@ RSpec.describe 'Send an application back to the provider' do
       let(:current_user_role) { UserRole::AUDITOR }
 
       include_examples 'hides "Send back to provider" button'
+    end
+  end
+
+  context 'when a supervisor is assigned to the application' do
+    let(:current_user_role) { UserRole::SUPERVISOR }
+
+    before do
+      allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
+        .and_return(instance_double(DatastoreApi::Requests::UpdateApplication, call: {}))
+
+      Assigning::AssignToUser.new(
+        assignment_id: crime_application_id, user_id: current_user_id,
+        to_whom_id: current_user_id, reference: 100_123
+      ).call
+
+      visit crime_application_path(crime_application_id)
+    end
+
+    it 'the "Send back to provider" button is visible' do
+      expect(page).to have_link(send_back_cta)
     end
   end
 


### PR DESCRIPTION
## Description of change

- When a non reviewer has a previously assigned application, the reviewing actions are still visible, found during QA https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMAPP/boards/1375?assignee=712020%3A3d805bbe-8fa6-48b0-b8bd-f2d3612405d6&selectedIssue=CRIMAPP-2042. The buttons are now removed.
- Added policy to the reviewing action to prevent reviewing action, now only caseworkers and supervisors can review applications

## Link to relevant ticket
https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMAPP/boards/1375?assignee=712020%3A3d805bbe-8fa6-48b0-b8bd-f2d3612405d6&selectedIssue=CRIMAPP-2168

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:
<img width="768" height="536" alt="Screenshot 2026-03-25 at 13 57 12" src="https://github.com/user-attachments/assets/0fd7c4a6-c699-4ea4-8d32-aba17b02c4c4" />

## How to manually test the feature