### PR TITLE
Revert govuk-frontend to 5.11.2 and ministryofjustice/frontend to 8.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@hotwired/turbo-rails": "^8.0.23",
-    "@ministryofjustice/frontend": "^9.0.0",
+    "@ministryofjustice/frontend": "^8.0.0",
     "govuk-frontend": "^5.14.0",
     "sass": "^1.97.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,13 +220,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ministryofjustice/frontend@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@ministryofjustice/frontend@npm:9.0.0"
+"@ministryofjustice/frontend@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "@ministryofjustice/frontend@npm:8.0.1"
   peerDependencies:
-    govuk-frontend: ^6.0.0
+    govuk-frontend: ^5.11.2
     moment: 2.30.1
-  checksum: 10c0/6b08112f34a564c516692ae14de2422decefdc6b26963b3922c47442a3a3ee18b8e034c3f3bedc15b881e017b0a3e8465ace50aa7526a5a90d4d56adf1e623f5
+  checksum: 10c0/9754d558e3271aa3ef1ff1493d4d165eb6eeadc361f420f15c4b8591ab96c5e50b68ebb16adb66c378c721333aed45b1ade07018d2c71b808f581e92230a4137
   languageName: node
   linkType: hard
 
@@ -774,7 +774,7 @@ __metadata:
   resolution: "laa-review-criminal-legal-aid@workspace:."
   dependencies:
     "@hotwired/turbo-rails": "npm:^8.0.23"
-    "@ministryofjustice/frontend": "npm:^9.0.0"
+    "@ministryofjustice/frontend": "npm:^8.0.0"
     esbuild: "npm:^0.27.3"
     govuk-frontend: "npm:^5.14.0"
     sass: "npm:^1.97.3"


### PR DESCRIPTION
The new GOV.UK header navigation is incompatible with the current service navigation on Review. This PR reverts the recent MoJ Frontend upgrade until the service is updated to support the GOV.UK Frontend v6 header.