### PR TITLE
[CRIMAPP-2002] Use stored_searchable_text in prod

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,7 +31,7 @@ feature_flags:
     local: true
     test: true
     staging: true
-    production: false
+    production: true
 
 # For settings that vary by HostEnv name
 host_env_settings:


### PR DESCRIPTION
## Description of change
- set `use_stored_searchable_text` to `true` in production so users can see the updated content

## Link to relevant ticket
[CRIMAPP-2002](https://dsdmoj.atlassian.net/browse/CRIMAPP-2002)

[CRIMAPP-2002]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ