### PR TITLE
[CRIMAPP-2171] Office code in application returned email

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -16,16 +16,16 @@ class NotifyMailer < GovukNotifyRails::Mailer
   def application_returned_email(application_id, return_reason)
     application = CrimeApplication.find(application_id)
     provider_email = application.provider_details.provider_email
-    applicant_name = application.client_details.applicant.full_name
     application_reference = application.reference.to_s
     return_reason = I18n.t("emails_text.application_returned.#{return_reason}")
+    office_account_number = application.provider_details.office_code
 
     set_template(:application_returned_email)
 
     set_personalisation(
-      applicant_name:,
       application_reference:,
-      return_reason:
+      return_reason:,
+      office_account_number:
     )
 
     mail(to: provider_email)

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -13,9 +13,11 @@ class NotifyMailer < GovukNotifyRails::Mailer
 
   self.delivery_job = NotifyMailDeliveryJob
 
-  def application_returned_email(application_id, return_reason)
+  def application_returned_email(application_id, return_reason) # rubocop:disable Metrics/MethodLength
     application = CrimeApplication.find(application_id)
     provider_email = application.provider_details.provider_email
+    # TODO[CRIMAPP-2171]: remove applicant_name once the template is updated in production
+    applicant_name = application.client_details.applicant.full_name
     application_reference = application.reference.to_s
     return_reason = I18n.t("emails_text.application_returned.#{return_reason}")
     office_account_number = application.provider_details.office_code
@@ -23,6 +25,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
     set_template(:application_returned_email)
 
     set_personalisation(
+      applicant_name:,
       application_reference:,
       return_reason:,
       office_account_number:

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe NotifyMailer do
 
     let(:personalisation) do
       {
-        applicant_name: 'Kit Pound',
         application_reference: '6000001',
-        return_reason: 'clarification is required'
+        return_reason: 'clarification is required',
+        office_account_number: '1A123B'
       }
     end
 

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe NotifyMailer do
 
     let(:personalisation) do
       {
+        applicant_name: 'Kit Pound',
         application_reference: '6000001',
         return_reason: 'clarification is required',
         office_account_number: '1A123B'


### PR DESCRIPTION
## Description of change
- add `office_account_number` to `application_returned` email

## Link to relevant ticket
[CRIMAPP-2171](https://dsdmoj.atlassian.net/browse/CRIMAPP-2171)

[CRIMAPP-2171]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ