### PR TITLE
[CRIMAPP-2179] Update view evidence UI

### DIFF
--- a/app/components/evidence_embed_component.html.erb
+++ b/app/components/evidence_embed_component.html.erb
@@ -1,4 +1,9 @@
 <% if evidence.viewable_inline? %>
+  <% if show_view_link? %>
+    <p class="govuk-body">
+      <%= govuk_link_to(t('.view_in_new_tab'), view_path, target: '_blank', rel: 'noopener noreferrer') %>
+    </p>
+  <% end %>
   <% if evidence.pdf? %>
     <%= tag.iframe(
           src: raw_path,
@@ -6,13 +11,13 @@
           title: evidence.filename
         ) %>
   <% else %>
+    <%= govuk_details(summary_text: t('.rotate_or_zoom_summary')) do %>
+      <p class="govuk-body"><%= t('.rotate_or_zoom_details') %></p>
+    <% end %>
     <%= tag.img(
           src: raw_path,
           class: 'app-evidence-embed app-evidence-embed--image',
           alt: evidence.filename
         ) %>
   <% end %>
-<% else %>
-  <p class="govuk-body"><%= t('.not_embeddable') %></p>
-  <%= govuk_link_to(download_text, download_path) %>
 <% end %>

--- a/app/components/evidence_embed_component.html.erb
+++ b/app/components/evidence_embed_component.html.erb
@@ -1,23 +1,27 @@
-<% if evidence.viewable_inline? %>
-  <% if show_view_link? %>
-    <p class="govuk-body">
-      <%= govuk_link_to(t('.view_in_new_tab'), view_path, target: '_blank', rel: 'noopener noreferrer') %>
-    </p>
-  <% end %>
-  <% if evidence.pdf? %>
-    <%= tag.iframe(
-          src: raw_path,
-          class: 'app-evidence-embed app-evidence-embed--pdf',
-          title: evidence.filename
-        ) %>
-  <% else %>
-    <%= govuk_details(summary_text: t('.rotate_or_zoom_summary')) do %>
-      <p class="govuk-body"><%= t('.rotate_or_zoom_details') %></p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if evidence.viewable_inline? %>
+      <% if show_view_link? %>
+        <p class="govuk-body">
+          <%= govuk_link_to(t('.view_in_new_tab'), view_path, target: '_blank', rel: 'noopener noreferrer') %>
+        </p>
+      <% end %>
+      <% if evidence.pdf? %>
+        <%= tag.iframe(
+              src: raw_path,
+              class: 'app-evidence-embed app-evidence-embed--pdf',
+              title: evidence.filename
+            ) %>
+      <% else %>
+        <%= govuk_details(summary_text: t('.rotate_or_zoom_summary')) do %>
+          <p class="govuk-body"><%= t('.rotate_or_zoom_details') %></p>
+        <% end %>
+        <%= tag.img(
+              src: raw_path,
+              class: 'app-evidence-embed app-evidence-embed--image',
+              alt: evidence.filename
+            ) %>
+      <% end %>
     <% end %>
-    <%= tag.img(
-          src: raw_path,
-          class: 'app-evidence-embed app-evidence-embed--image',
-          alt: evidence.filename
-        ) %>
-  <% end %>
-<% end %>
+  </div>
+</div>

--- a/app/components/evidence_embed_component.html.erb
+++ b/app/components/evidence_embed_component.html.erb
@@ -1,27 +1,48 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% if evidence.viewable_inline? %>
-      <% if show_view_link? %>
-        <p class="govuk-body">
-          <%= govuk_link_to(t('.view_in_new_tab'), view_path, target: '_blank', rel: 'noopener noreferrer') %>
-        </p>
-      <% end %>
-      <% if evidence.pdf? %>
-        <%= tag.iframe(
-              src: raw_path,
-              class: 'app-evidence-embed app-evidence-embed--pdf',
-              title: evidence.filename
-            ) %>
-      <% else %>
-        <%= govuk_details(summary_text: t('.rotate_or_zoom_summary')) do %>
-          <p class="govuk-body"><%= t('.rotate_or_zoom_details') %></p>
+<% if FeatureFlags.evidence_viewing_iteration.enabled? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <% if evidence.viewable_inline? %>
+        <% if show_view_link? %>
+          <p class="govuk-body">
+            <%= govuk_link_to(t('.view_in_new_tab'), view_path, target: '_blank', rel: 'noopener noreferrer') %>
+          </p>
         <% end %>
-        <%= tag.img(
-              src: raw_path,
-              class: 'app-evidence-embed app-evidence-embed--image',
-              alt: evidence.filename
-            ) %>
+        <% if evidence.pdf? %>
+          <%= tag.iframe(
+                src: raw_path,
+                class: 'app-evidence-embed app-evidence-embed--pdf',
+                title: evidence.filename
+              ) %>
+        <% else %>
+          <%= govuk_details(summary_text: t('.rotate_or_zoom_summary')) do %>
+            <p class="govuk-body"><%= t('.rotate_or_zoom_details') %></p>
+          <% end %>
+          <%= tag.img(
+                src: raw_path,
+                class: 'app-evidence-embed app-evidence-embed--image',
+                alt: evidence.filename
+              ) %>
+        <% end %>
       <% end %>
-    <% end %>
+    </div>
   </div>
-</div>
+<% else %>
+  <% if evidence.viewable_inline? %>
+    <% if evidence.pdf? %>
+      <%= tag.iframe(
+            src: raw_path,
+            class: 'app-evidence-embed app-evidence-embed--pdf',
+            title: evidence.filename
+          ) %>
+    <% else %>
+      <%= tag.img(
+            src: raw_path,
+            class: 'app-evidence-embed app-evidence-embed--image',
+            alt: evidence.filename
+          ) %>
+    <% end %>
+  <% else %>
+    <p class="govuk-body"><%= t('.not_embeddable') %></p>
+    <%= govuk_link_to(download_text, download_path) %>
+  <% end %>
+<% end %>

--- a/app/components/evidence_embed_component.rb
+++ b/app/components/evidence_embed_component.rb
@@ -15,8 +15,16 @@ class EvidenceEmbedComponent < ViewComponent::Base
 
   attr_reader :evidence, :crime_application
 
+  def show_view_link?
+    helpers.current_page?(helpers.crime_application_documents_path(crime_application))
+  end
+
   def raw_path
     raw_crime_application_document_path(crime_application, evidence.s3_object_key)
+  end
+
+  def view_path
+    crime_application_document_path(crime_application, evidence.s3_object_key)
   end
 
   def download_path

--- a/app/views/casework/documents/index.html.erb
+++ b/app/views/casework/documents/index.html.erb
@@ -6,10 +6,11 @@
 
 <h2 class="govuk-heading-l"><%= t('.heading') %></h2>
 
-<% if @crime_application.supporting_evidence.present? %>
+<% viewable_evidence = @crime_application.supporting_evidence.select(&:viewable_inline?) %>
+<% if viewable_evidence.present? %>
   <%= govuk_accordion do |accordion|
-        @crime_application.supporting_evidence.each do |evidence|
-          accordion.with_section(heading_text: evidence.filename) do
+        viewable_evidence.each do |evidence|
+          accordion.with_section(heading_text: evidence.filename, expanded: true) do
             render EvidenceEmbedComponent.new(
               evidence: evidence,
               crime_application: @crime_application

--- a/app/views/casework/documents/index.html.erb
+++ b/app/views/casework/documents/index.html.erb
@@ -6,18 +6,43 @@
 
 <h2 class="govuk-heading-l"><%= t('.heading') %></h2>
 
-<% viewable_evidence = @crime_application.supporting_evidence.select(&:viewable_inline?) %>
-<% if viewable_evidence.present? %>
-  <%= govuk_accordion do |accordion|
-        viewable_evidence.each do |evidence|
-          accordion.with_section(heading_text: evidence.filename, expanded: true) do
-            render EvidenceEmbedComponent.new(
-              evidence: evidence,
-              crime_application: @crime_application
-            )
-          end
-        end
-      end %>
+<% if @crime_application.supporting_evidence.empty? %>
+  <p class="govuk-body"><%= t('labels.no_files_uploaded') %></p>
 <% else %>
-  <p class="govuk-body"><%= t(:no_files_uploaded, scope: 'values') %></p>
+  <% viewable_evidence = @crime_application.supporting_evidence.select(&:viewable_inline?) %>
+  <% non_viewable_evidence = @crime_application.supporting_evidence.reject(&:viewable_inline?) %>
+  <% non_viewable_count = non_viewable_evidence.count %>
+
+  <% if non_viewable_count > 0 %>
+    <%= govuk_warning_text(text: t('.non_viewable_warning', count: non_viewable_count)) %>
+
+    <h3 class="govuk-heading-m"><%= t('.download_heading') %></h3>
+    <p class="govuk-body"><%= t('.download_caption') %></p>
+
+    <div class="govuk-summary-card govuk-!-margin-bottom-6">
+      <div class="govuk-summary-card__content">
+        <%= govuk_summary_list do |summary_list|
+              non_viewable_evidence.each do |evidence|
+                summary_list.with_row do |row|
+                  row.with_key(text: evidence.filename)
+                  row.with_value(text: govuk_link_to("#{t('casework.documents.index.download')} (#{evidence.file_extension} #{number_to_human_size(evidence.file_size)})", download_crime_application_document_path(@crime_application, evidence.s3_object_key)))
+                end
+              end
+            end %>
+      </div>
+    </div>
+  <% end %>
+
+  <% if viewable_evidence.present? %>
+    <%= govuk_accordion do |accordion|
+          viewable_evidence.each do |evidence|
+            accordion.with_section(heading_text: evidence.filename, expanded: true) do
+              render EvidenceEmbedComponent.new(
+                evidence: evidence,
+                crime_application: @crime_application
+              )
+            end
+          end
+        end %>
+  <% end %>
 <% end %>

--- a/app/views/casework/documents/index.html.erb
+++ b/app/views/casework/documents/index.html.erb
@@ -4,11 +4,11 @@
 
 <%= render partial: 'subnavigation', locals: { crime_application: @crime_application } %>
 
-<h2 class="govuk-heading-l"><%= t('.heading') %></h2>
+<h2 class="govuk-heading-l"><%= FeatureFlags.evidence_viewing_iteration.enabled? ? t('.heading') : t('.heading_legacy') %></h2>
 
 <% if @crime_application.supporting_evidence.empty? %>
   <p class="govuk-body"><%= t('labels.no_files_uploaded') %></p>
-<% else %>
+<% elsif FeatureFlags.evidence_viewing_iteration.enabled? %>
   <% viewable_evidence = @crime_application.supporting_evidence.select(&:viewable_inline?) %>
   <% non_viewable_evidence = @crime_application.supporting_evidence.reject(&:viewable_inline?) %>
   <% non_viewable_count = non_viewable_evidence.count %>
@@ -45,4 +45,15 @@
           end
         end %>
   <% end %>
+<% else %>
+  <%= govuk_accordion do |accordion|
+        @crime_application.supporting_evidence.each do |evidence|
+          accordion.with_section(heading_text: evidence.filename) do
+            render EvidenceEmbedComponent.new(
+              evidence: evidence,
+              crime_application: @crime_application
+            )
+          end
+        end
+      end %>
 <% end %>

--- a/app/views/casework/documents/show.html.erb
+++ b/app/views/casework/documents/show.html.erb
@@ -3,7 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <title><%= @document.filename %></title>
-  <%= stylesheet_link_tag 'application', media: 'all' %>
+  <% if FeatureFlags.evidence_viewing_iteration.enabled? %>
+    <%= stylesheet_link_tag 'application', media: 'all' %>
+  <% end %>
   <style>
     html, body { margin: 0; padding: 0; }
     img { display: block; max-width: 100%; }

--- a/app/views/casework/documents/show.html.erb
+++ b/app/views/casework/documents/show.html.erb
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title><%= @document.filename %></title>
+  <%= stylesheet_link_tag 'application', media: 'all' %>
   <style>
     html, body { margin: 0; padding: 0; }
     img { display: block; max-width: 100%; }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,9 @@ en:
 
   evidence_embed_component:
     not_embeddable: This file cannot be displayed in the browser.
+    view_in_new_tab: View in a new tab
+    rotate_or_zoom_summary: Rotate or zoom
+    rotate_or_zoom_details: Hover over the image and press Ctrl twice, this will open an overlay with the image in. You will then be able to rotate or zoom using the controls at the bottom of the overlay.
 
   service:
     name: Review criminal legal aid applications

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -888,5 +888,11 @@ en:
     documents:
       index:
         page_title: All evidence
-        heading: All evidence
+        heading: Supporting evidence
+        download: Download
+        download_heading: Download evidence
+        download_caption: You'll need to download some evidence to view it.
+        non_viewable_warning:
+          one: "%{count} piece of evidence cannot be viewed in browser and may need to be downloaded."
+          other: "%{count} pieces of evidence cannot be viewed in browser and may need to be downloaded."
       show:

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -889,6 +889,7 @@ en:
       index:
         page_title: All evidence
         heading: Supporting evidence
+        heading_legacy: All evidence
         download: Download
         download_heading: Download evidence
         download_caption: You'll need to download some evidence to view it.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -32,6 +32,11 @@ feature_flags:
     test: true
     staging: true
     production: true
+  evidence_viewing_iteration:
+    local: true
+    test: true
+    staging: true
+    production: false
 
 # For settings that vary by HostEnv name
 host_env_settings:

--- a/spec/components/evidence_embed_component_spec.rb
+++ b/spec/components/evidence_embed_component_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe EvidenceEmbedComponent, type: :component do
 
   let(:crime_application) { instance_double(CrimeApplication, to_param: 'app-123') }
 
+  before do
+    allow(FeatureFlags).to receive(:evidence_viewing_iteration) {
+      instance_double(FeatureFlags::EnabledFeature, enabled?: true)
+    }
+  end
+
   context 'with a PDF document' do
     let(:evidence) do
       Document.new(
@@ -31,9 +37,7 @@ RSpec.describe EvidenceEmbedComponent, type: :component do
     end
 
     context 'when on the supporting evidence tab page' do
-      before do
-        allow_any_instance_of(described_class).to receive(:show_view_link?).and_return(true)
-      end
+      before { allow_any_instance_of(described_class).to receive(:show_view_link?).and_return(true) }
 
       it 'renders a "View in a new tab" link' do
         expect(rendered).to have_link('View in a new tab', href: /key%2Fpdf1/)
@@ -41,12 +45,28 @@ RSpec.describe EvidenceEmbedComponent, type: :component do
     end
 
     context 'when not on the supporting evidence tab page' do
-      before do
-        allow_any_instance_of(described_class).to receive(:show_view_link?).and_return(false)
-      end
+      before { allow_any_instance_of(described_class).to receive(:show_view_link?).and_return(false) }
 
       it 'does not render a "View in a new tab" link' do
         expect(rendered).to have_no_link('View in a new tab')
+      end
+    end
+
+    context 'when evidence_viewing_iteration feature flag is disabled' do
+      before do
+        allow(FeatureFlags).to receive(:evidence_viewing_iteration) {
+          instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+        }
+      end
+
+      it 'renders an iframe pointing to the raw document path' do
+        expect(rendered).to have_css(
+          "iframe.app-evidence-embed--pdf[src*='key%2Fpdf1'][src*='raw']"
+        )
+      end
+
+      it 'sets the iframe title to the filename' do
+        expect(rendered).to have_css("iframe[title='doc.pdf']")
       end
     end
   end
@@ -78,9 +98,7 @@ RSpec.describe EvidenceEmbedComponent, type: :component do
     end
 
     context 'when on the documents index page' do
-      before do
-        allow_any_instance_of(described_class).to receive(:show_view_link?).and_return(true)
-      end
+      before { allow_any_instance_of(described_class).to receive(:show_view_link?).and_return(true) }
 
       it 'renders a "View in a new tab" link' do
         expect(rendered).to have_link('View in a new tab', href: /key%2Fimg1/)
@@ -88,13 +106,59 @@ RSpec.describe EvidenceEmbedComponent, type: :component do
     end
 
     context 'when not on the documents index page' do
+      before { allow_any_instance_of(described_class).to receive(:show_view_link?).and_return(false) }
+
+      it 'does not render a "View in a new tab" link' do
+        expect(rendered).to have_no_link('View in a new tab')
+      end
+    end
+
+    context 'when evidence_viewing_iteration feature flag is disabled' do
       before do
-        allow_any_instance_of(described_class).to receive(:show_view_link?).and_return(false)
+        allow(FeatureFlags).to receive(:evidence_viewing_iteration) {
+          instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+        }
+      end
+
+      it 'renders an img tag pointing to the raw document path' do
+        expect(rendered).to have_css(
+          "img.app-evidence-embed--image[src*='key%2Fimg1'][src*='raw']"
+        )
+      end
+
+      it 'sets the alt text to the filename' do
+        expect(rendered).to have_css("img[alt='photo.png']")
+      end
+
+      it 'does not render rotate or zoom details' do
+        expect(rendered).to have_no_text('Rotate or zoom')
       end
 
       it 'does not render a "View in a new tab" link' do
         expect(rendered).to have_no_link('View in a new tab')
       end
+    end
+  end
+
+  context 'with a non-viewable document' do
+    before do
+      allow(FeatureFlags).to receive(:evidence_viewing_iteration) {
+        instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+      }
+    end
+
+    let(:evidence) do
+      Document.new(
+        filename: 'report.docx',
+        content_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        file_extension: 'docx',
+        file_size: 1024,
+        s3_object_key: 'key/docx1'
+      )
+    end
+
+    it 'renders a not embeddable message' do
+      expect(rendered).to have_text('This file cannot be displayed in the browser.')
     end
   end
 end

--- a/spec/components/evidence_embed_component_spec.rb
+++ b/spec/components/evidence_embed_component_spec.rb
@@ -26,8 +26,28 @@ RSpec.describe EvidenceEmbedComponent, type: :component do
       expect(rendered).to have_css("iframe[title='doc.pdf']")
     end
 
-    it 'does not render a download link' do
-      expect(rendered).to have_no_link
+    it 'does not render rotate or zoom details' do
+      expect(rendered).to have_no_text('Rotate or zoom')
+    end
+
+    context 'when on the supporting evidence tab page' do
+      before do
+        allow_any_instance_of(described_class).to receive(:show_view_link?).and_return(true)
+      end
+
+      it 'renders a "View in a new tab" link' do
+        expect(rendered).to have_link('View in a new tab', href: /key%2Fpdf1/)
+      end
+    end
+
+    context 'when not on the supporting evidence tab page' do
+      before do
+        allow_any_instance_of(described_class).to receive(:show_view_link?).and_return(false)
+      end
+
+      it 'does not render a "View in a new tab" link' do
+        expect(rendered).to have_no_link('View in a new tab')
+      end
     end
   end
 
@@ -52,36 +72,29 @@ RSpec.describe EvidenceEmbedComponent, type: :component do
       expect(rendered).to have_css("img[alt='photo.png']")
     end
 
-    it 'does not render a download link' do
-      expect(rendered).to have_no_link
-    end
-  end
-
-  context 'with a non-embeddable document' do
-    let(:evidence) do
-      Document.new(
-        filename: 'data.csv',
-        content_type: 'application/octet-stream',
-        file_extension: 'csv',
-        file_size: 2048,
-        s3_object_key: 'key/csv1'
-      )
+    it 'renders rotate or zoom details' do
+      expect(rendered).to have_text('Rotate or zoom')
+      expect(rendered).to have_text('Hover over the image and press Ctrl twice')
     end
 
-    it 'displays the not embeddable message' do
-      expect(rendered).to have_text('This file cannot be displayed in the browser.')
+    context 'when on the documents index page' do
+      before do
+        allow_any_instance_of(described_class).to receive(:show_view_link?).and_return(true)
+      end
+
+      it 'renders a "View in a new tab" link' do
+        expect(rendered).to have_link('View in a new tab', href: /key%2Fimg1/)
+      end
     end
 
-    it 'renders a download link' do
-      expect(rendered).to have_link(
-        'Download file (csv, 2 KB)',
-        href: /key%2Fcsv1/
-      )
-    end
+    context 'when not on the documents index page' do
+      before do
+        allow_any_instance_of(described_class).to receive(:show_view_link?).and_return(false)
+      end
 
-    it 'does not render an iframe or img tag' do
-      expect(rendered).to have_no_css('iframe')
-      expect(rendered).to have_no_css('img')
+      it 'does not render a "View in a new tab" link' do
+        expect(rendered).to have_no_link('View in a new tab')
+      end
     end
   end
 end

--- a/spec/system/casework/viewing_an_application/all_evidence_spec.rb
+++ b/spec/system/casework/viewing_an_application/all_evidence_spec.rb
@@ -49,34 +49,10 @@ RSpec.describe 'Viewing all evidence' do
         .to_return(status: 200, body: 'file content', headers: { 'Content-Type' => 'application/octet-stream' })
 
       allow(EvidenceAccessLogger).to receive(:log_view)
+      allow(FeatureFlags).to receive(:evidence_viewing_iteration) {
+        instance_double(FeatureFlags::EnabledFeature, enabled?: true)
+      }
       visit crime_application_documents_path(application_id)
-    end
-
-    it 'displays the page heading' do
-      expect(page).to have_content('Supporting evidence')
-    end
-
-    it 'displays a warning about non-viewable evidence' do
-      expect(page).to have_content('1 piece of evidence cannot be viewed in browser and may need to be downloaded.')
-    end
-
-    it 'displays the filename for each viewable document' do
-      expect(page).to have_content('test.pdf')
-      expect(page).to have_content('photo.jpg')
-    end
-
-    it 'does not display non-viewable files in the accordion' do
-      within('.govuk-accordion') do
-        expect(page).to have_no_content('report.docx')
-      end
-    end
-
-    it 'displays non-viewable files in a table with download links' do
-      within('.govuk-summary-card') do
-        expect(page).to have_content('report.docx')
-        expect(page).to have_link('Download (docx 1 KB)',
-                                  href: download_crime_application_document_path(application_id, docx_s3_key))
-      end
     end
 
     it 'embeds the PDF in an iframe' do
@@ -89,21 +65,6 @@ RSpec.describe 'Viewing all evidence' do
       expect(page).to have_css(
         "img[src='#{raw_crime_application_document_path(application_id, image_s3_key)}']"
       )
-    end
-
-    it 'displays a "View in a new tab" link for PDF' do
-      expect(page).to have_link('View in a new tab',
-                                href: crime_application_document_path(application_id, pdf_s3_key))
-    end
-
-    it 'displays a "View in a new tab" link for images' do
-      expect(page).to have_link('View in a new tab',
-                                href: crime_application_document_path(application_id, image_s3_key))
-    end
-
-    it 'displays rotate or zoom instructions for images' do
-      expect(page).to have_content('Rotate or zoom')
-      expect(page).to have_content('Hover over the image and press Ctrl twice')
     end
 
     context 'when the page loads' do
@@ -127,6 +88,77 @@ RSpec.describe 'Viewing all evidence' do
           "img[src='#{raw_crime_application_document_path(application_id, image_s3_key)}']"
         )
         expect(EvidenceAccessLogger).to have_received(:log_view).twice
+      end
+    end
+
+    context 'when evidence_viewing_iteration feature flag is enabled' do
+      it 'displays the page heading' do
+        expect(page).to have_content('Supporting evidence')
+      end
+
+      it 'displays a warning about non-viewable evidence' do
+        expect(page).to have_content('1 piece of evidence cannot be viewed in browser and may need to be downloaded.')
+      end
+
+      it 'displays the filename for each viewable document' do
+        expect(page).to have_content('test.pdf')
+        expect(page).to have_content('photo.jpg')
+      end
+
+      it 'does not display non-viewable files in the accordion' do
+        within('.govuk-accordion') do
+          expect(page).to have_no_content('report.docx')
+        end
+      end
+
+      it 'displays non-viewable files in a table with download links' do
+        within('.govuk-summary-card') do
+          expect(page).to have_content('report.docx')
+          expect(page).to have_link('Download (docx 1 KB)',
+                                    href: download_crime_application_document_path(application_id, docx_s3_key))
+        end
+      end
+
+      it 'displays a "View in a new tab" link for PDF' do
+        expect(page).to have_link('View in a new tab',
+                                  href: crime_application_document_path(application_id, pdf_s3_key))
+      end
+
+      it 'displays a "View in a new tab" link for images' do
+        expect(page).to have_link('View in a new tab',
+                                  href: crime_application_document_path(application_id, image_s3_key))
+      end
+
+      it 'displays rotate or zoom instructions for images' do
+        expect(page).to have_content('Rotate or zoom')
+        expect(page).to have_content('Hover over the image and press Ctrl twice')
+      end
+    end
+
+    context 'when evidence_viewing_iteration feature flag is disabled' do
+      before do
+        allow(FeatureFlags).to receive(:evidence_viewing_iteration) {
+          instance_double(FeatureFlags::EnabledFeature, enabled?: false)
+        }
+        visit crime_application_documents_path(application_id)
+      end
+
+      it 'displays the page heading' do
+        expect(page).to have_content('All evidence')
+      end
+
+      it 'displays the filename for each document' do # rubocop:disable RSpec/MultipleExpectations
+        expect(page).to have_content('test.pdf')
+        expect(page).to have_content('photo.jpg')
+        expect(page).to have_content('report.docx')
+      end
+
+      it 'shows a cannot-be-displayed message and download link for non-embeddable files' do
+        expect(page).to have_content('This file cannot be displayed in the browser.')
+        expect(page).to have_link(
+          'Download file (docx, 1 KB)',
+          href: download_crime_application_document_path(application_id, docx_s3_key)
+        )
       end
     end
   end

--- a/spec/system/casework/viewing_an_application/all_evidence_spec.rb
+++ b/spec/system/casework/viewing_an_application/all_evidence_spec.rb
@@ -53,7 +53,11 @@ RSpec.describe 'Viewing all evidence' do
     end
 
     it 'displays the page heading' do
-      expect(page).to have_content('All evidence')
+      expect(page).to have_content('Supporting evidence')
+    end
+
+    it 'displays a warning about non-viewable evidence' do
+      expect(page).to have_content('1 piece of evidence cannot be viewed in browser and may need to be downloaded.')
     end
 
     it 'displays the filename for each viewable document' do
@@ -62,7 +66,17 @@ RSpec.describe 'Viewing all evidence' do
     end
 
     it 'does not display non-viewable files in the accordion' do
-      expect(page).to have_no_content('report.docx')
+      within('.govuk-accordion') do
+        expect(page).to have_no_content('report.docx')
+      end
+    end
+
+    it 'displays non-viewable files in a table with download links' do
+      within('.govuk-summary-card') do
+        expect(page).to have_content('report.docx')
+        expect(page).to have_link('Download (docx 1 KB)',
+                                  href: download_crime_application_document_path(application_id, docx_s3_key))
+      end
     end
 
     it 'embeds the PDF in an iframe' do

--- a/spec/system/casework/viewing_an_application/all_evidence_spec.rb
+++ b/spec/system/casework/viewing_an_application/all_evidence_spec.rb
@@ -56,10 +56,13 @@ RSpec.describe 'Viewing all evidence' do
       expect(page).to have_content('All evidence')
     end
 
-    it 'displays the filename for each document' do # rubocop:disable RSpec/MultipleExpectations
+    it 'displays the filename for each viewable document' do
       expect(page).to have_content('test.pdf')
       expect(page).to have_content('photo.jpg')
-      expect(page).to have_content('report.docx')
+    end
+
+    it 'does not display non-viewable files in the accordion' do
+      expect(page).to have_no_content('report.docx')
     end
 
     it 'embeds the PDF in an iframe' do
@@ -74,12 +77,19 @@ RSpec.describe 'Viewing all evidence' do
       )
     end
 
-    it 'shows a cannot-be-displayed message and download link for non-embeddable files' do
-      expect(page).to have_content('This file cannot be displayed in the browser.')
-      expect(page).to have_link(
-        'Download file (docx, 1 KB)',
-        href: download_crime_application_document_path(application_id, docx_s3_key)
-      )
+    it 'displays a "View in a new tab" link for PDF' do
+      expect(page).to have_link('View in a new tab',
+                                href: crime_application_document_path(application_id, pdf_s3_key))
+    end
+
+    it 'displays a "View in a new tab" link for images' do
+      expect(page).to have_link('View in a new tab',
+                                href: crime_application_document_path(application_id, image_s3_key))
+    end
+
+    it 'displays rotate or zoom instructions for images' do
+      expect(page).to have_content('Rotate or zoom')
+      expect(page).to have_content('Hover over the image and press Ctrl twice')
     end
 
     context 'when the page loads' do


### PR DESCRIPTION
## Description of change

Updates the view evidence UI according to the latest designs: 
- If there are pieces of evidence that can not be viewed in browser then these pieces of evidence are listed in a table with download links for users to download.
- Adds a link to view each piece of evidence in it’s own tab
- All sections in the accordion are expanded as default
- A details component is added above images to provide instructions to rotate or zoom the file

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2179

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

**View when there is downloadble evidence**
<img width="1158" height="871" alt="Screenshot 2026-05-13 at 11 09 59" src="https://github.com/user-attachments/assets/162ab7d7-297a-4143-85a6-8e8bee517600" />

**View when all evidence uploaded is viewable (download content does not appear)**
<img width="1213" height="852" alt="Screenshot 2026-05-13 at 11 12 41" src="https://github.com/user-attachments/assets/cd463803-98f6-466a-a994-6038ed83771d" />

**View when no evidence has been uploaded (handles an edge case if a user navigates to this screen themselves)**
<img width="1213" height="647" alt="Screenshot 2026-05-13 at 11 11 52" src="https://github.com/user-attachments/assets/92e754a5-1d97-4692-bfbb-9a49093df887" />

**View when the only evidence uploaded was non viewable evidence**
<img width="1165" height="414" alt="Screenshot 2026-05-13 at 11 11 28" src="https://github.com/user-attachments/assets/3c5ac60f-fb03-4247-98e0-340ae246a3da" />

**View when an image is opened in a new tab with the added rotate or zoom detail**
<img width="1841" height="1246" alt="Screenshot 2026-05-13 at 11 10 59" src="https://github.com/user-attachments/assets/9e8cbb9d-df2e-49f3-9a98-31830ffe1c77" />

**View of the rotate or zoom detail opened**
<img width="1158" height="1004" alt="Screenshot 2026-05-13 at 11 10 38" src="https://github.com/user-attachments/assets/d40d835e-83d6-4509-b0b5-72a72f7df09e" />

## How to manually test the feature
