### PR TITLE
[CRIMAPP-2179] Add view evidence heading

### DIFF
--- a/app/views/casework/documents/index.html.erb
+++ b/app/views/casework/documents/index.html.erb
@@ -34,6 +34,7 @@
   <% end %>
 
   <% if viewable_evidence.present? %>
+    <h3 class="govuk-heading-m"><%= t('.view_heading') %></h3>
     <%= govuk_accordion do |accordion|
           viewable_evidence.each do |evidence|
             accordion.with_section(heading_text: evidence.filename, expanded: true) do

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -893,6 +893,7 @@ en:
         download: Download
         download_heading: Download evidence
         download_caption: You'll need to download some evidence to view it.
+        view_heading: View evidence
         non_viewable_warning:
           one: "%{count} piece of evidence cannot be viewed in browser and may need to be downloaded."
           other: "%{count} pieces of evidence cannot be viewed in browser and may need to be downloaded."


### PR DESCRIPTION
## Description of change
Adds the missing view evidence heading before the accordian as per design (whoops!)

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2179

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1233" height="652" alt="Screenshot 2026-05-20 at 13 40 37" src="https://github.com/user-attachments/assets/7e56ede5-d908-4189-adbe-8851c90d05bf" />

### After changes:
<img width="1233" height="652" alt="Screenshot 2026-05-20 at 13 40 08" src="https://github.com/user-attachments/assets/571dd4a4-170f-42f0-92c0-b2c72b72181f" />


## How to manually test the feature
