### PR TITLE
CRIMAPP-2130 Announce Sortable Column Headers

### DIFF
--- a/app/assets/stylesheets/local/sortable-table.scss
+++ b/app/assets/stylesheets/local/sortable-table.scss
@@ -1,5 +1,8 @@
 @use "govuk-frontend/dist/govuk" as *;
 
+[aria-sort] a,
+[aria-sort] a:hover,
+[aria-sort] a:visited,
 [aria-sort] button,
 [aria-sort] button:hover {
 
@@ -21,6 +24,45 @@
 
 }
 
+[aria-sort] a.app-table-sort-link {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+}
+
+[aria-sort] .app-table-sort-label {
+  min-width: 0;
+}
+
+[aria-sort] a.app-table-sort-link::before,
+[aria-sort] a.app-table-sort-link::after {
+  content: none;
+}
+
+[aria-sort] .app-table-sort-indicator {
+  position: relative;
+  flex: 0 0 10px;
+  width: 10px;
+  margin-left: 6px;
+}
+
+[aria-sort] .app-table-sort-indicator::before {
+  content: " \25bc";
+  position: absolute;
+  top: 9px;
+  right: -1px;
+  font-size: 0.5em;
+}
+
+[aria-sort] .app-table-sort-indicator::after {
+  content: " \25b2";
+  position: absolute;
+  top: 1px;
+  right: -1px;
+  font-size: 0.5em;
+}
+
+[aria-sort] a:focus,
 [aria-sort] button:focus {
   outline: none;
   color: $govuk-focus-text-colour;
@@ -30,10 +72,12 @@
     0 4px $govuk-focus-text-colour;
 }
 
+[aria-sort]:first-child a,
 [aria-sort]:first-child button {
   right: auto;
 }
 
+[aria-sort] a::before,
 [aria-sort] button::before {
   content: " \25bc";
   position: absolute;
@@ -42,6 +86,7 @@
   font-size: 0.5em;
 }
 
+[aria-sort] a::after,
 [aria-sort] button::after {
   content: " \25b2";
   position: absolute;
@@ -50,11 +95,19 @@
   font-size: 0.5em;
 }
 
+[aria-sort="ascending"] a::before,
 [aria-sort="ascending"] button::before,
+[aria-sort="descending"] a::before,
 [aria-sort="descending"] button::before {
   content: none;
 }
 
+[aria-sort="ascending"] .app-table-sort-indicator::before,
+[aria-sort="descending"] .app-table-sort-indicator::before {
+  content: none;
+}
+
+[aria-sort="ascending"] a::after,
 [aria-sort="ascending"] button::after {
   content: " \25b2";
   position: absolute;
@@ -63,7 +116,24 @@
   font-size: 0.8em;
 }
 
+[aria-sort="ascending"] .app-table-sort-indicator::after {
+  content: " \25b2";
+  position: absolute;
+  top: 2px;
+  right: -5px;
+  font-size: 0.8em;
+}
+
+[aria-sort="descending"] a::after,
 [aria-sort="descending"] button::after {
+  content: " \25bc";
+  position: absolute;
+  top: 2px;
+  right: -5px;
+  font-size: 0.8em;
+}
+
+[aria-sort="descending"] .app-table-sort-indicator::after {
   content: " \25bc";
   position: absolute;
   top: 2px;

--- a/app/assets/stylesheets/local/sortable-table.scss
+++ b/app/assets/stylesheets/local/sortable-table.scss
@@ -30,10 +30,6 @@
   width: 100%;
 }
 
-[aria-sort] .app-table-sort-label {
-  min-width: 0;
-}
-
 [aria-sort] a.app-table-sort-link::before,
 [aria-sort] a.app-table-sort-link::after {
   content: none;

--- a/app/components/data_table/header_cell_component.rb
+++ b/app/components/data_table/header_cell_component.rb
@@ -65,7 +65,6 @@ module DataTable
 
     def sorted_params
       {
-        locale: I18n.locale,
         filter: filter.to_h,
         sorting: {
           sort_by: colname.to_s,

--- a/app/components/data_table/header_cell_component.rb
+++ b/app/components/data_table/header_cell_component.rb
@@ -25,7 +25,15 @@ module DataTable
     def cell_content
       return name unless sortable?
 
-      button_to(name, nil, params: sorted_params, method: :get)
+      link_to(
+        safe_join([
+                    tag.span(name, class: 'app-table-sort-label'),
+                    tag.span('', class: 'app-table-sort-indicator', aria: { hidden: true })
+                  ]),
+        "?#{sorted_params.to_query}",
+        aria: { label: I18n.t('table_headings.sort_by', column: name) },
+        class: 'govuk-link app-table-sort-link'
+      )
     end
 
     def default_classes
@@ -57,6 +65,7 @@ module DataTable
 
     def sorted_params
       {
+        locale: I18n.locale,
         filter: filter.to_h,
         sorting: {
           sort_by: colname.to_s,

--- a/app/components/data_table/header_cell_component.rb
+++ b/app/components/data_table/header_cell_component.rb
@@ -27,7 +27,7 @@ module DataTable
 
       link_to(
         safe_join([
-                    tag.span(name, class: 'app-table-sort-label'),
+                    name,
                     tag.span('', class: 'app-table-sort-indicator', aria: { hidden: true })
                   ]),
         "?#{sorted_params.to_query}",

--- a/app/components/data_table/header_row_component.rb
+++ b/app/components/data_table/header_row_component.rb
@@ -16,7 +16,19 @@ module DataTable
     end
 
     def call
-      tag.tr(**html_attributes) { safe_join(cells) }
+      safe_join([
+                  caption,
+                  tag.tr(**html_attributes) { safe_join(cells) }
+                ])
+    end
+
+    def caption
+      tag.caption do
+        tag.span(
+          'Column headers with buttons are sortable.',
+          class: 'govuk-visually-hidden'
+        )
+      end
     end
 
     private

--- a/app/components/data_table/header_row_component.rb
+++ b/app/components/data_table/header_row_component.rb
@@ -25,7 +25,7 @@ module DataTable
     def caption
       tag.caption do
         tag.span(
-          'Column headers with buttons are sortable.',
+          I18n.t('table_headings.sortable_caption'),
           class: 'govuk-visually-hidden'
         )
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,3 +67,7 @@ en:
     currency:
       format:
         unit: "£"
+
+  table_headings:
+    sortable_caption: Column headers with buttons are sortable.
+    sort_by: sort by %{column}

--- a/spec/components/data_table/header_cell_component_spec.rb
+++ b/spec/components/data_table/header_cell_component_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe DataTable::HeaderCellComponent, type: :component do
+  subject(:component) do
+    described_class.new(
+      colname: colname,
+      scope: 'col',
+      colspan: 1,
+      sorting: sorting,
+      filter: nil,
+      numeric: false,
+      text: nil
+    )
+  end
+
+  let(:sorting) { ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending') }
+
+  context 'when the column is not sortable' do
+    let(:colname) { :caseworker }
+
+    before { render_inline(component) }
+
+    it 'renders a th with the column heading text and no aria-sort' do
+      expect(page).to have_css('th.govuk-table__header:not([aria-sort])', text: 'Caseworker')
+    end
+  end
+
+  context 'when the column is sortable but not the active sort' do
+    let(:colname) { :applicant_name }
+
+    before { render_inline(component) }
+
+    it 'renders a th with aria-sort="none" and a sort link' do
+      expect(page).to have_css('th.govuk-table__header[aria-sort="none"]')
+      expect(page).to have_link(text: 'Applicant\'s name', class: 'govuk-link')
+    end
+  end
+
+  context 'when the column is the active sort column' do
+    let(:colname) { :submitted_at }
+    let(:sorting) { ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'descending') }
+
+    before { render_inline(component) }
+
+    it 'renders a th with aria-sort set to the current sort direction' do
+      expect(page).to have_css('th.govuk-table__header[aria-sort="descending"]')
+      expect(page).to have_link(text: 'Date received', class: 'govuk-link')
+    end
+  end
+end

--- a/spec/components/data_table/header_row_component_spec.rb
+++ b/spec/components/data_table/header_row_component_spec.rb
@@ -1,0 +1,143 @@
+require 'rails_helper'
+
+RSpec.describe DataTable::HeaderRowComponent, type: :component do
+  subject(:component) { described_class.new(sorting:, filter:) }
+
+  let(:sorting) { ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending') }
+  let(:filter) { nil }
+
+  describe 'caption' do
+    before do
+      render_inline(component) { |row| row.with_cell(colname: 'reference', text: 'Reference') }
+    end
+
+    it 'renders a visually hidden caption' do
+      expect(page).to have_css('caption span.govuk-visually-hidden',
+                               text: 'Column headers with buttons are sortable.')
+    end
+  end
+
+  describe 'row structure' do
+    before do
+      render_inline(component) do |row|
+        row.with_cell(colname: 'reference', text: 'Reference')
+      end
+    end
+
+    it 'renders a tr with the govuk row class' do
+      expect(page).to have_css('tr.govuk-table__row')
+    end
+
+    it 'renders cells as th elements' do
+      expect(page).to have_css('th')
+    end
+  end
+
+  describe 'cells' do
+    context 'with multiple cells' do
+      before do
+        render_inline(component) do |row|
+          row.with_cell(colname: 'reference', text: 'LAA Reference')
+          row.with_cell(colname: 'caseworker', text: 'Caseworker')
+          row.with_cell(colname: 'status', text: 'Status')
+        end
+      end
+
+      it 'renders the correct number of th elements' do
+        expect(page).to have_css('th', count: 3)
+      end
+
+      it 'renders cell text in order' do
+        expect(page.all('th').map(&:text)).to eq(['LAA Reference', 'Caseworker', 'Status'])
+      end
+    end
+
+    context 'with a numeric cell' do
+      before do
+        render_inline(component) do |row|
+          row.with_cell(colname: 'reference', text: 'Reference', numeric: true)
+        end
+      end
+
+      it 'applies the numeric header class' do
+        expect(page).to have_css('th.govuk-table__header--numeric')
+      end
+    end
+
+    context 'with a custom colspan' do
+      before do
+        render_inline(component) do |row|
+          row.with_cell(colname: 'reference', text: 'Reference', colspan: 3)
+        end
+      end
+
+      it 'sets the colspan attribute' do
+        expect(page).to have_css('th[colspan="3"]')
+      end
+    end
+
+    context 'with a non-sortable column' do
+      before do
+        render_inline(component) do |row|
+          row.with_cell(colname: 'reference', text: 'Reference')
+        end
+      end
+
+      it 'does not set aria-sort on the th' do
+        expect(page).to have_css('th:not([aria-sort])')
+      end
+
+      it 'renders plain text, not a button' do
+        expect(page).not_to have_button('Reference')
+      end
+    end
+
+    context 'with a sortable column that is not active' do
+      before do
+        render_inline(component) do |row|
+          row.with_cell(colname: 'applicant_name', text: 'Name')
+        end
+      end
+
+      it 'sets aria-sort to none on the th' do
+        expect(page).to have_css('th[aria-sort="none"]')
+      end
+
+      it 'renders a link' do
+        expect(page).to have_link('Name', class: 'govuk-link')
+      end
+    end
+
+    context 'with the active sort column' do
+      let(:sorting) { ApplicationSearchSorting.new(sort_by: 'applicant_name', sort_direction: 'ascending') }
+
+      before do
+        render_inline(component) do |row|
+          row.with_cell(colname: 'applicant_name', text: 'Name')
+        end
+      end
+
+      it 'sets aria-sort to the current sort direction' do
+        expect(page).to have_css('th[aria-sort="ascending"]')
+      end
+
+      it 'renders a link with the column text' do
+        expect(page).to have_link('Name', class: 'govuk-link')
+      end
+    end
+
+    context 'when the active column is sorted descending' do
+      let(:sorting) { ApplicationSearchSorting.new(sort_by: 'applicant_name', sort_direction: 'descending') }
+
+      before do
+        render_inline(component) do |row|
+          row.with_cell(colname: 'applicant_name', text: 'Name')
+        end
+      end
+
+      it 'sets aria-sort to descending' do
+        expect(page).to have_css('th[aria-sort="descending"]')
+      end
+    end
+  end
+end

--- a/spec/shared_examples/table_with_sortable_headers.rb
+++ b/spec/shared_examples/table_with_sortable_headers.rb
@@ -14,7 +14,7 @@ RSpec.shared_examples 'a table with sortable headers' do
   describe 'when the active header is clicked' do
     it 'reverses the sort direction' do
       text = active_sort_headers.first
-      expect { click_button text }.to change {
+      expect { click_link text }.to change {
         page.find('thead tr th', text:)['aria-sort']
       }.from(active_sort_direction)
     end
@@ -23,7 +23,7 @@ RSpec.shared_examples 'a table with sortable headers' do
   describe 'when an inactive header is clicked' do
     it 'they become active' do
       inactive_sort_headers.each do |text|
-        expect { click_button text }.to change {
+        expect { click_link text }.to change {
           page.find('thead tr th', text:)['aria-sort']
         }.from('none')
       end
@@ -45,7 +45,7 @@ RSpec.shared_examples 'a table with sortable columns' do
   describe 'when the active header is clicked' do
     it 'reverses the sort direction' do
       colname = active.first
-      expect { page.find("th##{colname} button").click }.to change {
+      expect { page.find("th##{colname} a").click }.to change {
         page.find("th##{colname}")['aria-sort']
       }.from(active_direction)
     end
@@ -54,7 +54,7 @@ RSpec.shared_examples 'a table with sortable columns' do
   describe 'when an inactive header is clicked' do
     it 'they become active' do
       inactive.each do |colname|
-        expect { page.find("th##{colname} button").click }.to change {
+        expect { page.find("th##{colname} a").click }.to change {
           page.find("th##{colname}")['aria-sort']
         }.from('none')
       end


### PR DESCRIPTION
## Description of change

The sortable column headers in the tables should work better with screen readers.

This is done with the following covered in the PR:

For each tab (In Progress, Submitted, Returned, Decided), the displayed table contains a visually hidden element that states “Column headers with buttons are sortable."
Voiceover for each button clearly states its purpose in the form of "Sort by " (strings added for English and Welsh)
( Screen reading tools should no longer describe the icon in the form of “down pointing black pointer name up pointing black triangle” etc)
Each sortable column heading is now a link rather than a button - to the user this appears identical and has the same functionality but is semantically clearer.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2130

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

<img width="1085" height="747" alt="image" src="https://github.com/user-attachments/assets/62223428-6425-48c8-9b47-e3197aab9eb0" />

Using voiceover (command F5) - note that the arrows are voiced i.e. "“down pointing black pointer" and this makes it very disruptive

<img width="1141" height="705" alt="image" src="https://github.com/user-attachments/assets/a3c3e9df-f6df-4f49-9480-ac297fe9e16a" />

### After changes:

Note:

the caption element
forms have been removed from the header
form buttons are now links

<img width="1122" height="634" alt="image" src="https://github.com/user-attachments/assets/08b42196-ae43-4675-81a7-c7b108c86fc7" />


Note:

Voice over no longer mentions the icons
Voice over now states the header is for sorting

<img width="964" height="672" alt="image" src="https://github.com/user-attachments/assets/e2486d99-1c48-4c7d-8e80-6fb78dd32536" />

## How to manually test the feature

Go to any of the lists within **Review App**

- For regression select different tabs and sort by different fields to ensure that table functionality has not regressed since the change
- Inspect an element on the table and examine the console to see that a **Caption** exists explaining that the columns are sortable.
- Inspect an element on the table and examine the console to see that the forms have been removed and that the headers are now links.
- Press command f5 (mac) to get voice over. Tab through the sortable headers and voice will be "sort by <column name>"
- Repeat the above with search results