### PR TITLE
Update Dependabot config & add cron timezones

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,27 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10

--- a/.github/workflows/snyk-container.yml
+++ b/.github/workflows/snyk-container.yml
@@ -16,6 +16,7 @@ name: Snyk Container
 on:
   schedule:
     - cron: '30 22 * * 1,4' # At 22:30 on Monday and Thursday.
+      timezone: "Europe/London"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/snyk-infrastructure.yml
+++ b/.github/workflows/snyk-infrastructure.yml
@@ -15,6 +15,7 @@ name: Snyk Infrastructure as Code
 on:
   schedule:
     - cron: '30 21 * * 1' # at 21:30 on Monday evening
+      timezone: "Europe/London"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description of change
This change updates the Dependabot configuration by specifying the different pacakge ecosystems we use and setting the update check interval to be weekly, with a cooldown of 7 days. This brings it in line with the setup in the Crime Apply repository.

This change also sets the timezones on the Snyk workflows which are scheduled to run at specific times.