### PR TITLE
Dependabot config: group each ecosystem into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
@@ -13,6 +17,10 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
+    groups:
+      bundler:
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -20,6 +28,10 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
+    groups:
+      npm:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -27,3 +39,7 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description of chang

We’ve been seeing a high volume of Dependabot PRs, which is becoming difficult to manage.
This change groups updates by ecosystem (e.g. npm, GitHub Actions) into a single PR, rather than creating one PR per dependency.
It’s a small change, but should help reduce noise and improve overall workflow. We’ll review the impact in a couple of weeks to assess:

- whether it improved things
- whether it introduced any issues
- whether we should roll this out to other repositories

## Link to relevant ticket

None

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


