### PR TITLE
CRIMAPP-2167: Display frozen income/assets subject in Review

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.7.9'
+    tag: 'v1.8.0'
 
 gem 'jsbundling-rails'
 gem 'propshaft'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'laa-criminal-applications-datastore-api-client',
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.8.0'
+    tag: 'v1.8.1'
 
 gem 'jsbundling-rails'
 gem 'propshaft'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: eb402f50cc953e2d8caddaf9e2ee447efe8de584
-  tag: v1.8.0
+  revision: 4ad9e81f8b02cedec3fac84cafba340420bf6a5c
+  tag: v1.8.1
   specs:
-    laa-criminal-legal-aid-schemas (1.8.0)
+    laa-criminal-legal-aid-schemas (1.8.1)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: b2e8128fd1857b6bbcd205a316638aa746a631c8
-  tag: v1.7.9
+  revision: eb402f50cc953e2d8caddaf9e2ee447efe8de584
+  tag: v1.8.0
   specs:
-    laa-criminal-legal-aid-schemas (1.7.9)
+    laa-criminal-legal-aid-schemas (1.8.0)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/views/casework/crime_applications/sections/_income.html.erb
+++ b/app/views/casework/crime_applications/sections/_income.html.erb
@@ -24,6 +24,18 @@
             <%= t(income_details.has_frozen_income_or_assets, scope: 'values') %>
           </dd>
         </div>
+
+        <% if income_details.has_frozen_income_or_assets == 'yes' &&
+            income_details.frozen_income_or_assets_subject.present? %>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              <%= label_text(:frozen_income_or_assets_subject) %>
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= t(income_details.frozen_income_or_assets_subject, scope: 'values') %>
+            </dd>
+          </div>
+        <% end %>
       <% end %>
       <% unless income_details.client_owns_property.nil? %>
         <div class="govuk-summary-list__row">

--- a/app/views/casework/crime_applications/sections/_other_capital_details.html.erb
+++ b/app/views/casework/crime_applications/sections/_other_capital_details.html.erb
@@ -3,15 +3,28 @@
 <%= govuk_summary_card(heading_level: 3, title: label_text(:other_capital_details)) do %>
   <dl class="govuk-summary-list">
     <% unless capital_details&.has_frozen_income_or_assets.nil? %>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= label_text(:has_frozen_income_or_assets) %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= t(capital_details.has_frozen_income_or_assets, scope: 'values') %>
-      </dd>
-    </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= label_text(:has_frozen_income_or_assets) %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= t(capital_details.has_frozen_income_or_assets, scope: 'values') %>
+        </dd>
+      </div>
+
+      <% if capital_details.has_frozen_income_or_assets == 'yes' &&
+            capital_details.frozen_income_or_assets_subject.present? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= label_text(:frozen_income_or_assets_subject) %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= t(capital_details.frozen_income_or_assets_subject, scope: 'values') %>
+          </dd>
+        </div>
+      <% end %>
     <% end %>
+
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
         <%= label_text(:has_no_other_assets) %>

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -202,6 +202,7 @@ en:
     has_codefendants: Co-defendants?
     has_dependants: Has dependants?
     has_frozen_income_or_assets: Income, savings or assets under a restraint or freezing order
+    frozen_income_or_assets_subject: Who does the restraint or freezing order relate to?
     has_no_other_assets: Has no other assets or capital?
     has_premium_bonds: Premium Bonds
     has_premium_bonds_client: "Premium Bonds: client"
@@ -473,6 +474,8 @@ en:
     applicant: Client
     partner: Partner
     applicant_and_partner: Client and partner
+    client: Client
+    client_and_partner: Client and partner
     assessment_rules:
       appeal_to_crown_court: Appeal to Crown Court
       committal_for_sentence: Committal for sentence

--- a/config/locales/en/casework.yml
+++ b/config/locales/en/casework.yml
@@ -474,8 +474,6 @@ en:
     applicant: Client
     partner: Partner
     applicant_and_partner: Client and partner
-    client: Client
-    client_and_partner: Client and partner
     assessment_rules:
       appeal_to_crown_court: Appeal to Crown Court
       committal_for_sentence: Committal for sentence

--- a/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Viewing the income details of an application' do
           'means_details' => {
             'income_details' => {
               'has_frozen_income_or_assets' => 'yes',
-              'frozen_income_or_assets_subject' => 'client'
+              'frozen_income_or_assets_subject' => 'applicant'
             }
           }
         )
@@ -53,7 +53,7 @@ RSpec.describe 'Viewing the income details of an application' do
 
         within(income_heading.find(:xpath, './ancestor::div[@class="govuk-summary-card"][1]')) do
           expect(page).to have_content(
-            'Who does the restraint or freezing order relate to? Client'
+            'Who does the restraint or freezing order relate to? Applicant'
           )
         end
       end

--- a/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
@@ -35,6 +35,25 @@ RSpec.describe 'Viewing the income details of an application' do
     it 'shows savings or investments' do
       expect(page).to have_content('Savings or investments? Yes')
     end
+
+    context 'when income is under a restraint or freezing order' do
+      let(:application_data) do
+        super().deep_merge(
+          'means_details' => {
+            'income_details' => {
+              'has_frozen_income_or_assets' => 'yes',
+              'frozen_income_or_assets_subject' => 'client'
+            }
+          }
+        )
+      end
+
+      it 'shows who the restraint or freezing order relates to' do
+        expect(page).to have_content(
+          'Who does the restraint or freezing order relate to? Client'
+        )
+      end
+    end
   end
 
   context 'with no income details' do

--- a/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
@@ -49,7 +49,9 @@ RSpec.describe 'Viewing the income details of an application' do
       end
 
       it 'shows who the restraint or freezing order relates to' do
-        within('.govuk-summary-card', text: 'Income') do
+        income_heading = page.find('h3.govuk-summary-card__title', text: 'Income')
+
+        within(income_heading.find(:xpath, './ancestor::div[@class="govuk-summary-card"][1]')) do
           expect(page).to have_content(
             'Who does the restraint or freezing order relate to? Client'
           )

--- a/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
@@ -49,9 +49,11 @@ RSpec.describe 'Viewing the income details of an application' do
       end
 
       it 'shows who the restraint or freezing order relates to' do
-        expect(page).to have_content(
-          'Who does the restraint or freezing order relate to? Client'
-        )
+        within('.govuk-summary-card', text: 'Income') do
+          expect(page).to have_content(
+            'Who does the restraint or freezing order relate to? Client'
+          )
+        end
       end
     end
   end

--- a/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/income_details_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Viewing the income details of an application' do
 
         within(income_heading.find(:xpath, './ancestor::div[@class="govuk-summary-card"][1]')) do
           expect(page).to have_content(
-            'Who does the restraint or freezing order relate to? Applicant'
+            'Who does the restraint or freezing order relate to? Client'
           )
         end
       end

--- a/spec/system/casework/viewing_an_application/application_details/other_capital_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/other_capital_details_spec.rb
@@ -34,9 +34,11 @@ RSpec.describe 'Viewing the other capital details of an application' do
     end
 
     it 'shows who the restraint or freezing order relates to' do
-      expect(page).to have_content(
-        'Who does the restraint or freezing order relate to? Client'
-      )
+      within('.govuk-summary-card', text: 'Other capital') do
+        expect(page).to have_content(
+          'Who does the restraint or freezing order relate to? Client'
+        )
+      end
     end
   end
 end

--- a/spec/system/casework/viewing_an_application/application_details/other_capital_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/other_capital_details_spec.rb
@@ -40,5 +40,35 @@ RSpec.describe 'Viewing the other capital details of an application' do
         )
       end
     end
+
+    context 'when the answer is no' do
+      let(:application_data) do
+        super().deep_merge(
+          'means_details' => {
+            'capital_details' => {
+              'has_frozen_income_or_assets' => 'no'
+            }
+          }
+        )
+      end
+
+      let(:other_capital_card) do
+        page.find(
+          :xpath,
+          "//h3[normalize-space()='Other capital']/ancestor::div[@class='govuk-summary-card'][1]"
+        )
+      end
+
+      it 'shows whether client has income, savings or assets under a restraint or freezing order' do
+        within(other_capital_card) do
+          expect(page).to have_content(
+            'Income, savings or assets under a restraint or freezing order No'
+          )
+          expect(page).to have_no_content(
+            'Who does the restraint or freezing order relate to?'
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/system/casework/viewing_an_application/application_details/other_capital_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/other_capital_details_spec.rb
@@ -13,13 +13,30 @@ RSpec.describe 'Viewing the other capital details of an application' do
 
   context 'when user was asked about frozen income or assets in capital' do
     let(:application_data) do
-      super().deep_merge('means_details' => { 'capital_details' => { 'has_frozen_income_or_assets' => 'no' } })
+      super().deep_merge(
+        'means_details' => {
+          'capital_details' => {
+            'has_frozen_income_or_assets' => 'yes',
+            'frozen_income_or_assets_subject' => 'client'
+          }
+        }
+      )
     end
 
     it { expect(page).to have_content('Other capital') }
 
     it 'shows whether client has income, savings or assets under a restraint or freezing order' do
-      expect(page).to have_content('Income, savings or assets under a restraint or freezing order No')
+      within('.govuk-summary-card', text: 'Other capital') do
+        expect(page).to have_content(
+          'Income, savings or assets under a restraint or freezing order Yes'
+        )
+      end
+    end
+
+    it 'shows who the restraint or freezing order relates to' do
+      expect(page).to have_content(
+        'Who does the restraint or freezing order relate to? Client'
+      )
     end
   end
 end

--- a/spec/system/casework/viewing_an_application/application_details/other_capital_details_spec.rb
+++ b/spec/system/casework/viewing_an_application/application_details/other_capital_details_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Viewing the other capital details of an application' do
         'means_details' => {
           'capital_details' => {
             'has_frozen_income_or_assets' => 'yes',
-            'frozen_income_or_assets_subject' => 'client'
+            'frozen_income_or_assets_subject' => 'applicant'
           }
         }
       )


### PR DESCRIPTION
## Description of change
Bump laa-criminal-legal-aid-schemas to v1.8.0 to consume the new frozen_income_or_assets_subject attribute.

Update the income and other capital summary sections to display the follow-up question "Who does the restraint or freezing order relate to?" when the applicant has income, savings or assets under a restraint or freezing order and the subject is present.

Add the required locale entries for the new question and schema enum values (client and client_and_partner).

Extend the system specs to verify the new follow-up question is rendered for both the income and other capital sections.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2167

## Notes for reviewer
- Depends on laa-criminal-legal-aid-schemas v1.8.0.
- The new follow-up question is displayed only when has_frozen_income_or_assets is yes and a frozen_income_or_assets_subject is present.
- System specs have been added for both the Income and Other Capital sections.
## Screenshots of changes (if applicable)

### Before changes:
When an application indicated income, savings or assets under a restraint or freezing order, Review displayed only the Yes/No answer.

### After changes:
Review now also displays the follow-up question showing who the restraint or freezing order relates to (Client, Partner or Client and partner) in both the Income and Other Capital sections, where applicable.
<img width="1007" height="530" alt="Screenshot 2026-06-25 at 15 51 27" src="https://github.com/user-attachments/assets/bf63fb9e-b430-43c6-b9d4-82ff1ba75178" />


## How to manually test the feature
1. Check out this branch and ensure `laa-criminal-legal-aid-schemas` v1.8.0 is installed.
2. Start the Review application.
3. Open an application containing:
   - `has_frozen_income_or_assets: "yes"`
   - `frozen_income_or_assets_subject: "client"` (or `partner` / `client_and_partner`)
4. Verify the Income section displays:
   - "Income, savings or assets under a restraint or freezing order" → Yes
   - "Who does the restraint or freezing order relate to?" → the correct value.
5. Verify the Other Capital section behaves the same when the capital details contain the new field.
6. Verify that when `has_frozen_income_or_assets` is `no` (or the subject is absent), the follow-up question is not displayed.