### PR TITLE
Add search_text to log filters

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -28,5 +28,6 @@ Rails.application.config.filter_parameters += [
   :phone,
   :postcode,
   :reason,
-  :urn
+  :urn,
+  :search_text
 ]


### PR DESCRIPTION
## Description of change
Filter `search_text` from the logs as caseworkers will occasionally search by client name.

## How to manually test the feature
Perform a search on Review staging by client name. Check the [Review staging logs ](https://app-logs.cloud-platform.service.justice.gov.uk/_dashboards/app/data-explorer/discover#?_a=(discover:(columns:!(log),isDirty:!t,sort:!()),metadata:(indexPattern:bb90f230-0d2e-11ef-bf63-53113938c53a,view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:bb90f230-0d2e-11ef-bf63-53113938c53a,key:kubernetes.namespace_name,negate:!f,params:(query:laa-review-criminal-legal-aid-staging),type:phrase),query:(match_phrase:(kubernetes.namespace_name:laa-review-criminal-legal-aid-staging)))),query:(language:kuery,query:'')))to see if the `search_text` parameter is filtered out.