### PR TITLE
CRIMAPP-2182: Reinstate sticky report headers

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -63,8 +63,16 @@ html {
   color: $govuk-link-colour;
 }
 
+// Reports no longer require horizontal scrolling after column heading changes.
+// If future tables require horizontal scrolling again, this may need revisiting.
 .app-table-container {
-  overflow-x: auto
+  overflow-x: visible
+}
+
+@media (max-width: 1024px) {
+  .app-table-container {
+    overflow-x: auto;
+  }
 }
 
 .app-service-navigation {

--- a/app/components/data_table/header_row_component.rb
+++ b/app/components/data_table/header_row_component.rb
@@ -16,19 +16,7 @@ module DataTable
     end
 
     def call
-      safe_join([
-                  caption,
-                  tag.tr(**html_attributes) { safe_join(cells) }
-                ])
-    end
-
-    def caption
-      tag.caption do
-        tag.span(
-          I18n.t('table_headings.sortable_caption'),
-          class: 'govuk-visually-hidden'
-        )
-      end
+      tag.tr(**html_attributes) { safe_join(cells) }
     end
 
     private

--- a/app/components/data_table_component.rb
+++ b/app/components/data_table_component.rb
@@ -8,4 +8,15 @@ class DataTableComponent < GovukComponent::TableComponent
   def call
     tag.table(**html_attributes) { safe_join([caption, colgroups, head, sortable_head, bodies, foot]) }
   end
+
+  private
+
+  def caption
+    tag.caption do
+      tag.span(
+        I18n.t('table_headings.sortable_caption'),
+        class: 'govuk-visually-hidden'
+      )
+    end
+  end
 end

--- a/config/locales/en/reporting.yml
+++ b/config/locales/en/reporting.yml
@@ -59,7 +59,7 @@ en:
     application_type: Application type
     applications_closed: Number of closed applications
     applications_received: Applications received
-    assigned_to_user: "from<br>list"
+    assigned_to_user: "from list"
     closed: Closed
     colpsan_assigned_to_user: "Assigned"
     colspan_closed_by_user: Closed
@@ -74,17 +74,17 @@ en:
     percentage_closed_sent_back: "closed sent back"
     processed_on: When applications were closed
     provider_name: Legal representative
-    reassigned_from_user: "by<br>another"
-    reassigned_to_user: "from<br>another"
+    reassigned_from_user: "by another"
+    reassigned_to_user: "from another"
     received: Received
     received_applications_by_age: Applications received
     return_reason: Reason
-    sent_back_by_user: "sent<br>back"
+    sent_back_by_user: "sent back"
     total_assigned_to_user: total
     total_closed_by_user: total
     total_unassigned_from_user: total
-    unassigned_from_user: "from<br>self"
-    user_name: "&nbsp;"
+    unassigned_from_user: "from self"
+    user_name: Case worker
     what: What
     day_before_yesterday: Day before yesterday
     today: Today

--- a/spec/components/data_table/header_row_component_spec.rb
+++ b/spec/components/data_table/header_row_component_spec.rb
@@ -6,17 +6,6 @@ RSpec.describe DataTable::HeaderRowComponent, type: :component do
   let(:sorting) { ApplicationSearchSorting.new(sort_by: 'submitted_at', sort_direction: 'ascending') }
   let(:filter) { nil }
 
-  describe 'caption' do
-    before do
-      render_inline(component) { |row| row.with_cell(colname: 'reference', text: 'Reference') }
-    end
-
-    it 'renders a visually hidden caption' do
-      expect(page).to have_css('caption span.govuk-visually-hidden',
-                               text: 'Column headers with buttons are sortable.')
-    end
-  end
-
   describe 'row structure' do
     before do
       render_inline(component) do |row|

--- a/spec/components/data_table_component_spec.rb
+++ b/spec/components/data_table_component_spec.rb
@@ -1,0 +1,20 @@
+# spec/components/data_table_component_spec.rb
+
+require 'rails_helper'
+
+RSpec.describe DataTableComponent, type: :component do
+  before do
+    render_inline(described_class.new)
+  end
+
+  describe 'table caption' do
+    subject(:caption) { page.first('table > caption') }
+
+    it 'renders a visually hidden sortable caption' do
+      expect(caption).to have_css(
+        '.govuk-visually-hidden',
+        text: I18n.t('table_headings.sortable_caption')
+      )
+    end
+  end
+end

--- a/spec/system/reporting/caseworker_report_spec.rb
+++ b/spec/system/reporting/caseworker_report_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe 'Caseworker report' do
     colgroup_detail_headings = all('.app-table thead tr.colgroup-details th').map(&:text)
 
     expected = [
-      ' ',
-      'fromlist',
-      'fromanother',
+      'Case worker',
+      'from list',
+      'from another',
       'total',
-      'fromself',
-      'byanother',
+      'from self',
+      'by another',
       'total',
-      'sentback',
+      'sent back',
       'completed',
       'total',
       'assigned un-assigned',


### PR DESCRIPTION
## Description of change
- correct the sortable table HTML structure by moving the caption to the table level
- reduce report column widths so tables no longer require horizontal scrolling
- reinstate sticky headers now that the report scrolls with the page

## Link to relevant ticket
CRIMAPP-2182

## Screenshots of changes (if applicable)
<img width="964" height="483" alt="Screenshot 2026-07-10 at 10 37 19" src="https://github.com/user-attachments/assets/e055cd4e-af1a-4222-b52f-98ba5c99ef89" />

## How to manually test the feature

### Manual testing
Visit the reporting pages at [https://staging.review-criminal-legal-aid.service.justice.gov.uk/reporting](https://staging.review-criminal-legal-aid.service.justice.gov.uk/reporting) and verify that sticky headers remain visible while scrolling through each report. Confirm that the updated column headings remove the need for horizontal scrolling, and verify that sorting continues to work correctly. At smaller viewport widths (or when browser zoom causes the responsive breakpoint to be reached), confirm that the sticky headers are disabled as expected.
