### PR TITLE
CRIMAPP-2305: Fix decision page heading hierarchy

### DIFF
--- a/app/views/casework/decisions/comments/edit.html.erb
+++ b/app/views/casework/decisions/comments/edit.html.erb
@@ -12,9 +12,11 @@
       <%= govuk_link_to(t('calls_to_action.view_application'), crime_application_path(@crime_application), no_visited_state: true) %>
     </p>
 
-    <h2 class="govuk-heading-xl govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
       <%= @crime_application.applicant.full_name %>
-    </h2>
+    </h1>
+
+    <h2 class="govuk-heading-l"><%= t('.title') %></h2>
 
     <%= govuk_error_summary(@form_object) %>
   </div>

--- a/app/views/casework/decisions/overall_results/edit.html.erb
+++ b/app/views/casework/decisions/overall_results/edit.html.erb
@@ -7,9 +7,9 @@
       <%= govuk_link_to(t('calls_to_action.view_application'), crime_application_path(@crime_application), no_visited_state: true) %>
     </p>
 
-    <h2 class="govuk-heading-xl govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
       <%= @crime_application.applicant.full_name %>
-    </h2>
+    </h1>
 
     <h2 class="govuk-heading-l"> <%= t '.title' %> </h2>
 

--- a/app/views/casework/maat_decisions/edit.html.erb
+++ b/app/views/casework/maat_decisions/edit.html.erb
@@ -7,9 +7,9 @@
       <%= govuk_link_to(t('calls_to_action.view_application'), crime_application_path(@crime_application), no_visited_state: true) %>
     </p>
 
-    <h2 class="govuk-heading-xl govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
       <%= @crime_application.applicant.full_name %>
-    </h2>
+    </h1>
 
     <%= govuk_error_summary(@form_object) %>
   </div>

--- a/spec/system/casework/deciding/adding_a_maat_decision_by_maat_id_spec.rb
+++ b/spec/system/casework/deciding/adding_a_maat_decision_by_maat_id_spec.rb
@@ -57,8 +57,10 @@ RSpec.describe 'Adding a decision by MAAT ID' do
       expect(current_path).to eq(
         "/applications/696dd4fd-b619-4637-ab42-a5f4565bcf4a/decisions/#{maat_id}/comment"
       )
-      expect(page).to have_selector('h1', count: 1)
-      expect(page).to have_selector('h1.govuk-heading-xl', text: applicant_name)
+    end
+
+    it 'uses the applicant name as h1 and action title as h2' do
+      expect(page).to have_selector('h1.govuk-heading-xl', count: 1, text: applicant_name)
       expect(page).to have_selector('h2.govuk-heading-l', text: I18n.t('casework.decisions.comments.edit.title'))
     end
   end

--- a/spec/system/casework/deciding/adding_a_maat_decision_by_maat_id_spec.rb
+++ b/spec/system/casework/deciding/adding_a_maat_decision_by_maat_id_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe 'Adding a decision by MAAT ID' do
   include_context 'when adding a decision by MAAT ID'
 
   let(:maat_decision_maat_id) { maat_id }
+  let(:applicant_name) do
+    [
+      application_data.dig('client_details', 'applicant', 'first_name'),
+      application_data.dig('client_details', 'applicant', 'last_name')
+    ].join(' ')
+  end
 
   before do
     visit crime_application_path(application_id)
@@ -51,6 +57,9 @@ RSpec.describe 'Adding a decision by MAAT ID' do
       expect(current_path).to eq(
         "/applications/696dd4fd-b619-4637-ab42-a5f4565bcf4a/decisions/#{maat_id}/comment"
       )
+      expect(page).to have_selector('h1', count: 1)
+      expect(page).to have_selector('h1.govuk-heading-xl', text: applicant_name)
+      expect(page).to have_selector('h2.govuk-heading-l', text: I18n.t('casework.decisions.comments.edit.title'))
     end
   end
 

--- a/spec/system/casework/deciding/adding_a_non_means_decision_spec.rb
+++ b/spec/system/casework/deciding/adding_a_non_means_decision_spec.rb
@@ -80,8 +80,7 @@ RSpec.describe 'Adding a Non-means application' do
       click_button 'Start'
       complete_ioj_form
 
-      expect(page).to have_selector('h1', count: 1)
-      expect(page).to have_selector('h1.govuk-heading-xl', text: applicant_name)
+      expect(page).to have_selector('h1.govuk-heading-xl', count: 1, text: applicant_name)
       expect(page).to have_selector('h2.govuk-heading-l', text: I18n.t('casework.decisions.overall_results.edit.title'))
     end
   end

--- a/spec/system/casework/deciding/adding_a_non_means_decision_spec.rb
+++ b/spec/system/casework/deciding/adding_a_non_means_decision_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe 'Adding a Non-means application' do
   include DecisionFormHelpers
 
   let(:current_user_role) { UserRole::CASEWORKER }
+  let(:applicant_name) do
+    [
+      application_data.dig('client_details', 'applicant', 'first_name'),
+      application_data.dig('client_details', 'applicant', 'last_name')
+    ].join(' ')
+  end
 
   # rubocop:disable RSpec/ExampleLength
   shared_examples 'hides "Start" button' do
@@ -68,6 +74,15 @@ RSpec.describe 'Adding a Non-means application' do
         'Overall result', 'Granted',
         'Comments', 'Caseworker comment'
       )
+    end
+
+    it 'uses applicant name and section title headings on overall result' do
+      click_button 'Start'
+      complete_ioj_form
+
+      expect(page).to have_selector('h1', count: 1)
+      expect(page).to have_selector('h1.govuk-heading-xl', text: applicant_name)
+      expect(page).to have_selector('h2.govuk-heading-l', text: I18n.t('casework.decisions.overall_results.edit.title'))
     end
   end
 

--- a/spec/system/casework/deciding/updating_a_decision_from_maat_spec.rb
+++ b/spec/system/casework/deciding/updating_a_decision_from_maat_spec.rb
@@ -51,8 +51,7 @@ RSpec.describe 'Adding a decision by MAAT reference' do
 
   it 'uses the applicant name as the page heading on the MAAT decision page' do
     expect(page).to have_button('Update from MAAT')
-    expect(page).to have_selector('h1', count: 1)
-    expect(page).to have_selector('h1.govuk-heading-xl', text: applicant_name)
+    expect(page).to have_selector('h1.govuk-heading-xl', count: 1, text: applicant_name)
   end
 
   context 'when nothing has changed on MAAT details are missing' do

--- a/spec/system/casework/deciding/updating_a_decision_from_maat_spec.rb
+++ b/spec/system/casework/deciding/updating_a_decision_from_maat_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe 'Adding a decision by MAAT reference' do
   end
 
   let(:reference) { 6_000_001 }
+  let(:v2) { Maat::Decision.new(**maat_decision.attributes) }
+  let(:applicant_name) do
+    [
+      application_data.dig('client_details', 'applicant', 'first_name'),
+      application_data.dig('client_details', 'applicant', 'last_name')
+    ].join(' ')
+  end
 
   before do
     allow(DatastoreApi::Requests::UpdateApplication).to receive(:new)
@@ -40,11 +47,18 @@ RSpec.describe 'Adding a decision by MAAT reference' do
     visit crime_application_path(application_id)
     click_on 'Edit'
     click_on 'Change'
-    click_button 'Update from MAAT'
+  end
+
+  it 'uses the applicant name as the page heading on the MAAT decision page' do
+    expect(page).to have_button('Update from MAAT')
+    expect(page).to have_selector('h1', count: 1)
+    expect(page).to have_selector('h1.govuk-heading-xl', text: applicant_name)
   end
 
   context 'when nothing has changed on MAAT details are missing' do
-    let(:v2) { Maat::Decision.new(**maat_decision.attributes) }
+    before do
+      click_button 'Update from MAAT'
+    end
 
     it 'instructs the caseworker to make changes on MAAT' do
       expect(page).to have_notification_banner(
@@ -62,6 +76,10 @@ RSpec.describe 'Adding a decision by MAAT reference' do
   context 'when changed on MAAT with missing details provided' do
     let(:v2) do
       Maat::Decision.new(**maat_decision.attributes, funding_decision: 'GRANTED')
+    end
+
+    before do
+      click_button 'Update from MAAT'
     end
 
     it 'instructs the caseworker to check the decision' do


### PR DESCRIPTION
## Description of change
Change the crime decision edit pages to use a proper h1/h2 hierarchy for accessibility:
- make the applicant name the h1
- add the page title as h2 on comments/edit
- keep the existing overall result h2
- fix the MAAT decision edit page heading structure

Strengthen system specs to assert the semantic heading structure for the affected pages.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2305

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
<img width="1190" height="622" alt="Screenshot 2026-08-06 at 15 48 18" src="https://github.com/user-attachments/assets/becccd67-6fc0-4a85-8361-332aa75bd8ee" />

### After changes:
<img width="1426" height="739" alt="Screenshot 2026-08-06 at 17 33 26" src="https://github.com/user-attachments/assets/7fbdf2e9-50be-4666-a431-83309c2d538e" />

## How to manually test the feature
Manual test:

1. Open each page:
   - `comments/edit`
   - `overall_results/edit`
   - `maat_decisions/edit`

2. Check the visible headings:
   - Applicant name should be the main heading
   - On `comments/edit`, the page title should now appear as a second heading
   - On `overall_results/edit`, the existing title should still appear below the applicant name

3. Inspect the DOM or use an accessibility tool:
   - There should be **exactly one `<h1>`**
   - The first heading should be the applicant name
   - Heading order should be valid: `h1 → h2 → h3`

4. Screen reader check:
   - Use VoiceOver/NVDA and tab or move through headings
   - The first heading announced should be the applicant name at level 1

5. Optional regression check:
   - Confirm the page still looks the same apart from the restored title on `comments/edit` and the corrected semantic heading levels.