### PR TITLE
Bump brace-expansion to 5.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css  ./app/assets/stylesheets/print.scss:./app/assets/builds/print.css  --no-source-map  --load-path=.  --load-path=node_modules  --quiet-deps"
   },
   "resolutions": {
-    "brace-expansion": "5.0.6",
+    "brace-expansion": "5.0.9",
     "glob": "^13.0.3",
     "minimatch": "^10.2.3",
     "picomatch": "2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -426,12 +426,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:5.0.6":
-  version: 5.0.6
-  resolution: "brace-expansion@npm:5.0.6"
+"brace-expansion@npm:5.0.9":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description of change
- Bump `brace-expansions` to 5.0.9

This resolves a number of **high** vulnerabilities, such as https://github.com/ministryofjustice/laa-review-criminal-legal-aid/security/dependabot/171
