### PR TITLE
CRIMAPP-2307: Remove invalid role="tablist" from tab-style navigation

### DIFF
--- a/app/views/casework/crime_applications/index.html.erb
+++ b/app/views/casework/crime_applications/index.html.erb
@@ -5,7 +5,7 @@
 </h1>
 
 <div class="govuk-tabs">
-  <ul class="govuk-tabs__list" role="tablist">
+  <ul class="govuk-tabs__list">
     <% current_user.work_streams.each do |work_stream| %>
       <% css_class = %w[govuk-tabs__list-item govuk-tabs__list-item--selected] %>
       <%= content_tag(:li, class: work_stream == current_work_stream ? css_class : css_class.first) do %>

--- a/app/views/reporting/temporal_reports/show.html.erb
+++ b/app/views/reporting/temporal_reports/show.html.erb
@@ -7,7 +7,7 @@
     </h1>
 
     <div class="govuk-tabs">
-      <ul class="govuk-tabs__list" role="tablist">
+      <ul class="govuk-tabs__list">
         <% @intervals.each_with_index do |interval, index| %>
           <% css_class = %w[govuk-tabs__list-item govuk-tabs__list-item--selected] %>
           <%= content_tag(:li, class: @interval == interval ? css_class : css_class.first) do %>

--- a/app/views/reporting/user_temporal_reports/show.html.erb
+++ b/app/views/reporting/user_temporal_reports/show.html.erb
@@ -31,7 +31,7 @@
     </div>
 
     <div class="govuk-tabs">
-      <ul class="govuk-tabs__list" role="tablist">
+      <ul class="govuk-tabs__list">
         <% @intervals.each do |interval| %>
           <% css_class = %w[govuk-tabs__list-item govuk-tabs__list-item--selected] %>
           <%= content_tag(:li, class: @interval == interval ? css_class : css_class.first) do %>


### PR DESCRIPTION
## What

Removes `role="tablist"` from the `<ul class="govuk-tabs__list">` in three views that render GOV.UK tab-style navigation.

## Why

[CRIMAPP-2307](https://dsdmoj.atlassian.net/browse/CRIMAPP-2307)

These views use `<ul class="govuk-tabs__list" role="tablist">` but the GOV.UK Frontend `govuk-tabs` JS module is never initialised (`data-module="govuk-tabs"` is absent). As a result:

- The `<a>` elements never receive `role="tab"`, `aria-selected`, or `aria-controls`
- The panels never receive `role="tabpanel"`

An ARIA `tablist` must contain `tab` children, so a `tablist` with plain links is an invalid ARIA pattern flagged by automated scanners (WCAG 4.1.2). These tabs also navigate to full new URLs (server-side navigation), so the full ARIA tab pattern doesn't apply.

Per the ticket's recommended fix, `role="tablist"` is removed while the GOV.UK tab CSS classes are retained for unchanged visual styling. `data-module="govuk-tabs"` is intentionally **not** added.

## Affected views

- `app/views/casework/crime_applications/index.html.erb`
- `app/views/reporting/temporal_reports/show.html.erb`
- `app/views/reporting/user_temporal_reports/show.html.erb`

## Acceptance criteria

- [x] `role="tablist"` no longer present on the `<ul>`
- [x] No "Required children role not present" axe error for the list
- [x] Links are focusable and announce as links, not tabs
- [x] Visual appearance unchanged (tab classes retained)

[CRIMAPP-2307]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ