### PR TITLE
CRIMAPP-2308: Add accessible history link suffix

### DIFF
--- a/app/views/manage_competencies/caseworker_competencies/_table_cells.html.erb
+++ b/app/views/manage_competencies/caseworker_competencies/_table_cells.html.erb
@@ -2,5 +2,5 @@
   <%= govuk_link_to(caseworker.caseworker_presenter.formatted_user_competencies, edit_manage_competencies_caseworker_competency_path(id: caseworker), no_visited_state: true) %>
 </td>
 <td class="govuk-table__cell">
-  <%= govuk_link_to(t('.history'), manage_competencies_history_path(id: caseworker), no_visited_state: true) %>
+  <%= govuk_link_to(t('.history'), manage_competencies_history_path(id: caseworker), no_visited_state: true, visually_hidden_suffix: caseworker.name) %>
 </td>

--- a/spec/system/manage_competencies/change_user_competencies_spec.rb
+++ b/spec/system/manage_competencies/change_user_competencies_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Change caseworker competencies' do
 
     it 'displays selected competency' do
       first_data_row = page.first('.govuk-table tbody tr').text
-      expect(first_data_row).to eq('Iain Testing Extradition, Initial View history')
+      expect(first_data_row).to eq('Iain Testing Extradition, Initial View history Iain Testing')
     end
 
     it 'form is pre-populated with selected competency' do

--- a/spec/system/manage_competencies/viewing_spec.rb
+++ b/spec/system/manage_competencies/viewing_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Manage Competencies Dashboard' do
 
     it 'shows the correct table content' do
       first_data_row = page.first('.govuk-table tbody tr').text
-      expect(first_data_row).to eq(['Iain Testing No competencies View history'].join(' '))
+      expect(first_data_row).to eq(['Iain Testing No competencies View history Iain Testing'].join(' '))
     end
 
     context 'when clicking links' do


### PR DESCRIPTION
## Description of change
Include the caseworker's name in the visually hidden History link text so screen reader users can distinguish links in the competencies table.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2308

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
Sign in as a user with Manage Competencies access and open the Manage competencies dashboard. Confirm each row’s visible History link still reads “View history” (or “History”, depending on the deployed translation), then use a screen reader’s links list or inspect the link’s accessible name in browser DevTools: it should include the relevant caseworker’s full name, for example “View history Iain Testing”. Check multiple rows to confirm each History link has the correct matching name, and activate one to confirm it still opens that caseworker’s competency history.
