### PR TITLE
Upgrade sidekiq and related dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,8 +39,9 @@ gem 'turbo-rails', '>= 2.0.0'
 gem 'bootsnap', require: false
 
 # Exceptions notifications
-gem 'sentry-rails', '>= 5.15.1'
+gem 'sentry-rails', '~> 6.7'
 gem 'sentry-ruby'
+gem 'sentry-sidekiq', '~> 6.7'
 gem 'stackprof'
 
 gem 'dry-schema'
@@ -94,5 +95,7 @@ gem 'csv', '~> 3.3'
 
 gem 'ostruct', '~> 0.6.1'
 
-gem 'sidekiq', '~> 7.0'
-gem 'sidekiq-scheduler', '~> 5.0'
+gem 'sidekiq', '~> 8.1'
+gem 'sidekiq-scheduler', '~> 6.0'
+
+gem 'ratatui_ruby', '~> 1.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
       rubocop (>= 1)
       smart_properties
     erubi (1.13.1)
-    et-orbi (1.2.11)
+    et-orbi (1.4.1)
       tzinfo
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
@@ -254,8 +254,8 @@ GEM
       faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
-    fugit (1.11.1)
-      et-orbi (~> 1, >= 1.2.11)
+    fugit (1.13.0)
+      et-orbi (~> 1.4)
       raabro (~> 1.4)
     globalid (1.4.0)
       activesupport (>= 6.1)
@@ -423,9 +423,9 @@ GEM
     public_suffix (7.0.5)
     puma (8.0.2)
       nio4r (~> 2.0)
-    raabro (1.4.0)
+    raabro (1.5.0)
     racc (1.8.1)
-    rack (3.2.6)
+    rack (3.2.7)
     rack-oauth2 (2.2.1)
       activesupport
       attr_required
@@ -487,6 +487,15 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
+    rake-compiler-dock (1.12.0)
+    ratatui_ruby (1.5.0)
+      rb_sys (~> 0.9)
+      rexml (~> 3.4)
+    ratatui_ruby (1.5.0-x86_64-linux)
+      rb_sys (~> 0.9)
+      rexml (~> 3.4)
+    rb_sys (0.9.128)
+      rake-compiler-dock (= 1.12.0)
     rbs (4.1.2)
       logger
       prism (>= 1.6.0)
@@ -496,7 +505,7 @@ GEM
       prism (>= 1.6.0)
       rbs (>= 4.0.0)
       tsort
-    redis-client (0.24.0)
+    redis-client (0.30.1)
       connection_pool
     regexp_parser (2.12.0)
     reline (0.6.3)
@@ -573,23 +582,25 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    sentry-rails (6.6.2)
+    sentry-rails (6.7.0)
       railties (>= 5.2.0)
-      sentry-ruby (~> 6.6.2)
-    sentry-ruby (6.6.2)
+      sentry-ruby (~> 6.7.0)
+    sentry-ruby (6.7.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       logger
-    sidekiq (7.3.9)
-      base64
-      connection_pool (>= 2.3.0)
-      logger
-      rack (>= 2.2.4)
-      redis-client (>= 0.22.2)
-    sidekiq-scheduler (5.0.6)
+    sentry-sidekiq (6.7.0)
+      sentry-ruby (~> 6.7.0)
+      sidekiq (>= 5.0)
+    sidekiq (8.1.6)
+      connection_pool (>= 3.0.0)
+      json (>= 2.16.0)
+      logger (>= 1.7.0)
+      rack (>= 3.2.0)
+      redis-client (>= 0.29.0)
+    sidekiq-scheduler (6.0.2)
       rufus-scheduler (~> 3.2)
-      sidekiq (>= 6, < 8)
-      tilt (>= 1.4.0, < 3)
+      sidekiq (>= 7.3, < 9)
     simplecov (1.0.3)
     smart_properties (1.17.0)
     snaky_hash (2.0.7)
@@ -602,7 +613,6 @@ GEM
       faraday (~> 2.0)
       faraday-follow_redirects
     thor (1.5.0)
-    tilt (2.6.0)
     timeout (0.6.1)
     tsort (0.2.0)
     turbo-rails (2.0.23)
@@ -691,6 +701,7 @@ DEPENDENCIES
   puma
   rails
   rails_event_store (~> 2.19.2)
+  ratatui_ruby (~> 1.5)
   rspec-rails (>= 7.0.1)
   rspec_junit_formatter
   rubocop
@@ -698,10 +709,11 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   selenium-webdriver
-  sentry-rails (>= 5.15.1)
+  sentry-rails (~> 6.7)
   sentry-ruby
-  sidekiq (~> 7.0)
-  sidekiq-scheduler (~> 5.0)
+  sentry-sidekiq (~> 6.7)
+  sidekiq (~> 8.1)
+  sidekiq-scheduler (~> 6.0)
   simplecov
   stackprof
   turbo-rails (>= 2.0.0)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,5 @@
 require 'active_support/core_ext/integer/time'
-require 'sidekiq/testing'
+require 'sidekiq'
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
@@ -66,5 +66,5 @@ Rails.application.configure do
 
   config.active_storage.service = :test
 
-  Sidekiq::Testing.inline!
+  Sidekiq.testing!(:inline)
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,7 +5,6 @@ require 'laa_crime_schemas'
 require 'spec_helper'
 require 'rspec/rails'
 require 'axe-rspec'
-require 'sidekiq/testing'
 
 ['init/*.rb', 'shared_contexts/*.rb', 'shared_examples/*.rb', 'support/**/*.rb'].each do |path|
   Dir[File.expand_path(path, __dir__)].each { |f| require f }


### PR DESCRIPTION
## Description of change
- Upgrade `sidekiq` to 8.1.6
- Upgrade `sidekiq-scheduler` to 6.0.2

Add new dependencies:
- `ratatui_ruby` - to enable the use of `kiq`, a command-line UI for Sidekiq introduced with `sidekiq` v8.1.2. The Sidekiq Web UI is disabled in production and having a UI in the terminal would make debugging issues with jobs easier.
- `sentry-sidekiq` - to allow Sentry to properly log exceptions in Sidekiq job runs.

### Using kiq

To use `kiq`, run:
```shell
bundle exec kiq
```
 If running locally, supply `REDIS_URL`, e.g.
```shell
REDIS_URL=redis://localhost:6379 bundle exec kiq
```

You may also have to provide `LANG=en` if your environment has it set to `C.UTF-8` by default, e.g.
```shell
LANG=en bundle exec kiq
```
This seems to be a Sidekiq bug.