### PR TITLE
CRIMAPP-2311: fix reporting link accessible name by using visually_hi…

### DIFF
--- a/app/helpers/reporting/temporal_reports_helper.rb
+++ b/app/helpers/reporting/temporal_reports_helper.rb
@@ -14,7 +14,7 @@ module Reporting
         count,
         unassigned_from_self_report_path(data_row, report),
         no_visited_state: true,
-        visually_hidden_text: "view #{data_row.user_name} unassigned from self",
+        visually_hidden_suffix: "- view #{data_row.user_name} unassigned from self report",
         data: { turbo: false }
       )
     end

--- a/spec/system/reporting/caseworker_report_unassigns_spec.rb
+++ b/spec/system/reporting/caseworker_report_unassigns_spec.rb
@@ -72,27 +72,21 @@ RSpec.describe 'Caseworker report unassigns from self' do
     end
 
     it 'displays the unassign count as a clickable link' do
-      within('.app-table tbody') do
-        row = find('tr', text: 'Jane Doe')
-        unassign_detail_cell = row.all('td.colgroup-detail')[2]
-        view_link = unassign_detail_cell.find('a', text: '2')
+      expect(unassign_detail_cell_for('Jane Doe')).to have_link('2')
+    end
 
-        expect(unassign_detail_cell).to have_link('2')
-        expect(view_link[:'visually-hidden-text']).to be_nil
-        expect(view_link).to have_css(
-          '.govuk-visually-hidden',
-          text: '- view Jane Doe unassigned from self report'
-        )
-      end
+    it 'provides accessible context for the unassign link', :aggregate_failures do
+      view_link = unassign_detail_cell_for('Jane Doe').find('a', text: '2')
+
+      expect(view_link[:'visually-hidden-text']).to be_nil
+      expect(view_link).to have_css(
+        '.govuk-visually-hidden',
+        text: '- view Jane Doe unassigned from self report'
+      )
     end
 
     it 'navigates to the caseworker unassigned applications page', :aggregate_failures do
-      within('.app-table tbody') do
-        row = find('tr', text: 'Jane Doe')
-        unassign_detail_cell = row.all('td.colgroup-detail')[2]
-
-        unassign_detail_cell.click_link('2')
-      end
+      unassign_detail_cell_for('Jane Doe').click_link('2')
 
       expect(page).to have_content('Jane Doe')
       expect(page).to have_content('Applications removed from list')
@@ -154,5 +148,10 @@ RSpec.describe 'Caseworker report unassigns from self' do
         expect(unassign_detail_cell).to have_text('2')
       end
     end
+  end
+
+  def unassign_detail_cell_for(caseworker_name)
+    row = find('.app-table tbody tr', text: caseworker_name)
+    row.all('td.colgroup-detail')[2]
   end
 end

--- a/spec/system/reporting/caseworker_report_unassigns_spec.rb
+++ b/spec/system/reporting/caseworker_report_unassigns_spec.rb
@@ -75,8 +75,14 @@ RSpec.describe 'Caseworker report unassigns from self' do
       within('.app-table tbody') do
         row = find('tr', text: 'Jane Doe')
         unassign_detail_cell = row.all('td.colgroup-detail')[2]
+        view_link = unassign_detail_cell.find('a', text: '2')
 
         expect(unassign_detail_cell).to have_link('2')
+        expect(view_link[:'visually-hidden-text']).to be_nil
+        expect(view_link).to have_css(
+          '.govuk-visually-hidden',
+          text: '- view Jane Doe unassigned from self report'
+        )
       end
     end
 


### PR DESCRIPTION
…dden_suffix

## Description of change

Optional body:
- replace invalid visually_hidden_text option in temporal reporting helper
- ensure unassigned count link renders GOV.UK visually hidden context
- add system spec assertion to prevent regression and invalid attribute leakage

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2311

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
